### PR TITLE
Enable mmap in presence of Linux address randomization

### DIFF
--- a/src/runtime/linux-os.c
+++ b/src/runtime/linux-os.c
@@ -337,6 +337,9 @@ os_validate(os_vm_address_t addr, os_vm_size_t len)
         addr=under_2gb_free_pointer;
     }
 #endif
+
+    if (addr) flags |= MAP_FIXED;
+
     actual = mmap(addr, len, OS_VM_PROT_ALL, flags, -1, 0);
     if (actual == MAP_FAILED) {
         perror("mmap");


### PR DESCRIPTION
Dreamhost  (and others)  uses a  Linux  kernel patch  that uses  address
randomization, causing this  mmap to fail when an  address is passed-in,
unless the MAP_FIXED  flag is passed. This patch enables  SBCL to run in
the presence of that address randomization feature.