### PR TITLE
fixed bug which caused 32bit windows crash when type in Ctrl+C

### DIFF
--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -291,7 +291,7 @@ static inline struct thread *arch_os_get_current_thread(void)
 
 #elif defined(LISP_FEATURE_X86) && defined(LISP_FEATURE_WIN32)
     register struct thread *me=0;
-    __asm__ ("movl %%fs:0xE10+(4*63), %0" : "=r"(me) :);
+    __asm__ volatile ("movl %%fs:0xE10+(4*63), %0" : "=r"(me) :);
     return me;
 
 #else


### PR DESCRIPTION
Disable a gcc optimization in callback_wrapper_trampoline, which optimizes
out the first line (get new 'th' value) of detach_os_thread, and use the
old wrong value (NULL in alien callbacks scenario), which causes a
page-fault.

Actually the crash always happens in an alien-callback.