### PR TITLE
Fix build failures with gcc-9, such as:

### DIFF
--- a/src/runtime/Config.arm-android
+++ b/src/runtime/Config.arm-android
@@ -10,7 +10,7 @@
 # files for more informration.
 
 CC=${NDK_PATH}/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/arm-linux-androideabi/bin/gcc
-CFLAGS += -marm -march=armv5 --sysroot=${NDK_PATH}/platforms/android-15/arch-arm/
+CFLAGS += -marm -march=armv7 --sysroot=${NDK_PATH}/platforms/android-15/arch-arm/
 LINKFLAGS += --sysroot=${NDK_PATH}/platforms/android-15/arch-arm/
 NM = ${NDK_PATH}/toolchains/arm-linux-androideabi-4.8/prebuilt/linux-x86_64/arm-linux-androideabi/bin/nm
 

--- a/src/runtime/Config.arm-linux
+++ b/src/runtime/Config.arm-linux
@@ -9,7 +9,7 @@
 # provided with absolutely no warranty. See the COPYING and CREDITS
 # files for more information.
 
-CFLAGS += -marm -march=armv5
+CFLAGS += -marm -march=armv7
 NM = ./linux-nm
 
 ASSEM_SRC = arm-assem.S ldso-stubs.S


### PR DESCRIPTION
make[2]: Entering directory '/<<PKGBUILDDIR>>/tools-for-build'
cc -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -marm -march=armv5 -Wdate-time -D_FORTIFY_SOURCE=2 -I../src/runtime -Wl,-Bsymbolic-functions -Wl,-z,relro  determine-endianness.c  -ldl -o determine-endianness
cc: error: unrecognized -march target: armv5
cc: note: valid arguments are: armv4 armv4t armv5t armv5te armv5tej armv6 armv6j armv6k armv6z armv6kz armv6zk armv6t2 armv6-m armv6s-m armv7 armv7-a armv7ve armv7-r armv7-m armv7e-m armv8-a armv8.1-a armv8.2-a armv8.3-a armv8.4-a armv8.5-a armv8-m.base armv8-m.main armv8-r iwmmxt iwmmxt2 native; did you mean 'armv4'?