### PR TITLE
Fix a few typos in the documentation

### DIFF
--- a/doc/manual/debugger.texinfo
+++ b/doc/manual/debugger.texinfo
@@ -578,7 +578,7 @@ When the debugger command loop establishes variable bindings for
 available variables, these variable bindings have lexical scope and
 dynamic extent.@footnote{The variable bindings are actually created
 using the Lisp @code{symbol-macrolet} special form.}  You can close
-over them, but such closures can't be used as upward funargs.
+over them, but such closures can't be used as upward function arguments.
 
 You can also set local variables using @code{setq}, but if the
 variable was closed over in the original source and never set, then
@@ -815,7 +815,7 @@ value for optimization qualities.  It may be useful to specify
 documentation.
 
 @item 1
-Level @code{1} provides argument documentation (printed arglists) and
+Level @code{1} provides argument documentation (printed argument lists) and
 derived argument/result type information.  This makes @code{describe}
 more informative, and allows the compiler to do compile-time argument
 count and type checking for any calls compiled at run-time.  This is

--- a/doc/manual/deprecated.texinfo
+++ b/doc/manual/deprecated.texinfo
@@ -43,7 +43,7 @@ unwilling to track changes to SBCL internals.
 Ideally we'd like to be free to refactor our own internals as we
 please, without even going through the hassle of deprecating things.
 Sometimes, however, it turns out that our internal interfaces have
-several external users who aren't using them advicedly, but due to
+several external users who aren't using them advisedly, but due to
 misunderstandings regarding their status or stability.
 
 Consider a deprecated internal interface a reminder for SBCL

--- a/doc/manual/start-stop.texinfo
+++ b/doc/manual/start-stop.texinfo
@@ -241,7 +241,7 @@ As a runtime option this is equivalent to @code{--noinform}
 @code{--disable-ldb} @code{--lose-on-corruption}
 @code{--end-runtime-options} @code{--script} @var{filename}. See the
 description of @code{--script} as a toplevel option below. If there
-are no other commandline arguments following @code{--script}, the
+are no other command line arguments following @code{--script}, the
 filename argument can be omitted.
 
 

--- a/src/code/fd-stream.lisp
+++ b/src/code/fd-stream.lisp
@@ -2166,7 +2166,7 @@
            (let ((posn (sb!unix:unix-lseek (fd-stream-fd stream)
                                            offset origin)))
              ;; CLHS says to return true if the file-position was set
-             ;; succesfully, and NIL otherwise. We are to signal an error
+             ;; successfully, and NIL otherwise. We are to signal an error
              ;; only if the given position was out of bounds, and that is
              ;; dealt with above. In times past we used to return NIL for
              ;; errno==ESPIPE, and signal an error in other cases.

--- a/src/code/target-thread.lisp
+++ b/src/code/target-thread.lisp
@@ -322,7 +322,7 @@ terminating the main thread would terminate the entire process. If
 ALLOW-EXIT is true, aborting the main thread is equivalent to calling
 SB-EXT:EXIT code 1 and :ABORT NIL.
 
-Invoking the initial ABORT restart estabilished by MAKE-THREAD is
+Invoking the initial ABORT restart established by MAKE-THREAD is
 equivalent to calling ABORT-THREAD in other than main threads.
 However, whereas ABORT restart may be rebound, ABORT-THREAD always
 unwinds the entire thread. (Behaviour of the initial ABORT restart for

--- a/src/code/thread.lisp
+++ b/src/code/thread.lisp
@@ -153,7 +153,7 @@ and the MUTEX is not immediately available, sleep until it is available.
 If TIMEOUT is given, it specifies a relative timeout, in seconds, on how long
 the system should try to acquire the lock in the contested case.
 
-If the mutex isn't acquired succesfully due to either WAIT-P or TIMEOUT, the
+If the mutex isn't acquired successfully due to either WAIT-P or TIMEOUT, the
 body is not executed, and WITH-MUTEX returns NIL.
 
 Otherwise body is executed with the mutex held by current thread, and
@@ -194,7 +194,7 @@ held by the current thread, sleep until it is available.
 If TIMEOUT is given, it specifies a relative timeout, in seconds, on how long
 the system should try to acquire the lock in the contested case.
 
-If the mutex isn't acquired succesfully due to either WAIT-P or TIMEOUT, the
+If the mutex isn't acquired successfully due to either WAIT-P or TIMEOUT, the
 body is not executed, and WITH-RECURSIVE-LOCK returns NIL.
 
 Otherwise body is executed with the mutex held by current thread, and

--- a/src/pcl/cache.lisp
+++ b/src/pcl/cache.lisp
@@ -271,7 +271,7 @@
             ;; The place was already taken, and doesn't match our key.
             (return-from try-update-cache-line nil))
           (unless layouts
-            ;; All keys match or succesfully saved, save our value --
+            ;; All keys match or successfully saved, save our value --
             ;; just smash it in. Until the first time it is written
             ;; there is ..EMPTY.. here, which probes look for, so we
             ;; don't get bogus hits. This is necessary because we want


### PR DESCRIPTION
I went through the manual and spotted a few typos, and a couple of abbreviations I thought should be expanded.