### PR TITLE
Manual: Fix link to CLOS MOP spec, linking to modern public domain version

### DIFF
--- a/doc/manual/intro.texinfo
+++ b/doc/manual/intro.texinfo
@@ -495,7 +495,7 @@ shock.
 @item Art Of Metaobject Programming, by Gregor Kiczales et al.
 Currently the prime source of information on the Common Lisp Metaobject
 Protocol, which is supported by SBCL. Section 2 (Chapters 5 and 6) are
-freely available at @uref{http://www.lisp.org/mop/}.
+freely available at @uref{https://clos-mop.hexstreamsoft.com/}.
 
 @end table
 


### PR DESCRIPTION
Hello,

There is a broken link to the old (in my biased view, *obsolete*) copyrighted no-modifications-allowed version of the CLOS MOP specification in the manual. I think we should consider taking the opportunity to link to my modern public domain version instead, while fixing the link.

Full faithfulness to the contents of the book has been a top priority, which was ensured by carefully auditing the new version against the actual book, so this is very complete and safe to use. Mobile support is already implemented, and offline support and further improvements are underway.

I think it's safe to say that most people would prefer to use this new version over any other previously existing versions. A cursory look at my version should easily convince most people of this.

https://clos-mop.hexstreamsoft.com/

I hope this is to your satisfaction.

-------------------------------------------

(Note that all or almost all of the CSS validation "errors" (as seen when clicking on "✔ CSS3" at the bottom of the page) stem from the validator not yet supporting CSS variables, a widely supported feature in all modern standards-compliant browsers. I consider this a bug in the validator.)

(Relatedly, I am also seeking to get specbot updated to link to this modern version: https://github.com/stassats/lisp-bots/pull/6)