### PR TITLE
 Change ioctl request type to unsigned long

### DIFF
--- a/src/code/unix.lisp
+++ b/src/code/unix.lisp
@@ -534,8 +534,8 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
 #!-win32
 (defun unix-ioctl (fd cmd arg)
   (declare (type unix-fd fd)
-           (type (signed-byte 32) cmd))
-  (void-syscall ("ioctl" int int (* char)) fd cmd arg))
+           (type (unsigned-byte 32) cmd))
+  (void-syscall ("ioctl" int unsigned-long (* char)) fd cmd arg))
 
 ;;;; sys/resource.h
 


### PR DESCRIPTION
The ioctl specification, insofar as it exists,[1] specifies the request type to be unsigned long.

Currently sbcl declares a (signed-byte 32), and uses the sb-alien C-type export of int. sb-alien uses a (signed-byte 32) for this, as ints in C are signed by default when no sign is declared.

This results in an error when ioctl commands larger than 2^31 are issued. For example, accessing SPI hardware registers on the Raspberry Pi requires commands larger than 2^31.[2]

It looks like at some point (15 years ago)[3] this argument type changed from signed-int to int, though as far as I understand removing the "signed" does not turn it into an unsigned integer.

Using unsigned-long as the type matches the ioctl specification, and works on my system. I don't know if this would break any currently existing programs, or if the cmd argument of unix-ioctl will get cast automatically in most cases.

[1] http://man7.org/linux/man-pages/man2/ioctl.2.html
[2] https://github.com/Shinmera/cl-spidev/blob/master/constants.lisp
[3] https://github.com/sbcl/sbcl/commit/0677c33068646b6ec33d5f622771673f3de38504#diff-e32cce0bfb6cd207741f69a9af4a57ce