### PR TITLE
Fix documentation for MAPL

### DIFF
--- a/src/code/list.lisp
+++ b/src/code/list.lisp
@@ -1328,7 +1328,7 @@
   (map1 function (cons list more-lists) :nconc t))
 
 (defun mapl (function list &rest more-lists)
-  "Apply FUNCTION to successive CDRs of list. Return NIL."
+  "Apply FUNCTION to successive CDRs of list. Return the second argument."
   (declare (explicit-check))
   (map1 function (cons list more-lists) nil nil))
 


### PR DESCRIPTION
Like MAPC, MAPL returns the input list.