### PR TITLE
Fix emit of INSERTPS instruction on SIMD x86_64.

### DIFF
--- a/src/compiler/x86-64/insts.lisp
+++ b/src/compiler/x86-64/insts.lisp
@@ -3056,7 +3056,6 @@
   (define-insert-sse-instruction pinsrb #x66 #x3a #x20)
   (define-insert-sse-instruction pinsrw #x66 #xc4 nil)
   (define-insert-sse-instruction pinsrd #x66 #x3a #x22)
-  (define-insert-sse-instruction insertps #x66 #x3a #x21)
 
   (define-extract-sse-instruction pextrb #x66 #x3a #x14)
   (define-extract-sse-instruction pextrd #x66 #x3a #x16)
@@ -3220,6 +3219,8 @@
   (regular-2byte-sse-inst-imm pcmpestri #x66 #x3a #x61)
   (regular-2byte-sse-inst-imm pcmpistrm #x66 #x3a #x62)
   (regular-2byte-sse-inst-imm pcmpistri #x66 #x3a #x63)
+
+  (regular-2byte-sse-inst-imm insertps #x66 #x3a #x21)
 
   (regular-2byte-sse-inst-imm aeskeygenassist #x66 #x3a #xdf))
 


### PR DESCRIPTION
SBCL reports a bug when trying to emit INSERTPS SIMD x86_64 instruction,
both Debian 9 stock `SBCL 1.3.14.debian` and `SBCL 1.4.3.280-b7f7daf50`.

The bug is caused by `insertps` defined via `define-insert-sse-instruction` 
when it is more accurate to defined it via `regular-2byte-sse-inst-imm`
in `src/compiler/x86-64/insts.lisp`,
which is what proposed pull does.

Here is the content of the test file `../test-insert.ps` that produces
the bug,


    (defpackage "TEST-INSERTPS"
      (:use "CL" "SB-EXT" "SB-C"))
    
    (in-package "TEST-INSERTPS")
    
    (defknown insertps-test
      ((simd-pack single-float) (simd-pack single-float)) (simd-pack single-float)
      (movable flushable always-translatable)
      :overwrite-fndb-silently t)
    
    (in-package "SB-VM")
    
    (define-vop (test-insertps::insertps-test)
      (:translate test-insertps::insertps-test)
      (:policy :fast-safe)
      (:args (x :scs (single-sse-reg) :target r)
             (y :scs (single-sse-reg)))
      (:arg-types simd-pack-single simd-pack-single)
      (:results (r :scs (single-sse-reg)))
      (:result-types simd-pack-single)
      (:generator 4
        (cond ((location= r y)    ;;ssddzzzz
               (inst insertps y x #b01101000)) ;; y2 := x1, y3 := 0.0
              (t
               (move r x)
               (inst insertps r y #b01101000)))))
    
    (in-package "TEST-INSERTPS")
    
    (defun insertps-test (x y)
      (insertps-test x y))
    
    ;;;;;;;;;;; Tests: ;;;;;;;;;;;
    
    (disassemble 'insertps-test)
    
    (format t "~%~S~%~%"
      (insertps-test
        (%make-simd-pack-single 1f0 2f0 3f0 4f0)
        (%make-simd-pack-single 5f0 6f0 7f0 8f0)))

and here is the bug:

    $ sh ./make.sh
    [...]

    $ cd tests && sh ./run-tests.sh && cd ..
    [...]

    $ sh ./run-sbcl.sh --load ../test-insert.lisp --quit
    (running SBCL from: .)
    This is SBCL 1.4.3.280-b7f7daf50, an implementation of ANSI Common Lisp.
    More information about SBCL is available at <http://www.sbcl.org/>.
    
    SBCL is free software, provided as is, with absolutely no warranty.
    It is mostly in the public domain; some portions are provided under
    BSD-style licenses.  See the CREDITS and COPYING files in the
    distribution for more information.
    While evaluating the form starting at line 31, column 0
      of #P"/home/user/github/sbcl/../test-insert.lisp":
    
    debugger invoked on a SB-INT:BUG in thread
    #<THREAD "main thread" RUNNING {10005585B3}>:
        failed AVER:
          (AND (SB-X86-64-ASM::XMM-REGISTER-P SB-X86-64-ASM::DST)
               (NOT (SB-X86-64-ASM::XMM-REGISTER-P SB-X86-64-ASM::SRC)))
      This is probably a bug in SBCL itself. (Alternatively, SBCL might have been
      corrupted by bad user code, e.g. by an undefined Lisp operation like
      (FMAKUNBOUND 'COMPILE), or by stray pointers from alien code or from unsafe
      Lisp code; or there might be a bug in the OS or hardware that SBCL is running
      on.) If it seems to be a bug in SBCL itself, the maintainers would like to
      know about it. Bug reports are welcome on the SBCL mailing lists, which you
      can find at <http://sbcl.sourceforge.net/>.
    
    Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.
    
    restarts (invokable by number or by possibly-abbreviated name):
      0: [RETRY   ] Retry EVAL of current toplevel form.
      1: [CONTINUE] Ignore error and continue loading file "/home/user/github/sbcl/../test-insert.lisp".
      2: [ABORT   ] Abort loading file "/home/user/github/sbcl/../test-insert.lisp".
      3:            Ignore runtime option --load "../test-insert.lisp".
      4:            Skip rest of --eval and --load options.
      5:            Skip to toplevel READ/EVAL/PRINT loop.
      6: [EXIT    ] Exit SBCL (calling #'EXIT, killing the process).
    
    (SB-INT:BUG "~@<failed AVER: ~2I~_~S~:>" (AND (SB-X86-64-ASM::XMM-REGISTER-P SB-X86-64-ASM::DST) (NOT (SB-X86-64-ASM::XMM-REGISTER-P SB-X86-64-ASM::SRC))))
    0] ; 
    ; compilation unit aborted
    ;   caught 1 fatal ERROR condition

After applying the change in `fix-insertps` branch,

    $ git checkout fix-insertps
    [...]

    $ sh ./make-sbcl.sh
    [...]

the test works fine:

    $ sh ./run-sbcl.sh --load ../test-insert.lisp  --quit
    (running SBCL from: .)
    This is SBCL 1.4.3.280.fix-insertps.1-7c663e88c-dirty, an implementation of ANSI Common Lisp.
    More information about SBCL is available at <http://www.sbcl.org/>.
    
    SBCL is free software, provided as is, with absolutely no warranty.
    It is mostly in the public domain; some portions are provided under
    BSD-style licenses.  See the CREDITS and COPYING files in the
    distribution for more information.
    ; disassembly for INSERTPS-TEST
    ; Size: 96 bytes. Origin: #x10019B0F7C
    ; 7C:       498B4C2458       MOV RCX, [R12+88]                ; no-arg-parsing entry point
                                                                  ; thread.binding-stack-pointer
    ; 81:       48894DF8         MOV [RBP-8], RCX
    ; 85:       0F28CA           MOVAPS XMM1, XMM2
    ; 88:       660F3A21C868     INSERTPS XMM1, XMM0, 104
    ; 8E:       49896C2438       MOV [R12+56], RBP                ; thread.pseudo-atomic-bits
    ; 93:       4D8B5C2418       MOV R11, [R12+24]                ; thread.alloc-region
    ; 98:       498D5320         LEA RDX, [R11+32]
    ; 9C:       493B542420       CMP RDX, [R12+32]
    ; A1:       772C             JNBE L2
    ; A3:       4989542418       MOV [R12+24], RDX                ; thread.alloc-region
    ; A8: L0:   498D530F         LEA RDX, [R11+15]
    ; AC:       66C742F16503     MOV WORD PTR [RDX-15], 869
    ; B2:       48C742F902000000 MOV QWORD PTR [RDX-7], 2
    ; BA:       0F294A01         MOVAPS [RDX+1], XMM1
    ; BE:       49316C2438       XOR [R12+56], RBP                ; thread.pseudo-atomic-bits
    ; C3:       7402             JEQ L1
    ; C5:       CC09             BREAK 9                          ; pending interrupt trap
    ; C7: L1:   488BE5           MOV RSP, RBP
    ; CA:       F8               CLC
    ; CB:       5D               POP RBP
    ; CC:       C3               RET
    ; CD:       CC10             BREAK 16                         ; Invalid argument count trap
    ; CF: L2:   6A20             PUSH 32
    ; D1:       41BB4001B021     MOV R11D, #x21B00140             ; ALLOC-TRAMP-R11
    ; D7:       41FFD3           CALL R11
    ; DA:       EBCC             JMP L0
    
    #<SIMD-PACK 1.0000000e+0 2.0000000e+0 6.0000000e+0 0.0000000e+0>
