### PR TITLE
Added *FULL-POSIX-ARGV*

### DIFF
--- a/doc/manual/beyond-ansi.texinfo
+++ b/doc/manual/beyond-ansi.texinfo
@@ -611,9 +611,12 @@ created by calling the following generic function:
 @node Command-line arguments
 @subsection Command-line arguments
 @vindex @sbext{@earmuffs{posix-argv}}
+@vindex @sbext{@earmuffs{full-posix-argv}}
 
-The UNIX command line can be read from the variable
-@code{sb-ext:*posix-argv*}.
+The UNIX command line with all options processed by SBCL removed can
+be read from the variable @code{sb-ext:*posix-argv*}.  The full UNIX
+command line with all SBCL options still included can be read from the
+variable @code{sb-ext:*full-posix-argv*}
 
 @node Querying the process environment
 @subsection Querying the process environment

--- a/package-data-list.lisp-expr
+++ b/package-data-list.lisp-expr
@@ -590,7 +590,8 @@ like *STACK-TOP-HINT* and unsupported stuff like *TRACED-FUN-LIST*."
       :use ("CL" "SB!ALIEN" "SB!INT" "SB!SYS" "SB!GRAY")
       :export ( ;; Information about how the program was invoked is
                ;; nonstandard but very useful.
-               "*POSIX-ARGV*" "*CORE-PATHNAME*" "*RUNTIME-PATHNAME*"
+               "*POSIX-ARGV*" "*FULL-POSIX-ARGV*"
+               "*CORE-PATHNAME*" "*RUNTIME-PATHNAME*"
                "POSIX-GETENV" "POSIX-ENVIRON"
 
                ;; Customizing initfile locations

--- a/src/code/common-os.lisp
+++ b/src/code/common-os.lisp
@@ -14,6 +14,8 @@
 (defvar *software-version* nil)
 
 (sb!alien:define-alien-variable ("posix_argv" *native-posix-argv*) (* (* char)))
+(sb!alien:define-alien-variable ("full_posix_argv" *native-full-posix-argv*)
+    (* (* char)))
 (sb!alien:define-alien-variable ("core_string" *native-core-string*) (* char))
 (sb!alien:define-alien-routine
  os-get-runtime-executable-path sb!alien:c-string (external-path boolean))
@@ -47,7 +49,8 @@
         *software-version* nil
         *runtime-pathname* nil
         *core-pathname* nil
-        *posix-argv* nil)
+        *posix-argv* nil
+        *full-posix-argv* nil)
   (sb!impl::%makunbound '*machine-version*))
 
 (defun os-cold-init-or-reinit ()
@@ -62,6 +65,13 @@
    *posix-argv*
    (loop for i from 0
          for arg = (sb!alien:deref *native-posix-argv* i)
+         until (sb!alien:null-alien arg)
+         collect (sb!alien:cast arg sb!alien:c-string)))
+  (/show0 "setting *FULL-POSIX-ARGV*")
+  (init-var-ignoring-errors
+   *full-posix-argv*
+   (loop for i from 0
+         for arg = (sb!alien:deref *native-full-posix-argv* i)
          until (sb!alien:null-alien arg)
          collect (sb!alien:cast arg sb!alien:c-string)))
   (/show0 "setting *DEFAULT-PATHNAME-DEFAULTS*")

--- a/src/code/early-impl.lisp
+++ b/src/code/early-impl.lisp
@@ -16,6 +16,7 @@
 ;;; listed here and then listed separately (and by now, 2001-06-06,
 ;;; slightly differently) elsewhere.
 (declaim (special *posix-argv*
+                  *full-posix-argv*
                   *core-string*
                   *stdin*
                   *stdout*

--- a/src/code/globals.lisp
+++ b/src/code/globals.lisp
@@ -24,7 +24,8 @@
                   #!+sb-thread *stop-for-gc-pending*
                   #!+sb-dynamic-core sb!vm::*required-runtime-c-symbols*
                   *load-verbose*
-                  *posix-argv*))
+                  *posix-argv*
+                  *full-posix-argv*))
 
 (declaim (ftype (function * *)
                 assert-error assert-prompt check-type-error

--- a/src/compiler/generic/parms.lisp
+++ b/src/compiler/generic/parms.lisp
@@ -132,7 +132,7 @@
   '(t
 
     ;; filled in by the C code to propagate to Lisp
-    *posix-argv* *core-string*
+    *posix-argv* *full-posix-argv* *core-string*
 
     ;; free pointers.  Note that these are FIXNUM word counts, not (as
     ;; one might expect) byte counts or SAPs. The reason seems to be

--- a/src/runtime/runtime.c
+++ b/src/runtime/runtime.c
@@ -358,6 +358,7 @@ parse_size_arg(char *arg, char *arg_name)
 }
 
 char **posix_argv;
+char **full_posix_argv;
 char *core_string;
 
 struct runtime_options *runtime_options;
@@ -488,11 +489,12 @@ main(int argc, char *argv[], char *envp[])
     if (runtime_options != NULL) {
         dynamic_space_size = runtime_options->dynamic_space_size;
         thread_control_stack_size = runtime_options->thread_control_stack_size;
-        sbcl_argv = argv;
+        full_posix_argv = sbcl_argv = argv;
     } else {
         int argi = 1;
 
         runtime_options = successful_malloc(sizeof(struct runtime_options));
+        full_posix_argv = argv;
 
         while (argi < argc) {
             char *arg = argv[argi];

--- a/tests/core.test.sh
+++ b/tests/core.test.sh
@@ -65,7 +65,7 @@ run_sbcl <<EOF
   (save-lisp-and-die "$tmpcore" :executable t)
 EOF
 chmod u+x "$tmpcore"
-./"$tmpcore" > "$tmpoutput" --no-userinit --no-sysinit --noprint <<EOF 
+./"$tmpcore" > "$tmpoutput" --no-userinit --no-sysinit --noprint <<EOF
   (exit :code 71)
 EOF
 status=$?
@@ -90,7 +90,7 @@ run_sbcl <<EOF
   (save-lisp-and-die "$tmpcore" :executable t)
 EOF
 chmod u+x "$tmpcore"
-./"$tmpcore" --no-userinit <<EOF 
+./"$tmpcore" --no-userinit <<EOF
   (save-lisp-and-die "$tmpcore" :executable t :save-runtime-options t)
 EOF
 chmod u+x "$tmpcore"
@@ -101,6 +101,16 @@ EOF
 status=$?
 if [ $status != 42 ]; then
     echo "saving runtime options from executable failed"
+    exit 1
+fi
+./"$tmpcore" --no-userinit --version --eval '(exit)' <<EOF
+  (when (equal *full-posix-argv* '("./$tmpcore" "--no-userinit"
+                                   "--version" "--eval" "(exit)"))
+    (exit :code 42))
+EOF
+status=$?
+if [ $status != 42 ]; then
+    echo "saving all runtime options from executable failed"
     exit 1
 fi
 


### PR DESCRIPTION
Added _FULL-POSIX-ARGV_ for those cases where one wants to snoop
on the command-line arguments that SBCL would otherwise absorb.
_FULL-POSIX-ARGV_ is the original ARGV[] passed to SBCL without
any of the SBCL options removed.
