### PR TITLE
Solaris x86 and x86_64 patches (tested on Solaris 10 and 11)

### DIFF
--- a/contrib/asdf-module.mk
+++ b/contrib/asdf-module.mk
@@ -11,7 +11,18 @@ FASL=$(DEST)/$(SYSTEM).fasl
 ASD=$(DEST)/$(SYSTEM).asd
 
 ifeq (SunOS,$(UNAME))
-  EXTRA_CFLAGS+=-D_XOPEN_SOURCE=500 -D__EXTENSIONS__
+  # _XOPEN_SOURCE tells your compiler to include definitions for some
+  # *extra* functions that are defined in the X/Open and POSIX standards.
+  # The numbers refer to different versions of the standard:
+  # 500 - X/Open 5, incorporating POSIX 1995
+  # 600 - X/Open 6, incorporating POSIX 2004
+  # 700 - X/Open 7, incorporating POSIX 2008
+  # OpenCSW GCC 5.5.0 and Oracle Studio compiler 12.5 both throw
+  # "Compiler or options invalid for pre-UNIX 03 X/Open applications and
+  #  pre-2001 POSIX applications" with -D_XOPEN_SOURCE=500.
+  EXTRA_CFLAGS+=-D_XOPEN_SOURCE=600 -D__EXTENSIONS__
+  # OpenCSW GCC 5.5.0 cannot compile foo.c successfully.
+  CC:=/usr/bin/cc
   PATH:=/usr/xpg4/bin:${PATH}
 endif
 ifeq (CYGWIN,$(findstring CYGWIN,$(UNAME)))

--- a/make.sh
+++ b/make.sh
@@ -80,7 +80,8 @@ maybetime sh make-host-1.sh
 maybetime sh make-target-1.sh
 maybetime sh make-host-2.sh
 maybetime sh make-target-2.sh
-maybetime sh make-target-contrib.sh
+# `make-target-contrib.sh' is not Bourne Shell-compliant (for /bin/sh on Solaris 10)
+maybetime bash make-target-contrib.sh
 
 NCONTRIBS=`find contrib -name Makefile -print | wc -l`
 NPASSED=`find obj/asdf-cache -name test-passed.test-report -print | wc -l`

--- a/src/runtime/Config.x86-64-sunos
+++ b/src/runtime/Config.x86-64-sunos
@@ -1,12 +1,36 @@
+# -*- makefile -*- for the C-level run-time support for SBCL
+
+# This software is part of the SBCL system. See the README file for
+# more information.
+#
+# This software is derived from the CMU CL system, which was
+# written at Carnegie Mellon University and released into the
+# public domain. The software is in the public domain and is
+# provided with absolutely no warranty. See the COPYING and CREDITS
+# files for more information.
+
+# The following configurations are confirmed working on Solaris 10 1/13 (Update 11),
+# with the following installed compilers:
+
+# 1. Oracle Studio 12.5 (/usr/bin/cc)
+# 2. OpenCSW GCC 5.5.0 (/opt/csw/bin/gcc)
+
 CC=gcc
-CFLAGS = -m64 -g -O2 -Wall -D__EXTENSIONS__ -D_POSIX_C_SOURCE=199506L -DSVR4 -D_REENTRANT -fno-omit-frame-pointer
+
+# -D_POSIX_C_SOURCE=199506L was removed, because OpenCSW GCC 5.5.0 doesn't support
+# "pre-UNIX 03 X/Open applications and pre-2001 POSIX applications" any more.
+# -- Chun Tian (binghe), Jan 5, 2018
+CFLAGS = -m64 -g -O2 -Wall -D__EXTENSIONS__ -DSVR4 -D_REENTRANT -fno-omit-frame-pointer
 LINKFLAGS = -m64 -g
 ASFLAGS = -m64 -Wall
 NM = nm -xgp
 GREP = ggrep
 
-#CC=/opt/SunStudioExpress/bin/cc
-#CFLAGS = -xarch=generic64 -g -O2 -Wall -D__EXTENSIONS__ -D_POSIX_C_SOURCE=199506L -DSVR4 -D_REENTRANT -fno-omit-frame-pointer
+# NOTE: Oracle Studio compiler 12.5 is confirmed *not* working, it stops at x86-64-assem.S
+# However, Sun compilers (cc) must be used for compiling contrib code (foo.c).
+# Also see contrib/asdf-module.mk. -- Chun Tian (binghe), Jan 5, 2018
+#CC=/usr/bin/cc
+#CFLAGS = -xarch=generic64 -g -O2 -Wall -D__EXTENSIONS__ -DSVR4 -D_REENTRANT -fno-omit-frame-pointer
 #ASFLAGS = -xarch=generic64 -Wall
 
 ASSEM_SRC = x86-64-assem.S ldso-stubs.S

--- a/src/runtime/Config.x86-sunos
+++ b/src/runtime/Config.x86-sunos
@@ -10,7 +10,7 @@
 # files for more information.
 
 CC=gcc
-CFLAGS = -g -O2 -Wall -D__EXTENSIONS__ -D_POSIX_C_SOURCE=199506L -DSVR4 -D_REENTRANT -fno-omit-frame-pointer
+CFLAGS = -g -O2 -Wall -D__EXTENSIONS__ -DSVR4 -D_REENTRANT -fno-omit-frame-pointer
 NM = nm -xgp
 GREP = ggrep
 

--- a/src/runtime/print.c
+++ b/src/runtime/print.c
@@ -307,7 +307,9 @@ static void brief_fixnum(lispobj obj)
     /* KLUDGE: Rather than update the tables in print_obj(), we
        declare all fixnum-or-unknown tags to be fixnums and sort it
        out here with a guard clause. */
-    if (!fixnump(obj)) return print_unknown(obj);
+    if (!fixnump(obj)) {
+        print_unknown(obj); return;
+    }
     printf("%"OBJ_FMTd, fixnum_value(obj));
 }
 
@@ -316,7 +318,9 @@ static void print_fixnum(lispobj obj)
     /* KLUDGE: Rather than update the tables in print_obj(), we
        declare all fixnum-or-unknown tags to be fixnums and sort it
        out here with a guard clause. */
-    if (!fixnump(obj)) return print_unknown(obj);
+    if (!fixnump(obj)) {
+        print_unknown(obj); return;
+    }
     printf(": %"OBJ_FMTd, fixnum_value(obj));
 }
 


### PR DESCRIPTION
Currently the SBCL binaries provided on sbcl.org is for version 1.2.7, the binaries may work on Solaris 11 but cannot run on Solaris 10.

I have successfully built latest SBCL (1.4.3) x86 and x86_64 on Solaris 10, and the resulting binaries are confirmed working on clean Solaris 11 installations (thus the binary doesn't depend on GCC runtime at all).  The main C compiler is GCC 5.5.0 from opencsw.org, but Oracle Developer Studio 12.5 (or 12.6) is also needed for compiling the `foo.c` in `sb-posix` package.

This PR contains all my changes. Some shell scripts must be called by `bash` instead of `sh` (they're different on Solaris 10).

Sample SBCL binaries (x86_64 version has `sb-threads` enabled) can be downloaded here:

- https://www.dropbox.com/s/lez4sav2bpxweb8/sbcl-1.4.3-x86-64-solaris.tar.bz2?dl=0
- https://www.dropbox.com/s/7wj9kg9qvutop2q/sbcl-1.4.3-x86-solaris.tar.bz2?dl=0
