### PR TITLE
Fix probable copy-paste error in list iterator, from end

### DIFF
--- a/src/pcl/sequence.lisp
+++ b/src/pcl/sequence.lisp
@@ -216,8 +216,7 @@
                   (if (eq iterator list)
                       *exhausted*
                       (do* ((cdr list (cdr cdr)))
-                           ((eq (cdr cdr) iterator) cdr)))
-                  (1+ iterator))
+                           ((eq (cdr cdr) iterator) cdr))))
                 (lambda (list iterator from-end)
                   (declare (ignore list from-end))
                   (cdr iterator)))


### PR DESCRIPTION
Hello,

There was a question today on Stackoverflow about how to traverse a list from end,
and trying to do it with SB-SEQUENCE, I noticed a bug.

The following code failed:

     (sb-sequence:with-sequence-iterator-functions
         (next stop value _set _index _copy)
         ('(a b c d) :from-end t)
       (loop until (stop) collect (value) do (next)))

... with the following error:

    The value
      (D)
    is not of type
      NUMBER
    when binding SB-KERNEL::X
       [Condition of type TYPE-ERROR]

The pull request fixes that, by dropping the line that tries to increment the iterator. It looks like it was copy-pasted from the vector iterator.