### PR TITLE
Provide more info in case of infinite error nesting (was needed to debug a swank error)

### DIFF
--- a/src/code/error-error.lisp
+++ b/src/code/error-error.lisp
@@ -10,35 +10,67 @@
 (in-package "SB!IMPL")
 
 ;;; These specials are used by ERROR-ERROR to track the success of recovery
-;;; attempts.
+;;; attempts. Not to be confused with SB-KERNEL::*CURRENT-ERROR-DEPTH*.
 (defvar *error-error-depth* 0)
 
 ;;; ERROR-ERROR can be called when the error system is in trouble and needs to
 ;;; punt fast. It prints a message without using FORMAT. If we get into this
 ;;; recursively, then we halt.
 (defun error-error (&rest messages)
+  ;; Be very conservative until nesting is dealt with, including consing.
   (let ((*error-error-depth* (1+ *error-error-depth*)))
-    (case *error-error-depth*
-      (1)
-      (2
-       (stream-cold-init-or-reset))
-      (3
-       (/show0 "*ERROR-ERROR-DEPTH* too big, trying THROW")
-       (throw 'toplevel-catcher nil))
-      (t
-       (/show0 "*ERROR-ERROR-DEPTH* too big, trying HALT")
-       (%primitive sb!c:halt)
-       (/show0 "*ERROR-ERROR-DEPTH* too big, trying THROW")
-       (throw 'toplevel-catcher nil)))
-
+    (when (> *error-error-depth* 4)
+      (/show0 "*ERROR-ERROR-DEPTH* too big, trying HALT")
+      (%primitive sb!c:halt)
+      (/show0 "*ERROR-ERROR-DEPTH* too big, trying THROW")
+      (throw 'toplevel-catcher nil))
+    ;; We can be somewhat more relaxed now, the above will save us.
     (with-standard-io-syntax
       (let ((*print-readably* nil))
-        (dolist (item messages)
-          (princ item *terminal-io*))
-        (terpri *terminal-io*)
-        (sb!debug:print-backtrace :stream *terminal-io*)
-        (force-output *terminal-io*)
-        (invoke-debugger
-         (coerce-to-condition "Maximum error nesting depth exceeded" nil
-                              'simple-error
-                              'error))))))
+        (flet
+            ((try-to-invoke-debugger ()
+               ;; Try to print something useful for debugging and try to invoke the debugger.
+               ;; Many things can trigger potentially nested errors beyond this point.
+               (dolist (item messages)
+                 (princ item *terminal-io*))
+               (terpri *terminal-io*)
+               (sb!debug:print-backtrace :stream *terminal-io* :emergency-best-effort t)
+               (force-output *terminal-io*)
+               (invoke-debugger
+                (coerce-to-condition "Maximum error nesting depth exceeded" nil
+                                     'simple-error
+                                     'error)))
+             (safely-print (message)
+               (handler-case
+                   (progn
+                     (princ "Help! ERROR-ERROR is " *terminal-io*)
+                     (princ *error-error-depth* *terminal-io*)
+                     (princ " levels deep. " *terminal-io*)
+                     (princ message *terminal-io*)
+                     (terpri *terminal-io*))
+                 (t ()))))
+          (declare (inline safely-print))
+          (case *error-error-depth*
+            (1
+             ;; Don't scream on the first invocation.
+             (try-to-invoke-debugger))
+            (2
+             (safely-print "Will try to reset the IO streams by calling STREAM-COLD-INIT-OR-RESET.")
+             (stream-cold-init-or-reset)
+             (try-to-invoke-debugger))
+            (3
+             (safely-print "Will try to THROW this thread to the toplevel.")
+             (/show0 "*ERROR-ERROR-DEPTH* too big, trying THROW")
+             ;; FIXME: TOPLEVEL-REPL installs a (catch 'toplevel-catcher ...)
+             ;; inside its LOOP. If any error nesting happens while inside that
+             ;; LOOP (e.g. due to a "Broken pipe" on stderr, which is used by the
+             ;; debugger), then when we get here this throw below will only unwind
+             ;; until inside this LOOP, and thus the repl will loop forever busy
+             ;; printing errors. https://bugs.launchpad.net/sbcl/+bug/1520694
+             (throw 'toplevel-catcher nil))
+            (t
+             (safely-print "Will try to halt this thread as a last resort.")
+             (/show0 "*ERROR-ERROR-DEPTH* too big, trying HALT")
+             (%primitive sb!c:halt)
+             (/show0 "*ERROR-ERROR-DEPTH* too big, trying THROW")
+             (throw '%abort-thread nil))))))))


### PR DESCRIPTION
 * Added an EMERGENCY-BEST-EFFORT keyword argument to PRINT-BACKTRACE,
   disabled by default. The debugger calls PRINT-BACKTRACE with the
   flag on only when it gets nested, so that e.g. errors from printing
   the backtrace also land in a (nested) debugger, but only when
   coming from the first level of the debugger.

 * Make ERROR-ERROR try to print more info on the way down into
   nesting and use this new keyword.

regarding the first point, another option would be to enable the flag by default, but then it's much harder to ask the debugger to enter into a nested session when there are e.g. print errors in the backtrace, so i chose the option described above, but i'm open for suggestions.