### PR TITLE
Use PRINT-SYMBOL-WITH-PREFIX to print class names.

### DIFF
--- a/src/code/early-format.lisp
+++ b/src/code/early-format.lisp
@@ -54,7 +54,7 @@
 ;;; Used by the expander stuff. List of (symbol . offset) for simple args.
 (defvar *simple-args*)
 
-(defun print-symbol-with-prefix (stream symbol colon at)
+(defun print-symbol-with-prefix (stream symbol &optional colon at)
   #!+sb-doc
   "For use with ~/: Write SYMBOL to STREAM as if it is not accessible from
   the current package."

--- a/src/pcl/print-object.lisp
+++ b/src/pcl/print-object.lisp
@@ -72,7 +72,7 @@
   (if (slot-boundp method '%generic-function)
       (print-unreadable-object (method stream :type t :identity t)
         (let ((generic-function (method-generic-function method)))
-          (format stream "~S ~{~S ~}~:S"
+          (format stream "~/sb-impl::print-symbol-with-prefix/ ~{~S ~}~:S"
                   (and generic-function
                        (generic-function-name generic-function))
                   (method-qualifiers method)
@@ -85,7 +85,7 @@
   (if (slot-boundp method '%generic-function)
       (print-unreadable-object (method stream :type t :identity t)
         (let ((generic-function (method-generic-function method)))
-          (format stream "~S, slot:~S, ~:S"
+          (format stream "~/sb-impl::print-symbol-with-prefix/, slot:~S, ~:S"
                   (and generic-function
                        (generic-function-name generic-function))
                   (accessor-method-slot-name method)
@@ -108,9 +108,8 @@
          (let ((name (slot-value instance 'name)))
            (print-unreadable-object
                (instance stream :type t :identity (not properly-named-p))
-             (if extra-p
-                 (format stream "~S ~:S" name extra)
-                 (prin1 name stream)))))
+             (format stream "~/sb-impl::print-symbol-with-prefix/~:[~:; ~:S~]"
+                     name extra-p extra))))
         ((not extra-p) ; case (2): empty body to avoid an extra space
          (print-unreadable-object (instance stream :type t :identity t)))
         (t ; case (3). no name, but extra data - show #<unbound slot> and data
@@ -123,7 +122,7 @@
       (let* ((name (class-name class))
              (proper-p (and (symbolp name) (eq (find-class name nil) class))))
         (print-unreadable-object (class stream :type t :identity (not proper-p))
-          (prin1 name stream)))
+          (print-symbol-with-prefix stream name)))
       ;; "#<CLASS #<unbound slot> {122D1141}>" is ugly. Don't show that.
       (print-unreadable-object (class stream :type t :identity t))))
 

--- a/tests/mop-4.impure-cload.lisp
+++ b/tests/mop-4.impure-cload.lisp
@@ -53,7 +53,7 @@
 
 (let ((output (with-output-to-string (*standard-output*)
                 (pcl1 3))))
-  (assert (search "(CALL-TO-GF #<MY-GENERIC-FUNCTION-PCL1 PCL1 (1)> 3)" output)))
+  (assert (search "(CALL-TO-GF #<MY-GENERIC-FUNCTION-PCL1 MOP-4::PCL1 (1)> 3)" output)))
 
 #|
 (defclass my-generic-function-pcl2 (standard-generic-function) ()


### PR DESCRIPTION
It can be very confusing when the same symbol names are used in two different packages, and when it leads to some confusion then the error messages also don't contain package information.

This patch uses ```print-symbol-with-prefix``` also for printing class names in addition to the other usage already in the sources, making things a bit more consistent.

```
$ rgrep -i print-symbol-with-prefix .
./code/class.lisp:                    ~/sb-impl::print-symbol-with-prefix/" name)
./code/early-format.lisp:(defun print-symbol-with-prefix (stream symbol &optional colon at)
./code/condition.lisp:                     ~/sb-impl::print-symbol-with-prefix/.~:@>"
./code/condition.lisp:             (format stream "redefining ~/sb-impl::print-symbol-with-prefix/ ~
./code/condition.lisp:             (format stream "redefining ~/sb-impl::print-symbol-with-prefix/ ~
./code/condition.lisp:             (format stream "redefining ~/sb-impl::print-symbol-with-prefix/ ~
./code/target-package.lisp:                ~{~/sb-impl::print-symbol-with-prefix/~^, ~}~:@>"
./code/target-package.lisp:                              ~/sb-impl::print-symbol-with-prefix/~}~@:_~}~
./code/ntrace.lisp:                   (warn "~/sb-impl::print-symbol-with-prefix/ is ~
./code/defstruct.lisp:      ;;x  (style-warn "redefining ~/sb-impl::print-symbol-with-prefix/ ~
./pcl/std-class.lisp:                  for class ~S:~4I~@:_~<~@{~/sb-impl::print-symbol-with-prefix/~^~:@_~}~:>~@:>"
./pcl/std-class.lisp:                   ~/sb-impl::print-symbol-with-prefix/ of an instance ~
./pcl/std-class.lisp:                                  ~/sb-impl::print-symbol-with-prefix/ ~
./pcl/slots.lisp:                 (format stream "~@<The slot ~/sb-ext:print-symbol-with-prefix/ ~
./pcl/slots.lisp:                         ~/sb-ext:print-symbol-with-prefix/ ~
./pcl/slots.lisp:                         ~/sb-ext:print-symbol-with-prefix/.~@:>"
./pcl/print-object.lisp:          (format stream "~/sb-impl::print-symbol-with-prefix/ ~{~S ~}~:S"
./pcl/print-object.lisp:          (format stream "~/sb-impl::print-symbol-with-prefix/, slot:~S, ~:S"
./pcl/print-object.lisp:             (format stream "~/sb-impl::print-symbol-with-prefix/~:[~:; ~:S~]"
./pcl/print-object.lisp:          (print-symbol-with-prefix stream name)))
./pcl/cpl.lisp:              (format nil "named ~/sb-impl::print-symbol-with-prefix/"
./pcl/cpl.lisp:               (format nil "named ~/sb-impl::print-symbol-with-prefix/"
./pcl/cpl.lisp:                 (format nil "named ~/sb-impl::print-symbol-with-prefix/"
./pcl/macros.lisp:                     ~/sb-impl::print-symbol-with-prefix/." symbol))
./compiler/early-c.lisp:                 ~/sb-impl::print-symbol-with-prefix/, not the~@
./compiler/ir1report.lisp:                "~@<~@(~D~) call~:P to ~/sb-impl:print-symbol-with-prefix/ ~2:*~[~;was~:;were~] ~
./compiler/ir1report.lisp:         "~@<Proclaiming ~/sb-impl:print-symbol-with-prefix/ to be INLINE, but ~D call~:P to it ~
./compiler/ir1report.lisp:           "~@<Call to ~/sb-impl:print-symbol-with-prefix/ could not be inlined because no definition ~
./compiler/ir1report.lisp:           "~@<Call to ~/sb-impl:print-symbol-with-prefix/ could not be inlined because its source code ~
```