### PR TITLE
Simplify build id generation

### DIFF
--- a/make-config.sh
+++ b/make-config.sh
@@ -794,7 +794,8 @@ if [ `uname` = "SunOS" ] ; then
   # use /usr/xpg4/bin/id instead of /usr/bin/id
   PATH=/usr/xpg4/bin:$PATH
 fi
-echo '"'`hostname`-`id -un`-`date +%Y-%m-%d-%H-%M-%S`'"' > output/build-id.inc
+
+echo '"'`id -u`-`date +%Y-%m-%d-%H-%M-%S`'"' > output/build-id.inc
 
 if [ -n "$SBCL_HOST_LOCATION" ]; then
     echo //setting up host configuration


### PR DESCRIPTION
I'm building SBCL on Windows under MinGW64.
My computer's name contains non-Ascii character (namely "Домашний", which is in Russian).
User name has non-Ascii characters as well.

So build fails.
Below is a part of output.

` ...
obj/from-xc/src/compiler/late-proclaim.lisp-obj
obj/from-xc/src/code/defboot.lisp-obj
obj/from-xc/src/code/setf.lisp-obj
obj/from-xc/src/code/macros.lisp-obj
obj/from-xc/src/code/loop.lisp-obj
obj/from-xc/src/code/late-format.lisp-obj
obj/from-xc/src/code/sxhash.lisp-obj
obj/from-xc/src/code/late-globaldb.lisp-obj
obj/from-xc/src/pcl/walk.lisp-obj
; SB!Loader: (274+725+11193+163+14252) structs/consts/funs/methods/other
[building initial core file in "output/cold-sbcl.core":
WARNING: Found non-STANDARD-CHAR in "▒▒▒▒▒▒▒▒-Соло-2018-04-09-13-30-31"
While evaluating the form starting at line 16, column 0
  of #P"C:/dev/sbcl-src/sbcl-1.4.6/make-genesis-2.lisp":

debugger invoked on a TYPE-ERROR in thread
#<THREAD "main thread" RUNNING {10027900C3}>:
  The value
    #\CYRILLIC_CAPITAL_LETTER_DE
  is not of type
    STANDARD-CHAR
  when binding CHARACTER

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [RETRY   ] Retry EVAL of current toplevel form.
  1: [CONTINUE] Ignore error and continue loading file "C:\\dev\\sbcl-src\\sbcl-1.4.6\\make-genesis-2.lisp".
  2: [ABORT   ] Abort loading file "C:\\dev\\sbcl-src\\sbcl-1.4.6\\make-genesis-2.lisp".
  3:            Abort building SBCL.
  4:            Exit debugger, returning to top level.

(SB!XC:CHAR-CODE #\CYRILLIC_CAPITAL_LETTER_DE) [external]
   source: (DEFUN SB!XC:CHAR-CODE (CHARACTER)
             (DECLARE (TYPE STANDARD-CHAR CHARACTER))
             (IF (CHAR= CHARACTER #\Newline)
                 10
                 (+ (POSITION CHARACTER ASCII-STANDARD-CHARS) 32)))
0] //testing for consistency of first and second GENESIS passes
diff: output/genesis-2: No such file or directory
error: header files do not match between first and second GENESIS

real    2m4.223s
user    0m0.030s
sys     0m0.151s`

There are several problems.
1) `hostname` returns name of the host with encoding CP1251 (in my case)
2) `id -un` returns logged user name with encoding UTF-8
3) genesis expects build id is `simple-string`

So constructed build id malformed from the very beginning.

Proposed solution:
-------------------
The main purpose of build id to discourage people from mismatching sbcl and *.core files.
If we eliminate hostname and change username to user id (which is done by `id -u` instead if `id -un`, we still get good uniqueness without mentioned problems.

