### PR TITLE
Fix RUN-PROGRAM failing if an output file doesn't exist.

### DIFF
--- a/src/code/run-program.lisp
+++ b/src/code/run-program.lisp
@@ -834,11 +834,13 @@ Users Manual for details about the PROCESS structure.
                                       output cookie
                                       :direction :output
                                       :if-exists if-output-exists
+                                      :if-does-not-exist :create
                                       :external-format external-format)
                (with-fd-and-stream-for ((stderr error-stream)  :error
                                         error cookie
                                         :direction :output
                                         :if-exists if-error-exists
+                                        :if-does-not-exist :create
                                         :external-format external-format)
                  (with-open-pty ((pty-name pty-stream) (pty cookie))
                    ;; Make sure we are not notified about the child


### PR DESCRIPTION
If a pathname is passed as :OUTPUT or as :ERROR to RUN-PROGRAM, the
target file is created if it doesn't exist. The problem was that when
:IF-OUTPUT-EXISTS / :IF-ERROR-EXISTS is also specified, RUN-PROGRAM
signaled an error if the file cannot be found. This behavior is caused
by NIL being passed as :IF-DOES-NOT-EXIST argument to OPEN, so let's fix
it by explicitly passing :IF-DOES-NOT-EXIST :CREATE.

An example:

``` cl
(sb-ext:run-program
 "ls" '("/tmp/")
 :search t
 :output #p"/tmp/out.txt"
 :if-output-exists :overwrite)
```

If /tmp/out.txt doesn't exist, an error is signalled unless you remove `:if-output-exists :overwrite`.
