### PR TITLE
Remove form feeds from source code files.

### DIFF
--- a/contrib/sb-aclrepl/inspect.lisp
+++ b/contrib/sb-aclrepl/inspect.lisp
@@ -592,7 +592,7 @@ position with the label if the label is a string."
               (push r list)))
           (format nil "[~W~{,~W~}]" (car list) (cdr list))))))
 
-
+
 ;;; INSPECTED-DESCRIPTION
 ;;;
 ;;; Accepts an object and returns
@@ -734,7 +734,7 @@ cons cells and LIST-TYPE is :normal, :dotted, or :cyclic"
 (defmethod inspected-description ((object (eql *inspect-unbound-object-marker*)))
   "..unbound..")
 
-
+
 ;;; FIXME: Most of this should be refactored to share the code
 ;;; with the vanilla inspector. Also, we should check what the
 ;;; Slime inspector does, and provide a an interface for it to

--- a/contrib/sb-aclrepl/repl.lisp
+++ b/contrib/sb-aclrepl/repl.lisp
@@ -390,7 +390,7 @@
       (ensure-directories-exist dest-path)
       (compile-file src-path :output-file dest-path))
     dest-path))
-
+
 ;;;; implementation of commands
 
 (defun apropos-cmd (string)
@@ -610,7 +610,7 @@
     (format *output* "~a~%" dir))
   (values))
 
-
+
 ;;;; dispatch table for commands
 
 (let ((cmd-table
@@ -656,7 +656,7 @@
   (dolist (cmd cmd-table)
     (destructuring-bind (cmd-string abbr-len func-name desc &key parsing) cmd
       (add-cmd-table-entry cmd-string abbr-len func-name desc parsing))))
-
+
 ;;;; machinery for aliases
 
 (defsetf alias (name &key abbr-len description) (user-func)
@@ -721,7 +721,7 @@
     (dolist (key keys)
       (remhash key *cmd-table-hash*))
     keys))
-
+
 ;;;; low-level reading/parsing functions
 
 ;;; Skip white space (but not #\NEWLINE), and peek at the next
@@ -747,7 +747,7 @@
 (defun whitespace-char-not-newline-p (x)
   (and (whitespace-char-p x)
        (not (char= x #\newline))))
-
+
 ;;;; linking into SBCL hooks
 
 (defun repl-prompt-fun (stream)

--- a/contrib/sb-bsd-sockets/local.lisp
+++ b/contrib/sb-bsd-sockets/local.lisp
@@ -1,6 +1,6 @@
 (in-package :sb-bsd-sockets)
 
-
+
 ;;;; Local domain sockets
 
 (defclass local-socket (socket)
@@ -36,7 +36,7 @@ also known as unix-domain sockets."))
   (let ((name (sockint::sockaddr-un-path sockaddr)))
     (unless (zerop (length name)) name)))
 
-
+
 ;;;; Local domain sockets in the abstract namespace
 
 (defclass local-abstract-socket (local-socket) ()

--- a/contrib/sb-bsd-sockets/sockets.lisp
+++ b/contrib/sb-bsd-sockets/sockets.lisp
@@ -63,7 +63,7 @@ directly instantiated.")))
           (sb-ext:finalize socket (lambda () (sockint::close fd))
                            :dont-save t)))))
 
-
+
 
 (defun call-with-socket-addr (socket sockaddr-args thunk)
   (multiple-value-bind (sockaddr size)
@@ -97,7 +97,7 @@ directly instantiated.")))
   (with-socket-fd-and-addr (fd sockaddr size address) socket
     (socket-error-case ("bind" (sockint::bind fd sockaddr size)))))
 
-
+
 
 (defmethod socket-accept ((socket socket))
   (with-socket-fd-and-addr (fd sockaddr size) socket
@@ -337,7 +337,7 @@ request an input stream and get an output stream in response\)."
     (sb-ext:cancel-finalization socket)
     stream))
 
-
+
 
 ;;; Error handling
 

--- a/contrib/sb-gmp/gmp.lisp
+++ b/contrib/sb-gmp/gmp.lisp
@@ -90,7 +90,7 @@
 ;; style warnings
 (%load-gmp)
 
-
+
 ;;; types and initialization
 
 (define-alien-type gmp-limb
@@ -193,7 +193,7 @@ pre-allocated bignum. The allocated bignum-length must be (1+ COUNT)."
 (define-alien-routine __gmpz_clear void
   (x (* (struct gmpint))))
 
-
+
 ;;; integer interface functions
 (defmacro define-twoarg-mpz-funs (funs)
   (loop for i in funs collect `(define-alien-routine ,i void
@@ -225,7 +225,7 @@ pre-allocated bignum. The allocated bignum-length must be (1+ COUNT)."
                            (declaim (inline ,@funs))
                            ,@defines))))
 
-
+
 (define-twoarg-mpz-funs (__gmpz_sqrt
                          __gmpz_nextprime))
 
@@ -304,7 +304,7 @@ pre-allocated bignum. The allocated bignum-length must be (1+ COUNT)."
   (a (* (struct gmpint)))
   (b unsigned-long))
 
-
+
 ;; ratio functions
 (defmacro define-threearg-mpq-funs (funs)
   (loop for i in funs collect `(define-alien-routine ,i void
@@ -321,7 +321,7 @@ pre-allocated bignum. The allocated bignum-length must be (1+ COUNT)."
                            __gmpq_mul
                            __gmpq_div))
 
-
+
 ;;;; SBCL interface
 
 ;;; utility macros for GMP mpz variable and result declaration and
@@ -423,7 +423,7 @@ pre-allocated bignum. The allocated bignum-length must be (1+ COUNT)."
                 (type integer ,@args))
        ,@body)))
 
-
+
 ;; SBCL/GMP functions
 (defgmpfun mpz-add (a b)
   (with-mpz-results ((result (1+ (max (blength a)
@@ -518,7 +518,7 @@ pre-allocated bignum. The allocated bignum-length must be (1+ COUNT)."
     (with-mpz-vars ((a ga))
       (__gmpz_sqrt (addr result) (addr ga)))))
 
-
+
 ;;; Functions that use GMP-side allocated integers and copy the result
 ;;; into a SBCL bignum at the end of the computation when the required
 ;;; bignum length is known.
@@ -603,7 +603,7 @@ pre-allocated bignum. The allocated bignum-length must be (1+ COUNT)."
   (with-gmp-mpz-results (fibn fibn-1)
     (__gmpz_fib2_ui (addr fibn) (addr fibn-1) n)))
 
-
+
 ;;;; Random bignum (mpz) generation
 
 ;; we do not actually use the gestalt of the struct but need its size
@@ -712,7 +712,7 @@ pre-allocated bignum. The allocated bignum-length must be (1+ COUNT)."
       (with-mpz-vars ((b gb))
         (__gmpz_urandomm (addr result) ref (addr gb))))))
 
-
+
 ;;; Rational functions
 (declaim (inline %lsize))
 (defun %lsize (minusp n)
@@ -809,7 +809,7 @@ pre-allocated bignum. The allocated bignum-length must be (1+ COUNT)."
 (defmpqfun mpq-mul __gmpq_mul)
 (defmpqfun mpq-div __gmpq_div)
 
-
+
 ;;;; SBCL interface and integration installation
 (macrolet ((def (name original)
              (let ((special (intern (format nil "*~A-FUNCTION*" name))))

--- a/contrib/sb-posix/posix-tests.lisp
+++ b/contrib/sb-posix/posix-tests.lisp
@@ -29,7 +29,7 @@
         (return-from ,name (values ,@values)))
       ,form)
     ,@values))
-
+
 (deftest chdir.1
   (sb-posix:chdir *test-directory*)
   0)
@@ -79,7 +79,7 @@
   #.sb-posix:enotdir
   #+win32
   #.sb-posix:einval)
-
+
 (deftest mkdir.1
   (let ((dne (make-pathname :directory '(:relative "mkdir.does-not-exist.1"))))
     (unwind-protect
@@ -136,7 +136,7 @@
         (sb-posix:rmdir dir)
         result)))
   #.sb-posix::eacces)
-
+
 (deftest rmdir.1
   (let ((dne (make-pathname :directory '(:relative "rmdir.does-not-exist.1"))))
     (ensure-directories-exist (merge-pathnames dne *test-directory*))
@@ -225,7 +225,7 @@
         (sb-posix:rmdir dir)
         result)))
   #.sb-posix::eacces)
-
+
 #-(or (and darwin x86) win32)
 (deftest stat.1
   (let* ((stat (sb-posix:stat *test-directory*))
@@ -326,7 +326,7 @@
         (sb-posix:rmdir dir)
         result)))
   #.sb-posix::eacces)
-
+
 ;;; stat-mode tests
 (defmacro with-stat-mode ((mode pathname) &body body)
   (let ((stat (gensym)))
@@ -396,7 +396,7 @@
              (sb-posix:s-isreg mode)))
       (ignore-errors (delete-file pathname))))
   t)
-
+
 ;;; see comment in filename's designator definition, in macros.lisp
 (deftest filename-designator.1
   (let ((file (format nil "~A/[foo].txt" (namestring *test-directory*))))
@@ -409,7 +409,7 @@
     (let ((*default-pathname-defaults* *test-directory*))
       (sb-posix:unlink (car (directory "*.txt")))))
   0)
-
+
 (deftest open.1
     (let ((name (merge-pathnames "open-test.txt" *test-directory*)))
       (unwind-protect
@@ -685,7 +685,7 @@
         (list (= (sb-posix:stat-atime stat) atime)
               (= (sb-posix:stat-mtime stat) mtime))))
   (t t))
-
+
 ;; readlink tests.
 #-win32
 (progn

--- a/contrib/sb-rotate-byte/arm64-vm.lisp
+++ b/contrib/sb-rotate-byte/arm64-vm.lisp
@@ -35,7 +35,7 @@
     (inst sub temp temp count)
     (inst ror (sb-vm::32-bit-reg res)
           (sb-vm::32-bit-reg integer) (sb-vm::32-bit-reg temp))))
-
+
 ;;; 64-bit
 (define-vop (%64bit-rotate-byte/c)
   (:policy :fast-safe)

--- a/contrib/sb-rotate-byte/x86-64-vm.lisp
+++ b/contrib/sb-rotate-byte/x86-64-vm.lisp
@@ -1,6 +1,6 @@
 (in-package "SB-ROTATE-BYTE")
 
-
+
 ;;; 32-bit rotates
 
 (define-vop (%32bit-rotate-byte/c)
@@ -42,7 +42,7 @@
       (emit-label label)
       (inst rol :dword result :cl)
       (emit-label end))))
-
+
 ;;; 64-bit rotates
 
 (define-vop (%64bit-rotate-byte/c)

--- a/contrib/sb-sprof/call-counting.lisp
+++ b/contrib/sb-sprof/call-counting.lisp
@@ -5,7 +5,7 @@
 
 (in-package #:sb-sprof)
 
-
+
 ;;;; Call counting
 
 ;;; The following functions tell sb-sprof to do call count profiling

--- a/contrib/sb-sprof/graph.lisp
+++ b/contrib/sb-sprof/graph.lisp
@@ -5,7 +5,7 @@
 
 (in-package #:sb-sprof)
 
-
+
 ;;;; Graph Utilities
 
 (defstruct (vertex (:constructor make-vertex)
@@ -133,7 +133,7 @@
     (setf (graph-vertices graph)
           (topological-sort (nconc (sccs) (trivial))))))
 
-
+
 ;;;; Call graph
 
 (deftype address ()
@@ -242,7 +242,7 @@
     (format stream "~s [~d]" (node-name (call-vertex call))
             (node-index (call-vertex call)))))
 
-
+
 ;;; Graph construction
 
 ;;; One function can have more than one COMPILED-DEBUG-FUNCTION with

--- a/contrib/sb-sprof/record.lisp
+++ b/contrib/sb-sprof/record.lisp
@@ -5,7 +5,7 @@
 
 (in-package #:sb-sprof)
 
-
+
 ;;; Append-only sample vector
 
 (deftype sampling-mode ()
@@ -119,7 +119,7 @@
     (setf (aref vector index) info
           (aref vector (1+ index)) pc-or-offset)
     (setf (samples-index samples) (+ index +elements-per-sample+))))
-
+
 ;;; Trace and sample and access functions
 
 (defun map-traces (function samples)
@@ -208,7 +208,7 @@ EXPERIMENTAL: Interface subject to change."
      (let* ((component (sb-di::compiled-debug-fun-component info))
             (start-pc (code-start component)))
        (+ start-pc pc-or-offset)))))
-
+
 ;;; Sampling
 
 (defvar *samples* nil)

--- a/contrib/sb-sprof/report.lisp
+++ b/contrib/sb-sprof/report.lisp
@@ -20,7 +20,7 @@
 (deftype report-sort-order ()
   '(member :descending :ascending))
 
-
+
 ;;;; Reporting
 
 (defun print-separator (&key (length 72) (char #\-))

--- a/doc/manual/generate-texinfo.lisp
+++ b/doc/manual/generate-texinfo.lisp
@@ -4,7 +4,7 @@
 
 (with-compilation-unit ()
   (load "docstrings.lisp"))
-
+
 ;;;; Generating documentation strings
 
 (defvar *contrib-directory* #P"../../contrib/")
@@ -53,7 +53,7 @@
             runtime (map 'list #'car contribs) packages)
     (map nil (lambda (contrib) (require (car contrib))) contribs)
     (apply #'sb-texinfo:generate-includes docstring-directory packages)))
-
+
 ;;;; Special cases: external formats list, package locks, variables.template
 
 (defun replace-all (new old string)
@@ -97,7 +97,7 @@
           (declare (ignore key))
           (pushnew (sb-impl::ef-names val) result :test #'equal))
         (table (sort result #'string< :key #'car))))))
-
+
 ;;;; Entry point
 
 (destructuring-bind (program runtime docstring-directory) *posix-argv*

--- a/src/assembly/alpha/arith.lisp
+++ b/src/assembly/alpha/arith.lisp
@@ -204,7 +204,7 @@
 
   DONE)
 
-
+
 ;;;; division
 
 (define-assembly-routine (signed-truncate
@@ -265,7 +265,7 @@
     (inst subq zero-tn rem rem)
     (emit-label label)))
 
-
+
 ;;;; comparison routines
 
 (macrolet

--- a/src/assembly/alpha/assem-rtns.lisp
+++ b/src/assembly/alpha/assem-rtns.lisp
@@ -8,7 +8,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Return-multiple with other than one value
 
 #+sb-assembling ;; We don't want a vop for this one.
@@ -90,7 +90,7 @@
 
   ;; Return.
   (lisp-return lra lip))
-
+
 ;;;; tail-call-variable
 
 #+sb-assembling ;; no vop for this one either
@@ -156,7 +156,7 @@
     (loadw temp lexenv closure-fun-slot fun-pointer-lowtag)
     (lisp-jump temp lip)))
 
-
+
 ;;;; non-local exit noise
 
 (define-assembly-routine

--- a/src/assembly/arm/arith.lisp
+++ b/src/assembly/arm/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; division
 
 (define-assembly-routine (signed-truncate

--- a/src/assembly/arm/array.lisp
+++ b/src/assembly/arm/array.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (define-assembly-routine (allocate-vector-on-heap
                           (:policy :fast-safe)
                           (:arg-types positive-fixnum

--- a/src/assembly/arm/assem-rtns.lisp
+++ b/src/assembly/arm/assem-rtns.lisp
@@ -1,5 +1,5 @@
 (in-package "SB-VM")
-
+
 ;;;; Return-multiple with other than one value
 
 #+sb-assembling ;; we don't want a vop for this one.
@@ -94,7 +94,7 @@
 
   ;; Return.
   (lisp-return lra :multiple-values))
-
+
 ;;;; tail-call-variable.
 
 #+sb-assembling ;; no vop for this one either.
@@ -167,7 +167,7 @@
   ;; to be the only ones available.
   (loadw temp lexenv closure-fun-slot fun-pointer-lowtag)
   (lisp-jump temp))
-
+
 ;;;; Non-local exit noise.
 
 (define-assembly-routine (throw

--- a/src/assembly/arm64/arith.lisp
+++ b/src/assembly/arm64/arith.lisp
@@ -10,6 +10,6 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 
 

--- a/src/assembly/arm64/array.lisp
+++ b/src/assembly/arm64/array.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (define-assembly-routine (allocate-vector-on-heap
                           (:policy :fast-safe)
                           (:arg-types positive-fixnum

--- a/src/assembly/arm64/assem-rtns.lisp
+++ b/src/assembly/arm64/assem-rtns.lisp
@@ -1,5 +1,5 @@
 (in-package "SB-VM")
-
+
 ;;;; Return-multiple with other than one value
 
 #+sb-assembling ;; we don't want a vop for this one.
@@ -70,7 +70,7 @@
 
   ;; Return.
   (lisp-return lra lip :multiple-values))
-
+
 ;;;; tail-call-variable.
 
 #+sb-assembling ;; no vop for this one either.
@@ -140,7 +140,7 @@
   (inst asr nargs nargs (- word-shift n-fixnum-tag-bits))
   (loadw temp lexenv closure-fun-slot fun-pointer-lowtag)
   (lisp-jump temp lip))
-
+
 ;;;; Non-local exit noise.
 
 (define-assembly-routine (throw

--- a/src/assembly/assemfile.lisp
+++ b/src/assembly/assemfile.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;; If non-NIL, emit assembly code. If NIL, emit VOP templates.
 (defvar *emit-assembly-code-not-vops-p* nil)
 

--- a/src/assembly/hppa/arith.lisp
+++ b/src/assembly/hppa/arith.lisp
@@ -1,6 +1,6 @@
 (in-package "SB-VM")
 
-
+
 ;;;; Multiplication and Division helping routines.
 
 ;;; ?? FIXME: Where are generic-* and generic-/?
@@ -84,7 +84,7 @@
   (inst move dividend zero-tn :>=)
   (inst sub zero-tn rem rem))
 
-
+
 ;;;; Generic arithmetic.
 
 (define-assembly-routine (generic-+
@@ -181,7 +181,7 @@
   (inst bv lip)
   (move csp-tn cfp-tn t))
 
-
+
 ;;;; Comparison routines.
 
 (macrolet

--- a/src/assembly/hppa/assem-rtns.lisp
+++ b/src/assembly/hppa/assem-rtns.lisp
@@ -64,7 +64,7 @@
   (inst add ocfp-tn nvals csp-tn)
   (lisp-return lra))
 
-
+
 ;;;; tail-call-variable.
 
 #+sb-assembling ;; no vop for this one either.
@@ -113,7 +113,7 @@
   (loadw temp lexenv closure-fun-slot fun-pointer-lowtag)
   (lisp-jump temp))
 
-
+
 ;;;; Non-local exit noise.
 
 (define-assembly-routine

--- a/src/assembly/mips/arith.lisp
+++ b/src/assembly/mips/arith.lisp
@@ -12,7 +12,7 @@
 (in-package "SB-VM")
 
 
-
+
 ;;;; Addition and subtraction.
 
 ;;; static-fun-offset returns the address of the raw_addr slot of
@@ -119,7 +119,7 @@
   (move cfp-tn csp-tn t))
 
 
-
+
 ;;;; Multiplication
 
 
@@ -219,7 +219,7 @@
   (frob fixnum-* "fixnum *" 30 tagged-num any-reg t))
 
 
-
+
 ;;;; Division.
 
 
@@ -292,7 +292,7 @@
     (inst mfhi rem))
 
 
-
+
 ;;;; Comparison routines.
 
 (macrolet

--- a/src/assembly/mips/array.lisp
+++ b/src/assembly/mips/array.lisp
@@ -11,5 +11,5 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Note: ALLOCATE-VECTOR is now implemented as a VOP.

--- a/src/assembly/mips/assem-rtns.lisp
+++ b/src/assembly/mips/assem-rtns.lisp
@@ -1,6 +1,6 @@
 (in-package "SB-VM")
 
-
+
 ;;;; Return-multiple with other than one value
 
 #+sb-assembling ;; we don't want a vop for this one.
@@ -84,7 +84,7 @@
   ;; Return.
   (lisp-return lra lip))
 
-
+
 ;;;; tail-call-variable.
 
 #+sb-assembling ;; no vop for this one either.
@@ -149,7 +149,7 @@
   (loadw temp lexenv closure-fun-slot fun-pointer-lowtag)
   (lisp-jump temp lip))
 
-
+
 ;;;; Non-local exit noise.
 
 (define-assembly-routine

--- a/src/assembly/ppc/arith.lisp
+++ b/src/assembly/ppc/arith.lisp
@@ -1,7 +1,7 @@
 (in-package "SB-VM")
 
 
-
+
 ;;;; Addition and subtraction.
 
 ;;; static-fun-offset returns the address of the raw_addr slot of
@@ -108,7 +108,7 @@
   (move res temp))
 
 
-
+
 ;;;; Multiplication
 
 
@@ -206,7 +206,7 @@
   (frob fixnum-* "fixnum *" 30 tagged-num any-reg))
 
 
-
+
 ;;;; Division.
 
 
@@ -282,7 +282,7 @@
     (inst mullw divisor quo divisor)
     (inst subf rem divisor dividend))
 
-
+
 ;;;; Comparison
 
 (macrolet

--- a/src/assembly/ppc/array.lisp
+++ b/src/assembly/ppc/array.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (define-assembly-routine (allocate-vector-on-heap
                           (:policy :fast-safe)
                           #-stack-allocatable-vectors

--- a/src/assembly/ppc/assem-rtns.lisp
+++ b/src/assembly/ppc/assem-rtns.lisp
@@ -1,6 +1,6 @@
 (in-package "SB-VM")
 
-
+
 ;;;; Return-multiple with other than one value
 
 #+sb-assembling ;; we don't want a vop for this one.
@@ -76,7 +76,7 @@
   (lisp-return lra lip))
 
 
-
+
 ;;;; tail-call-variable.
 
 #+sb-assembling ;; no vop for this one either.
@@ -136,7 +136,7 @@
   (lisp-jump temp lip))
 
 
-
+
 ;;;; Non-local exit noise.
 
 (define-assembly-routine (unwind

--- a/src/assembly/ppc64/arith.lisp
+++ b/src/assembly/ppc64/arith.lisp
@@ -1,7 +1,7 @@
 (in-package "SB-VM")
 
 
-
+
 ;;;; Addition and subtraction.
 
 ;;; static-fun-offset returns the address of the raw_addr slot of
@@ -108,7 +108,7 @@
   (move res temp))
 
 
-
+
 ;;;; Multiplication
 
 
@@ -204,7 +204,7 @@
   (frob fixnum-* "fixnum *" 30 tagged-num any-reg))
 
 
-
+
 ;;;; Division.
 
 (define-assembly-routine (positive-fixnum-truncate
@@ -274,7 +274,7 @@
     (inst mulld divisor quo divisor)
     (inst subf rem divisor dividend))
 
-
+
 ;;;; Comparison
 
 (macrolet

--- a/src/assembly/ppc64/array.lisp
+++ b/src/assembly/ppc64/array.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (define-assembly-routine (allocate-vector-on-heap
                           (:policy :fast-safe)
                           #-stack-allocatable-vectors

--- a/src/assembly/ppc64/assem-rtns.lisp
+++ b/src/assembly/ppc64/assem-rtns.lisp
@@ -1,6 +1,6 @@
 (in-package "SB-VM")
 
-
+
 ;;;; Return-multiple with other than one value
 
 #+sb-assembling ;; we don't want a vop for this one.
@@ -77,7 +77,7 @@
   (lisp-return lra lip))
 
 
-
+
 ;;;; tail-call-variable.
 
 #+sb-assembling ;; no vop for this one either.
@@ -138,7 +138,7 @@
   (lisp-jump temp lip))
 
 
-
+
 ;;;; Non-local exit noise.
 
 (define-assembly-routine (unwind

--- a/src/assembly/riscv/assem-rtns.lisp
+++ b/src/assembly/riscv/assem-rtns.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Return-multiple with other than one value
 #+sb-assembling ;; we don't want a vop for this one.
 (macrolet ((frob ()
@@ -146,7 +146,7 @@
                   (lisp-jump temp)))))
   (frob))
 
-
+
 ;;;; Non-local exit noise.
 
 (define-assembly-routine (throw (:return-style :none))

--- a/src/assembly/sparc/arith.lisp
+++ b/src/assembly/sparc/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Addition and subtraction.
 
 (define-assembly-routine (generic-+
@@ -101,7 +101,7 @@
   (move res temp))
 
 
-
+
 ;;;; Multiplication
 
 
@@ -241,7 +241,7 @@
   (frob fixnum-* "fixnum *" 30 tagged-num any-reg))
 
 
-
+
 ;;;; Division.
 
 #+sb-assembling
@@ -390,7 +390,7 @@
     (inst neg rem)
     (emit-label label)))
 
-
+
 ;;;; Comparison
 
 (macrolet

--- a/src/assembly/sparc/assem-rtns.lisp
+++ b/src/assembly/sparc/assem-rtns.lisp
@@ -8,7 +8,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Return-multiple with other than one value
 
 #+sb-assembling ;; we don't want a vop for this one.
@@ -95,7 +95,7 @@
   (lisp-return lra))
 
 
-
+
 ;;;; tail-call-variable.
 
 #+sb-assembling ;; no vop for this one either.
@@ -158,7 +158,7 @@
   (lisp-jump temp))
 
 
-
+
 ;;;; Non-local exit noise.
 
 (define-assembly-routine (unwind

--- a/src/assembly/x86-64/alloc.lisp
+++ b/src/assembly/x86-64/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; #+SB-ASSEMBLING as we don't need VOPS, just the asm routines:
 ;;; these are out-of-line versions called by VOPs.
 (fmakunbound 'define-per-register-allocation-routines)

--- a/src/assembly/x86-64/arith.lisp
+++ b/src/assembly/x86-64/arith.lisp
@@ -45,7 +45,7 @@
   (inst mov rcx-tn (fixnumize arg-count))
   (inst jmp (static-fun-addr fun))))
 
-
+
 ;;;; addition, subtraction, and multiplication
 
 #+sb-assembling
@@ -135,7 +135,7 @@
 
     SINGLE-WORD-BIGNUM
     (return-single-word-bignum res res rax)))
-
+
 ;;;; negation
 
 (define-assembly-routine (generic-negate
@@ -159,7 +159,7 @@
   (inst clc) (inst ret)
   GENERIC
   (tail-call-static-fun '%negate 1))
-
+
 ;;;; comparison
 
 (macrolet ((define-cond-assem-rtn (name translate static-fn test)

--- a/src/assembly/x86-64/assem-rtns.lisp
+++ b/src/assembly/x86-64/assem-rtns.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; RETURN-MULTIPLE
 
 ;;; For RETURN-MULTIPLE, we have to move the results from the end of
@@ -116,7 +116,7 @@
   (inst stc)
   (inst pop rbp-tn)
   (inst ret))
-
+
 ;;;; TAIL-CALL-VARIABLE
 
 ;;; For tail-call-variable, we have to copy the arguments from the end
@@ -268,7 +268,7 @@
   (emit-error-break nil error-trap (error-number-or-lose 'sb-kernel::object-not-callable-error)
                     (list fun)))
 
-
+
 (define-assembly-routine (throw
                           (:return-style :raw))
                          ((:arg target (descriptor-reg any-reg) rdx-offset)

--- a/src/assembly/x86/alloc.lisp
+++ b/src/assembly/x86/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Signed and unsigned bignums from word-sized integers. Argument
 ;;;; and return in the same register. No VOPs, as these are only used
 ;;;; as out-of-line versions: MOVE-FROM-[UN]SIGNED VOPs handle the

--- a/src/assembly/x86/arith.lisp
+++ b/src/assembly/x86/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; addition, subtraction, and multiplication
 
 (macrolet ((define-generic-arith-routine ((fun cost) &body body)
@@ -110,7 +110,7 @@
     OKAY
     (move res eax)
     DONE))
-
+
 ;;;; negation
 
 (define-assembly-routine (generic-negate
@@ -145,7 +145,7 @@
   (storew ecx res bignum-digits-offset other-pointer-lowtag)
 
   OKAY)
-
+
 ;;;; comparison
 
 (macrolet ((define-cond-assem-rtn (name translate static-fn test)
@@ -285,7 +285,7 @@
   (inst cmp x y)
   (inst pop ebp-tn))
 
-
+
 ;;; Support for the Mersenne Twister, MT19937, random number generator
 ;;; due to Matsumoto and Nishimura.
 ;;;

--- a/src/assembly/x86/array.lisp
+++ b/src/assembly/x86/array.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Note: On other platforms ALLOCATE-VECTOR is an assembly routine,
 ;;;; but on X86 it is a VOP.
 

--- a/src/assembly/x86/assem-rtns.lisp
+++ b/src/assembly/x86/assem-rtns.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; RETURN-MULTIPLE
 
 ;;; For RETURN-MULTIPLE, we have to move the results from the end of
@@ -123,7 +123,7 @@
   (inst stc)
   (inst pop ebp-tn)
   (inst ret))
-
+
 ;;;; TAIL-CALL-VARIABLE
 
 ;;; For tail-call-variable, we have to copy the arguments from the end
@@ -211,7 +211,7 @@
 
   ;; And away we go.
   (inst jmp (make-ea-for-object-slot eax closure-fun-slot fun-pointer-lowtag)))
-
+
 (define-assembly-routine (throw
                           (:return-style :raw))
                          ((:arg target (descriptor-reg any-reg) edx-offset)

--- a/src/code/alpha-vm.lisp
+++ b/src/code/alpha-vm.lisp
@@ -15,7 +15,7 @@
 (defun machine-type ()
   "Return a string describing the type of the local machine."
   "Alpha")
-
+
 (defconstant-eqx +fixup-kinds+
     #(:jmp-hint :bits-63-48 :bits-47-32 :ldah :lda :absolute32)
   #'equalp)
@@ -53,7 +53,7 @@
        (:absolute32
         (setf (sap-ref-32 sap offset) value))))
   nil))
-
+
 ;;;; "sigcontext" access functions, cut & pasted from x86-vm.lisp then
 ;;;; hacked for types.
 ;;;;
@@ -110,7 +110,7 @@
 (define-alien-routine ("os_context_fp_control" context-floating-point-modes)
     (unsigned 64) (context (* os-context-t)))
 
-
+
 (defun internal-error-args (context)
   (declare (type (alien (* os-context-t)) context))
   (let* ((pc (context-pc context))

--- a/src/code/ansi-stream.lisp
+++ b/src/code/ansi-stream.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;; HOW THE ANSI-STREAM STRUCTURE IS USED
 ;;;
 ;;; Many of the slots of the ANSI-STREAM structure contain functions
@@ -75,7 +75,7 @@
 ;;; operations. If the FAST-READ-CHAR and FAST-READ-BYTE macros are
 ;;; used, nearly all function call overhead is removed, vastly
 ;;; speeding up these important operations.
-
+
 ;;; the size of a stream in-buffer
 ;;;
 ;;; This constant it is used in a read-time-eval, and some implementations

--- a/src/code/arm-vm.lisp
+++ b/src/code/arm-vm.lisp
@@ -6,7 +6,7 @@
 (defun machine-type ()
   "Return a string describing the type of the local machine."
   "ARM")
-
+
 ;;;; FIXUP-CODE-OBJECT
 
 (defconstant-eqx +fixup-kinds+ #(:absolute) #'equalp)
@@ -21,7 +21,7 @@
       (:absolute
        (setf (sap-ref-32 sap offset) fixup))))
   nil))
-
+
 ;;;; "Sigcontext" access functions, cut & pasted from sparc-vm.lisp,
 ;;;; then modified for ARM.
 ;;;;
@@ -37,7 +37,7 @@
   (declare (ignore context index))
   (warn "stub %SET-CONTEXT-FLOAT-REGISTER")
   (coerce new-value format))
-
+
 ;;;; INTERNAL-ERROR-ARGS.
 
 ;;; Given a (POSIX) signal context, extract the internal error

--- a/src/code/arm64-vm.lisp
+++ b/src/code/arm64-vm.lisp
@@ -6,7 +6,7 @@
 (defun machine-type ()
   "Return a string describing the type of the local machine."
   "ARM64")
-
+
 ;;;; FIXUP-CODE-OBJECT
 
 (defconstant-eqx +fixup-kinds+ #(:absolute :cond-branch :uncond-branch)
@@ -28,7 +28,7 @@
          (setf (ldb (byte 26 0) (sap-ref-32 sap offset))
                (ash (- fixup (+ (sap-int sap) offset)) -2)))))
   nil))
-
+
 ;;;; "Sigcontext" access functions, cut & pasted from sparc-vm.lisp,
 ;;;; then modified for ARM.
 ;;;;
@@ -69,7 +69,7 @@
            (declare (type (complex double-float) value))
          (setf (sap-ref-double sap 0) (realpart value)
                (sap-ref-double sap 8) (imagpart value)))))))
-
+
 ;;;; INTERNAL-ERROR-ARGS.
 
 ;;; Given a (POSIX) signal context, extract the internal error

--- a/src/code/array.lisp
+++ b/src/code/array.lisp
@@ -14,7 +14,7 @@
 #-sb-fluid
 (declaim (inline adjustable-array-p
                  array-displacement))
-
+
 ;;;; miscellaneous accessor functions
 
 ;;; These functions are only needed by the interpreter, 'cause the
@@ -68,7 +68,7 @@
           (%with-array-data array index nil)
         (values vector index))
       (values (truly-the (simple-array * (*)) array) index)))
-
+
 
 ;;;; MAKE-ARRAY
 (defun %integer-vector-widetag-and-n-bits-shift (signed high)
@@ -635,7 +635,7 @@ of specialized arrays is supported."
   (let ((v (make-array (length objects))))
     (do-rest-arg ((x i) objects 0 v)
       (setf (aref v i) x))))
-
+
 
 ;;;; accessor/setter functions
 
@@ -996,7 +996,7 @@ of specialized arrays is supported."
   (setf (row-major-aref bit-array
                         (apply #'%array-row-major-index bit-array subscripts))
         new-value))
-
+
 ;;;; miscellaneous array properties
 
 (defun array-element-type (array)
@@ -1086,7 +1086,7 @@ of specialized arrays is supported."
   ;; but in practice we test using ADJUSTABLE-ARRAY-P in ADJUST-ARRAY.
   ;; -- CSR, 2004-03-01.
   (not (typep array 'simple-array)))
-
+
 ;;;; fill pointer frobbing stuff
 
 (declaim (inline array-has-fill-pointer-p))
@@ -1232,7 +1232,7 @@ of specialized arrays is supported."
                 (setf (%array-fill-pointer array)
                       (1- fill-pointer)))))))
 
-
+
 ;;;; ADJUST-ARRAY
 
 (defun adjust-array (array dimensions &key
@@ -1548,7 +1548,7 @@ function to be removed without further warning."
                            'array-storage-vector 'array-displacement))
                    (t
                     (%array-data array)))))
-
+
 
 ;;;; ZAP-ARRAY-DATA for ADJUST-ARRAY
 
@@ -1630,7 +1630,7 @@ function to be removed without further warning."
                     (the fixnum (* (the fixnum (car rev-subscripts))
                                    chunk-size))))
     (setq chunk-size (* chunk-size (the fixnum (car rev-dim-list))))))
-
+
 ;;;; some bit stuff
 
 (defun bit-array-same-dimensions-p (array1 array2)

--- a/src/code/backq.lisp
+++ b/src/code/backq.lisp
@@ -297,7 +297,7 @@
       (symbol-function '|List|)   #'list
       (symbol-function '|List*|)  #'list*
       (symbol-function '|Vector|) #'vector)
-
+
 ;;;; initialization
 
 ;;; Install BACKQ stuff in the current *READTABLE*.

--- a/src/code/bignum.lisp
+++ b/src/code/bignum.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-BIGNUM")
-
+
 ;;;; notes
 
 ;;; comments from CMU CL:
@@ -102,13 +102,13 @@
 ;;;          gcd of x and y.
 ;;;          "truncate" each by gcd, ignoring remainder 0.
 ;;;          form ratio of each result, bottom is positive.
-
+
 ;;;; What's a bignum?
 
 (defconstant digit-size sb-vm:n-word-bits)
 
 (defconstant all-ones-digit most-positive-word)
-
+
 ;;;; internal inline routines
 
 ;;; %ALLOCATE-BIGNUM must zero all elements.
@@ -258,9 +258,9 @@
 (defun bignum-plus-p (bignum)
   (declare (type bignum bignum))
   (%bignum-0-or-plusp bignum (%bignum-length bignum)))
-
+
 (declaim (optimize (speed 3) (safety 0)))
-
+
 ;;;; addition
 
 (defun add-bignums (a b)
@@ -314,7 +314,7 @@
       (setf (%bignum-ref res i) v)
       (setf carry k)))
   (values))
-
+
 ;;;; subtraction
 
 ;;; This subtracts b from a plugging result into res. Return-fun is the
@@ -360,7 +360,7 @@
            (type bignum-length len-a len-b))
   (subtract-bignum-loop a len-a b len-b result (max len-a len-b)
                         %normalize-bignum-buffer))
-
+
 ;;;; multiplication
 
 (defun multiply-bignums (a b)
@@ -440,7 +440,7 @@
             (%bignum-set res 1 high)
             (unless (eq a-minusp b-minusp) (negate-bignum-in-place res))
             (%normalize-bignum res 2))))))
-
+
 ;;;; BIGNUM-REPLACE and WITH-BIGNUM-BUFFERS
 
 (defmacro bignum-replace (dest src
@@ -490,7 +490,7 @@
     `(let* ,(binds)
        ,@(inits)
        ,@body)))
-
+
 ;;;; GCD
 
   ;; The asserts in the GCD implementation are way too expensive to
@@ -860,7 +860,7 @@
                                                  (+ (* index digit-size)
                                                     increment)))))))
 
-
+
 ;;;; negation
 
 ;;; This negates bignum-len digits of bignum, storing the resulting digits into
@@ -921,7 +921,7 @@
 (defun bignum-abs-buffer (bignum len)
   (unless (%bignum-0-or-plusp bignum len)
     (negate-bignum-buffer-in-place bignum len)))
-
+
 ;;;; shifting
 
 ;;; This macro is used by BIGNUM-ASHIFT-RIGHT, BIGNUM-BUFFER-ASHIFT-RIGHT, and
@@ -1118,7 +1118,7 @@
         (setf (%bignum-ref result (1+ right-zero-digits))
               (ldb (byte digit-size 0) left-half)))
             result)))
-
+
 ;;;; relational operators
 
 ;;; This compares two bignums returning -1, 0, or 1, depending on
@@ -1148,7 +1148,7 @@
           ((> len-a len-b)
            (if a-plusp 1 -1))
           (t (if a-plusp -1 1)))))
-
+
 ;;;; float conversion
 
 ;;; Make a single or double float with the specified significand,
@@ -1260,7 +1260,7 @@
      ;; Otherwise, round up.
      (t
       (round-up))))))
-
+
 ;;;; integer length and logbitp/logcount
 
 (defun bignum-buffer-integer-length (bignum len)
@@ -1303,7 +1303,7 @@
       (let ((digit (%bignum-ref bignum index)))
         (declare (type bignum-element-type digit))
         (incf result (logcount digit))))))
-
+
 ;;;; logical operations
 
 ;;;; NOT
@@ -1445,7 +1445,7 @@
     (declare (type bignum-index i))
     (setf (%bignum-ref res i) (%logxor sign (%bignum-ref b i))))
   (%normalize-bignum res len-b))
-
+
 ;;;; There used to be a bunch of code to implement "efficient" versions of LDB
 ;;;; and DPB here.  But it apparently was never used, so it's been deleted.
 ;;;;   --njf, 2007-02-04
@@ -1481,7 +1481,7 @@
                                            (%sign-digit bignum n-digits)))))
                        (ldb (byte low-part-size bit-index) ; low part
                             (%bignum-ref bignum word-index)))))))))
-
+
 ;;;; TRUNCATE
 
 ;;; This is the original sketch of the algorithm from which I implemented this
@@ -1875,7 +1875,7 @@
                     (if (typep rem 'fixnum)
                         rem
                         (%normalize-bignum rem (%bignum-length rem))))))))))
-
+
 ;;;; general utilities
 
 ;;; Internal in-place operations use this to fixup remaining digits in the
@@ -1933,7 +1933,7 @@
     (unless (= newlen len)
       (%bignum-set-length result newlen))
     result))
-
+
 ;;;; hashing
 
 ;;; the bignum case of the SXHASH function

--- a/src/code/bit-bash.lisp
+++ b/src/code/bit-bash.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; types
 
 (eval-when (:compile-toplevel)
@@ -110,7 +110,7 @@
   (setf (sap-ref-word sap (the index (ash offset word-shift)))
         value))
 
-
+
 ;;; the actual bashers and common uses of same
 
 ;;; This is a little ugly.  Fixing bug 188 would bring the ability to
@@ -586,7 +586,7 @@
         ;; FIXERS must come first so their inline expansions are available
         ;; for the bashers.
         finally (return `(progn ,@fixers ,@bashers)))
-
+
 ;;;; Bashing-Style search for bits
 ;;;;
 ;;;; Similar search would work well for base-strings as well.

--- a/src/code/bsd-os.lisp
+++ b/src/code/bsd-os.lisp
@@ -82,7 +82,7 @@
   (or sb-sys::*software-version*
       (setf sb-sys::*software-version*
             (sysctl :str ctl-kern kern-osrelease))))
-
+
 ;;; Return system time, user time and number of page faults.
 (defun get-system-info ()
   (multiple-value-bind (err? utime stime maxrss ixrss idrss

--- a/src/code/class.lisp
+++ b/src/code/class.lisp
@@ -14,7 +14,7 @@
 (in-package "SB-KERNEL")
 
 (!begin-collecting-cold-init-forms)
-
+
 ;;;; the CLASSOID structure
 
 ;;; The CLASSOID structure is a supertype of all classoid types.
@@ -32,7 +32,7 @@
   (declare (ignore env))
   `(find-classoid ',(classoid-name self)))
 
-
+
 ;;;; basic LAYOUT stuff
 
 ;;; a vector of conses, initialized by genesis
@@ -81,7 +81,7 @@
 (eval-when (#-sb-xc :compile-toplevel :load-toplevel :execute)
   (defun layout-proper-name (layout)
     (classoid-proper-name (layout-classoid layout))))
-
+
 ;;;; support for the hash values used by CLOS when working with LAYOUTs
 
 (defun random-layout-clos-hash ()
@@ -97,7 +97,7 @@
   ;; Method Dispatch in PCL", 1990.  -- CSR, 2005-11-30
   (1+ (random (1- layout-clos-hash-limit)
               *layout-clos-hash-random-state*)))
-
+
 ;;; If we can't find any existing layout, then we create a new one
 ;;; storing it in *FORWARD-REFERENCED-LAYOUTS*. In classic CMU CL, we
 ;;; used to immediately check for compatibility, but for
@@ -434,7 +434,7 @@ between the ~A definition and the ~A definition"
         (when (eql (svref inherits i) 0)
           (setf (svref inherits i) (svref inherits (1+ i)))))
       inherits)))
-
+
 ;;;; class precedence lists
 
 ;;; Topologically sort the list of objects to meet a set of ordering
@@ -503,7 +503,7 @@ between the ~A definition and the ~A definition"
                      (return (first intersection)))))))
       (note-class class)
       (topological-sort classes constraints #'std-cpl-tie-breaker))))
-
+
 ;;;; object types to represent classes
 
 ;;; BUILT-IN-CLASS is used to represent the standard classes that
@@ -520,7 +520,7 @@ between the ~A definition and the ~A definition"
                                     (hash-value name))))
 (defun make-structure-classoid (&key name)
   (%make-structure-classoid (interned-type-hash name) name))
-
+
 ;;;; classoid namespace
 
 (eval-when (#-sb-xc :compile-toplevel :load-toplevel :execute)
@@ -656,7 +656,7 @@ between the ~A definition and the ~A definition"
     (if (and name (eq (find-classoid name nil) classoid))
         name
         classoid)))
-
+
 ;;;; CLASS type operations
 
 ;; CLASSOID-ENUMERABLE-P is referenced during compile by !DEFINE-TYPE-CLASS.
@@ -851,7 +851,7 @@ between the ~A definition and the ~A definition"
 
 (define-type-method (classoid :unparse) (type)
   (classoid-proper-name type))
-
+
 ;;;; built-in classes
 
 ;;; The BUILT-IN-CLASSES list is a data structure which configures the
@@ -1201,7 +1201,7 @@ between the ~A definition and the ~A definition"
   (dolist (x +!built-in-classes+)
     (destructuring-bind (name &key (state :sealed) &allow-other-keys) x
       (setf (classoid-state (find-classoid name)) state))))
-
+
 ;;;; class definition/redefinition
 
 ;;; This is to be called whenever we are altering a class.
@@ -1234,7 +1234,7 @@ between the ~A definition and the ~A definition"
         (when subs
           (remhash classoid subs)))))
   (values))
-
+
 ;;;; cold loading initializations
 
 ;;; FIXME: It would be good to arrange for this to be called when the

--- a/src/code/cold-init.lisp
+++ b/src/code/cold-init.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; putting ourselves out of our misery when things become too much to bear
 
 (declaim (ftype (function (simple-string) nil) !cold-lose))
@@ -36,7 +36,7 @@
   (%primitive print "internal error: Control should never reach here, i.e.")
   (%primitive print where)
   (%halt))
-
+
 ;;;; !COLD-INIT
 
 ;;; a list of toplevel things set by GENESIS
@@ -339,7 +339,7 @@ process to continue normally."
               *exit-timeout* timeout)
         (throw '%end-of-the-world t)))
   (critically-unreachable "After trying to die in EXIT."))
-
+
 ;;;; initialization functions
 
 (defun thread-init-or-reinit ()
@@ -374,7 +374,7 @@ process to continue normally."
   (when (eq *invoke-debugger-hook* 'sb-debug::debugger-disabled-hook)
     (sb-debug::disable-debugger))
   (call-hooks "initialization" *init-hooks*))
-
+
 ;;;; some support for any hapless wretches who end up debugging cold
 ;;;; init code
 

--- a/src/code/condition.lisp
+++ b/src/code/condition.lisp
@@ -12,7 +12,7 @@
 ;;;; files for more information.
 
 (in-package "SB-KERNEL")
-
+
 ;;;; the CONDITION class
 
 (/show0 "condition.lisp 20")
@@ -106,7 +106,7 @@
               :stream stream :lines 1)))
     (t
      (print-unreadable-object (object stream :type t :identity t)))))
-
+
 ;;;; slots of CONDITION objects
 
 (defun find-slot-default (class slot)
@@ -174,7 +174,7 @@
                     (error "Unbound condition slot: ~S" (condition-slot-name cslot))
                     (return value))))))
         val)))
-
+
 ;;;; MAKE-CONDITION
 
 (defun allocate-condition (designator &rest initargs)
@@ -251,7 +251,7 @@
 
     condition))
 
-
+
 ;;;; DEFINE-CONDITION
 
 ;;; Compute the effective slots of CLASS, copying inherited slots and
@@ -503,7 +503,7 @@
          ;; we're under EVAL or loaded as source.
          (%set-condition-report ',name ,report)
          ',name))))
-
+
 ;;;; various CONDITIONs specified by ANSI
 
 (define-condition serious-condition (condition) ())
@@ -727,7 +727,7 @@
       (format stream "~2I~@[~:@_ ~:@_~:{~:(~A~): ~S~:^, ~:_~}~]~:@_ ~:@_Stream: ~S"
               (stream-error-position-info error-stream position)
               error-stream))))
-
+
 ;;;; special SBCL extension conditions
 
 ;;; an error apparently caused by a bug in SBCL itself
@@ -784,7 +784,7 @@
 ;;; unFBOUNDPness meant they were running on an system which didn't
 ;;; support the extension.)
 (define-condition unsupported-operator (simple-error) ())
-
+
 ;;; (:ansi-cl :function remove)
 ;;; (:ansi-cl :section (a b c))
 ;;; (:ansi-cl :glossary "similar")
@@ -1017,7 +1017,7 @@ SB-EXT:PACKAGE-LOCKED-ERROR-SYMBOL."))
      (format stream "Unknown &KEY argument: ~S"
              (unknown-keyword-argument-name condition)))))
 
-
+
 ;;;; various other (not specified by ANSI) CONDITIONs
 ;;;;
 ;;;; These might logically belong in other files; they're here, after
@@ -1331,13 +1331,13 @@ the values returned by the form as a list. No associated restarts."))
      (declare (ignore condition))
      (format stream "Returning from STEP")))
   (:documentation "Condition signaled when STEP returns."))
-
+
 ;;; A knob for muffling warnings, mostly for use while loading files.
 (defvar *muffled-warnings* 'uninteresting-redefinition
   "A type that ought to specify a subtype of WARNING.  Whenever a
 warning is signaled, if the warning is of this type and is not
 handled by any other handler, it will be muffled.")
-
+
 ;;; Various STYLE-WARNING signaled in the system.
 ;; For the moment, we're only getting into the details for function
 ;; redefinitions, but other redefinitions could be done later
@@ -1497,7 +1497,7 @@ handled by any other handler, it will be muffled.")
   (:report (lambda (warning stream)
              (format stream "Overwriting ~S"
                      (redefinition-with-deftransform-transform warning)))))
-
+
 ;;; Various other STYLE-WARNINGS
 (define-condition dubious-asterisks-around-variable-name
     (style-warning simple-condition)
@@ -1637,7 +1637,7 @@ the usual naming convention (names like *FOO*) for special variables"
   ()
   (:default-initargs :kind 'ftype :description "known function"))
 
-
+
 ;;;; deprecation conditions
 
 (define-condition deprecation-condition (reference-condition)
@@ -1728,7 +1728,7 @@ compile-time. An error will be signaled at run-time."))
    "This error is signaled at run-time when an attempt is made to use
 a thing that is in :FINAL deprecation, i.e. call a function or access
 a variable."))
-
+
 ;;;; restart definitions
 
 (define-condition abort-failure (control-error) ()

--- a/src/code/debug-info.lisp
+++ b/src/code/debug-info.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; flags for compiled debug variables
 
 ;;; FIXME: old CMU CL representation follows:
@@ -40,7 +40,7 @@
 (defconstant compiled-debug-var-minimal-p              #b00100000)
 (defconstant compiled-debug-var-deleted-p              #b01000000)
 (defconstant compiled-debug-var-indirect-p             #b10000000)
-
+
 ;;;; compiled debug blocks
 ;;;;
 ;;;;    Compiled debug blocks are in a packed binary representation in the
@@ -79,7 +79,7 @@
 (defconstant debug-info-var-optional -4)
 (defconstant debug-info-var-supplied-p -5)
 
-
+
 ;;;; DEBUG-FUN objects
 
 (def!struct (debug-fun (:constructor nil)
@@ -319,7 +319,7 @@
     (compiled-debug-fun-cleanup :cleanup)
     (compiled-debug-fun nil)))
 
-
+
 ;;;; minimal debug function
 
 ;;; The minimal debug info format compactly represents debug-info for some
@@ -371,7 +371,7 @@
 ;;; the component until you find the right one. Well, I guess you need
 ;;; to at least know which function is an XEP for the real function
 ;;; (which would be useful info anyway).
-
+
 ;;;; DEBUG SOURCE
 
 ;;; There is one per compiled file and one per function compiled at
@@ -396,7 +396,7 @@
   ;; be in one or more code components. They all point at the same form.
   form
   (function nil :read-only t))
-
+
 ;;;; DEBUG-INFO structures
 
 (def!struct (debug-info

--- a/src/code/debug-int.lisp
+++ b/src/code/debug-int.lisp
@@ -14,7 +14,7 @@
 
 ;;; FIXME: There are an awful lot of package prefixes in this code.
 ;;; Couldn't we have SB-DI use the SB-C and SB-VM packages?
-
+
 ;;;; conditions
 
 ;;;; The interface to building debugging tools signals conditions that
@@ -96,7 +96,7 @@
              (format stream "~&~S names more than one valid variable in ~S."
                      (ambiguous-var-name-name condition)
                      (ambiguous-var-name-frame condition)))))
-
+
 ;;;; errors and DEBUG-SIGNAL
 
 ;;; The debug-internals code tries to signal all programmer errors as
@@ -162,7 +162,7 @@
   `(let ((condition (make-condition ,datum ,@arguments)))
      (signal condition)
      (error 'unhandled-debug-condition :condition condition)))
-
+
 ;;;; structures
 ;;;;
 ;;;; Most of these structures model information stored in internal
@@ -336,7 +336,7 @@
             "~S~:[~;, interrupted~]"
             (debug-fun-name (frame-debug-fun obj))
             (compiled-frame-escaped obj))))
-
+
 
 ;;; This maps SB-C::COMPILED-DEBUG-FUNs to
 ;;; COMPILED-DEBUG-FUNs, so we can get at cached stuff and not
@@ -356,7 +356,7 @@
     (with-locked-system-table (table)
       (ensure-gethash compiler-debug-fun table
                       (%make-compiled-debug-fun compiler-debug-fun component)))))
-
+
 ;;;; breakpoints
 
 ;;; This is an internal structure that manages information about a
@@ -448,7 +448,7 @@
   ;; the :FUN-START breakpoint (if any) used to facilitate
   ;; function end breakpoints
   (end-starter nil :type (or null breakpoint)))
-
+
 ;;;; CODE-LOCATIONs
 
 (defmethod print-object ((obj code-location) str)
@@ -474,7 +474,7 @@
   (kind :unparsed :type (or (member :unparsed) sb-c::location-kind))
   (step-info :unparsed :type (or (member :unparsed :foo) simple-string))
   (context :unparsed))
-
+
 ;;;; frames
 
 ;;; This is used in FIND-ESCAPED-FRAME and with the "breakpoint return" objects
@@ -649,7 +649,7 @@
         (values nil (int-sap 0) (int-sap 0)))))
 
 ) ; #+x86 PROGN
-
+
 ;;; Return the top frame of the control stack as it was before calling
 ;;; this function.
 (defun top-frame ()
@@ -1151,7 +1151,7 @@ register."
         (when (and (not (symbolp candidate)) ;; NIL or :UNDEFINED-FUNCTION
                    (nth-value 1 (context-code-pc-offset context candidate)))
           (return candidate))))))
-
+
 ;;;; frame utilities
 
 (defun compiled-debug-fun-from-pc (debug-info pc &optional escaped)
@@ -1287,7 +1287,7 @@ register."
                    (catch-ref catch-block-previous-catch-slot)))))))
 
 
-
+
 ;;;; operations on DEBUG-FUNs
 
 ;;; Execute the forms in a context with BLOCK-VAR bound to each
@@ -1682,7 +1682,7 @@ register."
 
 (defun compiled-debug-fun-debug-info (debug-fun)
   (%code-debug-info (compiled-debug-fun-component debug-fun)))
-
+
 ;;;; unpacking variable and basic block data
 
 ;;; The argument is a debug internals structure. This returns the
@@ -1883,7 +1883,7 @@ register."
                                  (cond (more-context-p :more-context)
                                        (more-count-p :more-count)))
                                 buffer)))))))
-
+
 ;;;; CODE-LOCATIONs
 
 ;;; If we're sure of whether code-location is known, return T or NIL.
@@ -2130,7 +2130,7 @@ register."
       (setf (compiled-code-location-context code-location)
             (compiled-code-location-context found))
       t)))
-
+
 ;;;; operations on DEBUG-BLOCKs
 
 ;;; Execute FORMS in a context with CODE-VAR bound to each
@@ -2167,7 +2167,7 @@ register."
     ;; (There used to be more cases back before sbcl-0.7.0, when we
     ;; did special tricks to debug the IR1 interpreter.)
     ))
-
+
 ;;;; operations on debug variables
 
 (defun debug-var-symbol-name (debug-var)
@@ -2694,7 +2694,7 @@ register."
                             pos))
                :invalid
                :valid)))))
-
+
 ;;;; sources
 
 ;;; This code produces and uses what we call source-paths. A
@@ -2855,7 +2855,7 @@ register."
                    (loop repeat tlf-offset
                          do (read f)))))
           (read f))))))
-
+
 ;;;; PREPROCESS-FOR-EVAL
 
 ;;; Return a function of one argument that evaluates form in the
@@ -2949,7 +2949,7 @@ register."
   "Evaluate FORM in the lexical context of FRAME's current code location,
    returning the results of the evaluation."
   (funcall (preprocess-for-eval form (frame-code-location frame)) frame))
-
+
 ;;;; breakpoints
 
 ;;;; user-visible interface
@@ -3098,7 +3098,7 @@ register."
                   lra
                   (frame-saved-lra frame (frame-debug-fun frame))))
         (return t)))))
-
+
 ;;;; ACTIVATE-BREAKPOINT
 
 ;;; Cause the system to invoke the breakpoint's hook function until
@@ -3181,7 +3181,7 @@ register."
    (setf (breakpoint-data-breakpoints data)
          (append (breakpoint-data-breakpoints data) (list breakpoint)))
    (setf (breakpoint-internal-data breakpoint) data)))
-
+
 ;;;; DEACTIVATE-BREAKPOINT
 
 ;;; Stop the system from invoking the breakpoint's hook function.
@@ -3221,7 +3221,7 @@ register."
           (delete-breakpoint-data data))))
   (setf (breakpoint-status breakpoint) :inactive)
   breakpoint)
-
+
 ;;;; BREAKPOINT-INFO
 
 ;;; Return the user-maintained info associated with breakpoint. This
@@ -3233,7 +3233,7 @@ register."
   (let ((other (breakpoint-unknown-return-partner breakpoint)))
     (when other
       (setf (breakpoint-%info other) value))))
-
+
 ;;;; BREAKPOINT-ACTIVE-P and DELETE-BREAKPOINT
 
 (defun breakpoint-active-p (breakpoint)
@@ -3264,7 +3264,7 @@ register."
                    (breakpoint-what breakpoint))
                   nil))))))
   breakpoint)
-
+
 ;;;; C call out stubs
 
 ;;; This actually installs the break instruction in the component. It
@@ -3456,7 +3456,7 @@ register."
                                    #+(or x86 x86-64) sb-vm::sp->fp-offset)))
             results))
     (nreverse results)))
-
+
 ;;;; MAKE-BPT-LRA (used for :FUN-END breakpoints)
 
 ;;; Make a breakpoint LRA object that signals a breakpoint trap when returned to.
@@ -3521,7 +3521,7 @@ register."
                                           sb-vm:other-pointer-lowtag)))
                 (sb-vm:sanctify-for-execution code-object)
                 (trap-offset))))))
-
+
 ;;;; miscellaneous
 
 ;;; This appears here because it cannot go with the DEBUG-FUN
@@ -3543,7 +3543,7 @@ register."
     ;; we did special tricks to debug the IR1 interpreter.)
     ))
 
-
+
 ;;;; Single-stepping
 
 ;;; The single-stepper works by inserting conditional trap instructions

--- a/src/code/debug-var-io.lisp
+++ b/src/code/debug-var-io.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; reading variable length integers
 ;;;;
 ;;;; The debug info representation makes extensive use of 32-bit
@@ -78,7 +78,7 @@
                             vector)
      finally (return i)))
 
-
+
 ;;;; packed strings
 ;;;;
 ;;;; A packed string is a variable length integer length followed by
@@ -104,7 +104,7 @@
     (dotimes (i len)
       (write-var-integer (char-code (schar string i)) vec)))
   (values))
-
+
 ;;;; packed bit vectors
 
 ;;; Read the specified number of BYTES out of VEC at INDEX and convert

--- a/src/code/debug.lisp
+++ b/src/code/debug.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-DEBUG")
-
+
 ;;;; variables and constants
 
 ;;; things to consider when tweaking these values:
@@ -145,7 +145,7 @@ Other commands:
     Discard all pending input on *STANDARD-INPUT*. (This can be
     useful when the debugger was invoked to handle an error in
     deeply nested input syntax, and now the reader is confused.)")
-
+
 (defmacro with-debug-io-syntax (() &body body)
   (let ((thunk (sb-xc:gensym "THUNK")))
     `(dx-flet ((,thunk ()
@@ -166,7 +166,7 @@ Other commands:
               (t
                loc)))
       loc))
-
+
 ;;;; BACKTRACE
 
 (declaim (unsigned-byte *backtrace-frame-count*))
@@ -469,7 +469,7 @@ information."
                   (let ((thread (sb-thread::avlnode-data it)))
                     (when (< a (sb-thread::thread-stack-end thread))
                       thread))))))))
-
+
 ;;;; frame printing
 
 (eval-when (:compile-toplevel :execute)
@@ -767,7 +767,7 @@ the current thread are replaced with dummy objects which can safely escape."
               (format stream "~&   no source available for frame")))
           (error (c)
             (format stream "~&   error printing frame source: ~A" c)))))))
-
+
 ;;;; INVOKE-DEBUGGER
 
 (defvar *debugger-hook* nil
@@ -1169,7 +1169,7 @@ and LDB (the low-level debugger).  See also ENABLE-DEBUGGER."
       (clear-input *debug-io*))
     (let ((*suppress-frame-print* (typep *debug-condition* 'step-condition)))
       (funcall *debug-loop-fun*))))
-
+
 ;;;; DEBUG-LOOP
 
 ;;; Note: This defaulted to T in CMU CL. The changed default in SBCL
@@ -1266,7 +1266,7 @@ forms that explicitly control this kind of evaluation.")
       (fresh-line *debug-io*)
       (prin1 value *debug-io*)))
   (force-output *debug-io*))
-
+
 ;;;; debug loop functions
 
 ;;; These commands are functions, not really commands, so that users
@@ -1441,7 +1441,7 @@ forms that explicitly control this kind of evaluation.")
           (debug-var-value var *current-frame*)
           (error "invalid argument value"))
         var)))
-
+
 ;;;; machinery for definition of debug loop commands
 
 (define-load-time-global *debug-commands* nil)
@@ -1530,7 +1530,7 @@ forms that explicitly control this kind of evaluation.")
             (push (cons name restart-fun) commands))))
     (incf num))
   commands))
-
+
 ;;;; frame-changing commands
 
 (!def-debug-command "UP" ()
@@ -1581,7 +1581,7 @@ forms that explicitly control this kind of evaluation.")
   (print-frame-call *current-frame* *debug-io*))
 
 (!def-debug-command-alias "F" "FRAME")
-
+
 ;;;; commands for entering and leaving the debugger
 
 (!def-debug-command "TOPLEVEL" ()
@@ -1614,7 +1614,7 @@ forms that explicitly control this kind of evaluation.")
       (if restart
           (invoke-restart-interactively restart)
           (princ "There is no such restart." *debug-io*)))))
-
+
 ;;;; information commands
 
 (!def-debug-command "HELP" ()
@@ -1700,7 +1700,7 @@ forms that explicitly control this kind of evaluation.")
   (print (code-location-source-form (frame-code-location *current-frame*)
                                     (read-if-available 0))
          *debug-io*))
-
+
 ;;;; source location printing
 
 (defun code-location-source-form (location context &optional (errorp t))
@@ -1717,7 +1717,7 @@ forms that explicitly control this kind of evaluation.")
              (funcall (if errorp #'error #'warn)
                       "~@<Bogus form-number: the source file has ~
                           probably changed too much to cope with.~:@>"))))))
-
+
 
 ;;; start single-stepping
 (!def-debug-command "START" ()
@@ -1919,7 +1919,7 @@ forms that explicitly control this kind of evaluation.")
   (debug-var-info-available
    (code-location-debug-fun
     (frame-code-location frame))))
-
+
 ;;;; debug loop command utilities
 
 (defun read-prompting-maybe (prompt)

--- a/src/code/defbangtype.lisp
+++ b/src/code/defbangtype.lisp
@@ -8,7 +8,7 @@
 ;;;; files for more information.
 
 (in-package "SB-KERNEL")
-
+
 ;;;; the DEF!TYPE macro
 
 ;;; DEF!TYPE = cold DEFTYPE, a version of DEFTYPE which at

--- a/src/code/defboot.lisp
+++ b/src/code/defboot.lisp
@@ -20,7 +20,7 @@
 
 (in-package "SB-IMPL")
 
-
+
 ;;;; IN-PACKAGE
 
 (sb-xc:proclaim '(special *package*))
@@ -28,7 +28,7 @@
   (let ((string (string string-designator)))
     `(eval-when (:compile-toplevel :load-toplevel :execute)
        (setq *package* (find-undeleted-package-or-lose ,string)))))
-
+
 ;;;; MULTIPLE-VALUE-FOO
 
 (flet ((validate-vars (vars)
@@ -63,7 +63,7 @@
 
 (sb-xc:defmacro multiple-value-list (value-form)
   `(multiple-value-call #'list ,value-form))
-
+
 ;;;; various conditional constructs
 
 (flet ((prognify (forms env)
@@ -144,7 +144,7 @@ evaluated as a PROGN."
                 (if ,n-result
                     ,n-result
                     ,(expand-forms t (rest forms)))))))))
-
+
 ;;;; various sequencing constructs
 
 (flet ((prog-expansion-from-let (varlist body-decls let)
@@ -166,7 +166,7 @@ evaluated as a PROGN."
 
 (sb-xc:defmacro prog2 (form1 result &body body)
   `(prog1 (progn ,form1 ,result) ,@body))
-
+
 ;;;; DEFUN
 
 ;;; Should we save the inline expansion of the function named NAME?
@@ -288,7 +288,7 @@ evaluated as a PROGN."
   ;; extended defun as used by defstruct
   (sb-xc:defmacro sb-c:xdefun (&environment env name snippet lambda-list &body body)
     (defun-expander env name lambda-list body snippet)))
-
+
 ;;;; DEFVAR and DEFPARAMETER
 
 (sb-xc:defmacro defvar (var &optional (val nil valp) (doc nil docp))
@@ -343,7 +343,7 @@ evaluated as a PROGN."
 
 (defun %compiler-defvar (var)
   (sb-xc:proclaim `(special ,var)))
-
+
 ;;;; iteration constructs
 
 (flet
@@ -479,7 +479,7 @@ evaluated as a PROGN."
                ,var
                ,result)
             nil))))
-
+
 ;;;; conditions, handlers, restarts
 
 (sb-xc:defmacro with-condition-restarts
@@ -904,7 +904,7 @@ specification."
                                            `(,fun-name (cdr ,cell))
                                            `(,fun-name))))))
                          annotated-cases))))))))))
-
+
 ;;;; miscellaneous
 
 (sb-xc:defmacro return (&optional (value nil))

--- a/src/code/defstruct.lisp
+++ b/src/code/defstruct.lisp
@@ -13,7 +13,7 @@
 (in-package "SB-KERNEL")
 
 (/show0 "code/defstruct.lisp 15")
-
+
 ;;;; getting LAYOUTs
 
 ;;; Return the compiler layout for NAME. (The class referred to by
@@ -106,7 +106,7 @@
 ;;; FIXME: Perhaps both should be defined with SB-XC:DEFMACRO?
 ;;; FIXME: Do we really need both? If so, their names and implementations
 ;;; should probably be tweaked to be more parallel.
-
+
 ;;;; DEFSTRUCT-DESCRIPTION
 
 ;;; The DEFSTRUCT-DESCRIPTION structure holds compile-time information
@@ -122,7 +122,7 @@
 
 (defun dd-layout-or-lose (dd)
   (compiler-layout-or-lose (dd-name dd)))
-
+
 ;;;; DEFSTRUCT-SLOT-DESCRIPTION
 
 ;;; A DEFSTRUCT-SLOT-DESCRIPTION holds compile-time information about
@@ -214,7 +214,7 @@
          (t)))
 (defun dsd-primitive-accessor (dsd &aux (rsd (dsd-raw-slot-data dsd)))
   (if rsd (raw-slot-data-accessor-name rsd) '%instance-ref))
-
+
 ;;;; typed (non-class) structures
 
 ;;; Return a type specifier we can use for testing :TYPE'd structures.
@@ -222,7 +222,7 @@
   (ecase (dd-type defstruct)
     (list 'list)
     (vector `(simple-array ,(dd-element-type defstruct) (*)))))
-
+
 ;;;; shared machinery for inline and out-of-line slot accessor functions
 
 ;;; Classic comment preserved for entertainment value:
@@ -428,7 +428,7 @@
        ,@(!expander-for-defstruct
           null-env-p delayp name-and-options slot-descriptions
           :target))))
-
+
 ;;;; functions to generate code for various parts of DEFSTRUCT definitions
 
 ;;; First, a helper to determine whether a name names an inherited
@@ -499,7 +499,7 @@
                             slot with name ~S (accessing an inherited slot ~
                             instead).~:@>" name (dsd-name slot))))))))
     (stuff)))
-
+
 ;;;; parsing
 
 ;;; CLHS says that
@@ -744,7 +744,7 @@ unless :NAMED is also specified.")))
                 (parse-slots)))
             (parse-slots)))
       (values proto-classoid inherits))))
-
+
 ;;;; stuff to parse slot descriptions
 
 ;;; Parse a slot description for DEFSTRUCT, add it to the description
@@ -996,7 +996,7 @@ unless :NAMED is also specified.")))
             (when (and (dsd-safe-p included-slot) (not (dsd-safe-p new-slot)))
               ;; XXX: notify?
               )))))))
-
+
 ;;;; various helper functions for setting up DEFSTRUCTs
 
 ;;; This function is called at macroexpand time to compute the INHERITS
@@ -1061,7 +1061,7 @@ unless :NAMED is also specified.")))
     (when source-location
       (setf (classoid-source-location classoid) source-location))))
 
-
+
 ;;; Return a form accessing the writable place used for the slot
 ;;; described by DD and DSD in the INSTANCE (a form).
 (defun %accessor-place-form (dd dsd instance)
@@ -1323,7 +1323,7 @@ could not be inlined because the structure definition for ~
 DEFSTRUCT should precede references to the affected functions, ~
 or they must be declared locally notinline at each call site.~@:>"
        :format-arguments (list (length it) (nreverse it) (dd-name dd))))))
-
+
 ;;;; redefinition stuff
 
 ;;; Compare the slots of OLD and NEW, returning 3 lists of slot names:
@@ -1542,7 +1542,7 @@ or they must be declared locally notinline at each call site.~@:>"
              (progn
                (setf (layout-info old-layout) info)
                (values classoid old-layout nil)))))))))
-
+
 ;;; Return a list of pairs (name . index). Used for :TYPE'd
 ;;; constructors to find all the names that we have to splice in &
 ;;; where. Note that these types don't have a layout, so we can't look
@@ -1564,7 +1564,7 @@ or they must be declared locally notinline at each call site.~@:>"
           (setq i (dd-length info)))))
 
     (res)))
-
+
 ;;; These functions are called to actually make a constructor after we
 ;;; have processed the arglist. The correct variant (according to the
 ;;; DD-TYPE) should be called. The function is defined with the
@@ -1859,7 +1859,7 @@ or they must be declared locally notinline at each call site.~@:>"
                          ,(slot-access-transform :setf '(instance value) key))))
                   (sb-c:xdefun ,accessor-name :accessor (instance)
                     ,(slot-access-transform :read '(instance) key))))))
-
+
 ;;;; instances with ALTERNATE-METACLASS
 ;;;;
 ;;;; The CMU CL support for structures with ALTERNATE-METACLASS was a
@@ -2025,7 +2025,7 @@ or they must be declared locally notinline at each call site.~@:>"
          ;; A naive reading of 'build-order' suggests it is,
          ;; but due to def!struct delay voodoo, it isn't.
          (assert (null (symbol-value '*defstruct-hooks*))))))
-
+
 ;;;; finalizing bootstrapping
 
 ;;; Set up DD and LAYOUT for STRUCTURE-OBJECT class itself.

--- a/src/code/deftypes-for-target.lisp
+++ b/src/code/deftypes-for-target.lisp
@@ -12,7 +12,7 @@
 (in-package "SB-KERNEL")
 
 (/show0 "deftypes-for-target.lisp 14")
-
+
 ;;;; Now that DEFTYPE is set up, any pending requests for it can
 ;;;; be honored.
 
@@ -21,7 +21,7 @@
   (/show "about to force delayed DEF!TYPEs")
   (force-delayed-def!types)
   (/show "done forcing delayed DEF!TYPEs"))
-
+
 ;;;; standard types
 
 (sb-xc:deftype boolean () '(member t nil))
@@ -128,7 +128,7 @@
 (sb-xc:deftype simple-fun () '(satisfies simple-fun-p))
 
 (sb-xc:deftype closure () '(satisfies closurep))
-
+
 ;;;; some private types that we use in defining the standard functions,
 ;;;; or implementing declarations in standard compiler transforms
 

--- a/src/code/describe-policy.lisp
+++ b/src/code/describe-policy.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C") ;(SB-C, not SB-C, since we're built in warm load.)
-
+
 (defun describe-compiler-policy (&optional spec)
   "Print all global optimization settings, augmented by SPEC."
   (let ((policy (process-optimize-decl (cons 'optimize spec) *policy*)))

--- a/src/code/describe.lisp
+++ b/src/code/describe.lisp
@@ -130,7 +130,7 @@
     ;; again ANSI's specification of DESCRIBE doesn't mention it and
     ;; ANSI's example of DESCRIBE-OBJECT does its own final TERPRI.
     (values)))
-
+
 ;;;; DESCRIBE-OBJECT Protocol
 ;;;;
 ;;;; Style guide:
@@ -157,7 +157,7 @@
 (defgeneric object-self-string (object))
 
 (defgeneric object-type-string (object))
-
+
 ;;; Methods for builtin objects
 
 (defmethod object-self-string ((object t))
@@ -360,7 +360,7 @@
         (out "Exports" (humanize exports))
         (format stream "~@:_~S internal symbols."
                 (package-internal-symbol-count object))))))
-
+
 ;;;; Helpers to deal with shared functionality
 
 (defun describe-deprecation (namespace name stream)

--- a/src/code/dyncount.lisp
+++ b/src/code/dyncount.lisp
@@ -23,7 +23,7 @@ comments from CMU CL:
   (when *collect-dynamic-statistics*
     (error "Compiling this file with dynamic stat collection turned on would ~
     be a very bad idea.")))
-
+
 ;;;; hash utilities
 
 (defun make-hash-table-like (table)
@@ -87,7 +87,7 @@ comments from CMU CL:
           (funcall writer v s)
           (terpri s)))))
   table)
-
+
 ;;;; info accumulation
 
 ;;; Used to accumulate info about the usage of a single VOP. Cost and count
@@ -219,7 +219,7 @@ comments from CMU CL:
                 (get-vop-counts (list space) :clear t))
               spaces)
       (get-vop-counts spaces)))
-
+
 ;;;; adjustments
 
 (defun get-vop-costs ()
@@ -236,7 +236,7 @@ comments from CMU CL:
 
 (defvar *native-costs* (get-vop-costs)
   "Costs of assember routines on this machine.")
-
+
 ;;;; classification
 
 (defparameter *basic-classes*
@@ -316,7 +316,7 @@ comments from CMU CL:
               (incf (vop-stats-cost found) (vop-stats-cost value)))
             (setf (gethash key res) value))))
     res))
-
+
 ;;;; analysis
 
 ;;; Sum the count and costs.
@@ -375,7 +375,7 @@ comments from CMU CL:
           (incf (vop-stats-count found) (vop-stats-count v))
           (incf (vop-stats-cost found) (vop-stats-cost v)))))
     res))
-
+
 ;;;; report generation
 
 (defun sort-result (table by)

--- a/src/code/early-extensions.lisp
+++ b/src/code/early-extensions.lisp
@@ -65,7 +65,7 @@
 (defconstant return-char-code 13)
 (defconstant escape-char-code 27) ; unused
 (defconstant rubout-char-code 127)
-
+
 ;;;; type-ish predicates
 
 ;;; This is used for coalescing constants, check that the tree doesn't
@@ -133,7 +133,7 @@
   (or (consp x)
       (%instancep x)
       (typep x '(array t *))))
-
+
 ;;;; the COLLECT macro
 ;;;;
 ;;;; comment from CMU CL: "the ultimate collection macro..."
@@ -202,7 +202,7 @@
          ;; Since we don't know, all the -n-tail variable are ignorable.
          ,@(if ignores `((declare (ignorable ,@ignores))))
          ,@body))))
-
+
 ;;;; some old-fashioned functions. (They're not just for old-fashioned
 ;;;; code, they're also used as optimized forms of the corresponding
 ;;;; general functions when the compiler can prove that they're
@@ -270,7 +270,7 @@
           ((> old-length length)
            (subseq list 0 length))
           (t list))))
-
+
 ;;;; miscellaneous iteration extensions
 
 (defun filter-dolist-declarations (decls)
@@ -395,7 +395,7 @@
                   listp nil
                   decls nil))
       body)))
-
+
 ;;;; macro writing utilities
 
 (defmacro with-current-source-form ((&rest forms) &body body)
@@ -416,7 +416,7 @@ NOTE: This interface is experimental and subject to change."
   #-sb-xc-host `(sb-c::call-with-current-source-form
                  (lambda () ,@body) ,@forms)
   #+sb-xc-host `(progn (list ,@forms) ,@body))
-
+
 ;;;; hash cache utility
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -726,7 +726,7 @@ NOTE: This interface is experimental and subject to change."
                 (eql (pop x) (pop y))))
           (t
            (return)))))
-
+
 ;;;; various operations on names
 
 ;;; Is NAME a legal variable/function name?
@@ -775,7 +775,7 @@ NOTE: This interface is experimental and subject to change."
          (and (> (length name) 2) ; to exclude '* and '**
               (char= #\* (aref name 0))
               (char= #\* (aref name (1- (length name))))))))
-
+
 ;;;; ONCE-ONLY
 ;;;;
 ;;;; "The macro ONCE-ONLY has been around for a long time on various
@@ -807,7 +807,7 @@ NOTE: This interface is experimental and subject to change."
                    (,name (sb-xc:gensym ,(symbol-name name))))
                `(let ((,,name ,,exp-temp))
                   ,,(frob (rest specs) body))))))))
-
+
 ;;;; various error-checking utilities
 
 ;;; This function can be used as the default value for keyword
@@ -840,7 +840,7 @@ NOTE: This interface is experimental and subject to change."
   (error 'bug
          :format-control format-control
          :format-arguments format-arguments))
-
+
 ;;; Return a function like FUN, but expecting its (two) arguments in
 ;;; the opposite order that FUN does.
 (declaim (inline swapped-args-fun))
@@ -875,7 +875,7 @@ NOTE: This interface is experimental and subject to change."
           (list (c (car bound)))
           (c bound)))))
 
-
+
 ;;;; utilities for two-VALUES predicates
 
 (defmacro not/type (x)
@@ -918,7 +918,7 @@ NOTE: This interface is experimental and subject to change."
         (if sub-certain?
             (unless sub-value (return (values nil t)))
             (setf certain? nil))))))
-
+
 ;;;; DEFPRINTER
 
 ;;; These functions are called by the expansion of the DEFPRINTER
@@ -1067,7 +1067,7 @@ NOTE: This interface is experimental and subject to change."
 (defun print-type (stream type &optional colon at)
   (print-type-specifier stream (type-specifier type) colon at)))
 
-
+
 ;;;; Deprecating stuff
 
 (deftype deprecation-state ()
@@ -1276,7 +1276,7 @@ NOTE: This interface is experimental and subject to change."
                      decls)))
         (values (awhen (binding-decls) `(declare ,@it))
                 (mapcan (lambda (x) (if x (list `(declare ,@x)))) filtered))))))
-
+
 ;;; Delayed evaluation
 (defmacro delay (form)
   `(cons nil (lambda () ,form)))
@@ -1290,7 +1290,7 @@ NOTE: This interface is experimental and subject to change."
 (defun promise-ready-p (promise)
   (or (not (consp promise))
       (car promise)))
-
+
 ;;; Bind a few "potentially dangerous" printer control variables to
 ;;; safe values, respecting current values if possible.
 (defmacro with-sane-io-syntax (&body forms)
@@ -1452,5 +1452,5 @@ NOTE: This interface is experimental and subject to change."
               (eq (symbol-value x) x))))
     (cons nil)
     (t t)))
-
+
 (defvar *top-level-form-p* nil)

--- a/src/code/early-fasl.lisp
+++ b/src/code/early-fasl.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-FASL")
-
+
 ;;;; various constants and essentially-constants
 
 ;;; a string which appears at the start of a fasl file header
@@ -128,7 +128,7 @@
 ;;; So we keep the asterisks and make it defglobal.
 (declaim (type simple-string *fasl-file-type*))
 (defglobal *fasl-file-type* "fasl")
-
+
 ;;;; the FOP database
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -151,7 +151,7 @@
 (defglobal **fop-signatures**
     (cons (make-array n-ordinary-fops :element-type '(mod 4) :initial-element 0)
           (make-array n-ordinary-fops :element-type 'bit :initial-element 0)))
-
+
 ;;;; variables
 
 (defvar *load-depth* 0

--- a/src/code/early-float.lisp
+++ b/src/code/early-float.lisp
@@ -14,7 +14,7 @@
 ;;;; files for more information.
 
 (in-package "SB-KERNEL")
-
+
 ;;;; utilities
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -47,7 +47,7 @@
                    (ldb (byte 32 0) sig)))
 
 ) ; EVAL-WHEN
-
+
 ;;;; float parameters
 (defconstant sb-xc:most-positive-single-float #.sb-xc:most-positive-single-float)
 (defconstant sb-xc:most-negative-single-float #.sb-xc:most-negative-single-float)

--- a/src/code/early-format.lisp
+++ b/src/code/early-format.lisp
@@ -18,7 +18,7 @@
 
 (defvar *default-format-error-control-string* nil)
 (defvar *default-format-error-offset* nil)
-
+
 ;;;; specials used to communicate information
 
 ;;; Used both by the expansion stuff and the interpreter stuff. When it is

--- a/src/code/early-ntrace.lisp
+++ b/src/code/early-ntrace.lisp
@@ -20,7 +20,7 @@
 
 (defvar *trace-encapsulate-default* t
   "the default value for the :ENCAPSULATE option to TRACE")
-
+
 ;;;; internal state
 
 ;;; a hash table that maps each traced function to the TRACE-INFO. The

--- a/src/code/early-print.lisp
+++ b/src/code/early-print.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; level and length abbreviations
 
 ;;; The current level we are printing at, to be compared against
@@ -43,7 +43,7 @@
      (write-string "..." ,stream)
      (return)))
 
-
+
 ;;;; circularity detection stuff
 
 ;;; When *PRINT-CIRCLE* is T, this gets bound to a hash table that

--- a/src/code/early-type.lisp
+++ b/src/code/early-type.lisp
@@ -749,7 +749,7 @@
                        'simd-pack-256 *simd-pack-element-types*))
          (when (csubtypep element-type (specifier-type pack-type))
            (return (list pack-type)))))))
-
+
 ;;;; type utilities
 
 ;;; Return the type structure corresponding to a type specifier.
@@ -971,7 +971,7 @@ expansion happened."
   (values-specifier-type-cache-clear)
   (values))
 
-
+
 (!defun-from-collected-cold-init-forms !early-type-cold-init)
 
 ;;; When cross-compiling SPECIFIER-TYPE with a quoted argument,

--- a/src/code/eval.lisp
+++ b/src/code/eval.lisp
@@ -321,7 +321,7 @@
         (*eval-tlf-index* tlf-index)
         (*eval-source-info* sb-c::*source-info*))
     (eval-in-lexenv original-exp lexenv)))
-
+
 ;;; miscellaneous full function definitions of things which are
 ;;; ordinarily handled magically by the compiler
 

--- a/src/code/external-formats/enc-basic.lisp
+++ b/src/code/external-formats/enc-basic.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-IMPL")
 
-
+
 ;;; ASCII
 
 (declaim (inline code->ascii-mapper))
@@ -69,7 +69,7 @@
       (code-char byte))
   ascii->string-aref
   string->ascii)
-
+
 ;;; Latin-1
 
 (declaim (inline get-latin1-bytes))
@@ -110,7 +110,7 @@
   latin1->string-aref
   string->latin1)
 
-
+
 ;;; UTF-8
 
 ;;; to UTF-8

--- a/src/code/external-formats/enc-ucs.lisp
+++ b/src/code/external-formats/enc-ucs.lisp
@@ -78,7 +78,7 @@
         (sap-ref-8 sap (1+ offset)) (ldb (byte 8 16) value)
         (sap-ref-8 sap (+ offset 2)) (ldb (byte 8 8) value)
         (sap-ref-8 sap (+ offset 3)) (logand value #xff)))
-
+
 ;;;
 ;;;   octets
 ;;;
@@ -256,7 +256,7 @@
   (code-char (sap-ref-16be sap head))
   ucs-2be->string-aref
   string->ucs-2be)
-
+
 (declaim (inline char->ucs-4le))
 (defun char->ucs-4le (char dest string pos)
   (declare (optimize speed (safety 0))

--- a/src/code/external-formats/enc-utf.lisp
+++ b/src/code/external-formats/enc-utf.lisp
@@ -16,7 +16,7 @@
 
 (in-package "SB-IMPL")
 
-
+
 (declaim (inline utf-noncharacter-code-p))
 (defun utf-noncharacter-code-p (code)
   (or (<= #xd800 code #xdfff)
@@ -324,7 +324,7 @@
       (t (code-char bits))))
   utf-16be->string-aref
   string->utf-16be)
-
+
 (declaim (inline char->utf-32le))
 (defun char->utf-32le (char dest string pos)
   (declare (optimize speed (safety 0))

--- a/src/code/fd-stream.lisp
+++ b/src/code/fd-stream.lisp
@@ -80,7 +80,7 @@
   (reset-buffer buffer)
   (atomic-push buffer *available-buffers*))
 
-
+
 ;;;; the FD-STREAM structure
 
 ;;; Coarsely characterizes the element type of an FD-STREAM w.r.t.
@@ -219,7 +219,7 @@
               (- charpos (aref newlines index) 1))
         ;; zero newlines were seen
         (cons 1 charpos))))
-
+
 ;;;; CORE OUTPUT FUNCTIONS
 
 ;;; Buffer the section of THING delimited by START and END by copying
@@ -435,7 +435,7 @@
 (define-deprecated-function :late "1.0.8.16" output-raw-bytes write-sequence
     (stream thing &optional start end)
   (write-or-buffer-output stream thing (or start 0) (or end (length thing))))
-
+
 ;;;; output routines and related noise
 
 (define-load-time-global *output-routines* ()
@@ -948,7 +948,7 @@
                                     (ldb (byte 8 (- i 8 (* j 8))) byte)))))))
               `(signed-byte ,i)
               (/ i 8)))))
-
+
 ;;;; input routines and related noise
 
 ;;; a list of all available input routines. Each element is a list of
@@ -1716,7 +1716,7 @@
                                             (apply ',string-to-octets-sym rest)))))
         (dolist (ef ',external-format)
           (setf (gethash ef *external-formats*) entry))))))
-
+
 ;;;; utility functions (misc routines, etc)
 
 ;;; Fill in the various routine slots for the given type. INPUT-P and
@@ -2217,7 +2217,7 @@
              (return-from fd-stream-set-file-position
                (typep posn '(alien sb-unix:unix-offset))))))))
 
-
+
 ;;;; creation routines (MAKE-FD-STREAM and OPEN)
 
 ;;; Create a stream for the given Unix file descriptor.
@@ -2559,7 +2559,7 @@
                        :interactive read-evaluated-form
                        (setf filename (the pathname-designator value))))
                    (go retry))))))))))
-
+
 ;;;; initialization
 
 ;;; the stream connected to the controlling terminal, or NIL if there is none
@@ -2673,7 +2673,7 @@
                 (make-two-way-stream *stdin* *stdout*))))
     (princ (get-output-stream-string *error-output*) *stderr*))
   (values))
-
+
 ;;;; miscellany
 
 ;;; the Unix way to beep

--- a/src/code/fdefinition.lisp
+++ b/src/code/fdefinition.lisp
@@ -18,7 +18,7 @@
 ;; but it's compiled after this file is.
 (!define-load-time-global *user-hash-table-tests* nil)
 
-
+
 ;;;; fdefinition (fdefn) objects
 
 (defun make-fdefn (name)
@@ -214,7 +214,7 @@
 (%defun '%coerce-callable-for-call
         #'%coerce-callable-to-fun)
 
-
+
 ;;;; definition encapsulation
 
 (defstruct (encapsulation-info (:constructor make-encapsulation-info
@@ -315,7 +315,7 @@
       (declare (type (or encapsulation-info null) encap-info))
       (when (eq (encapsulation-info-type encap-info) type)
         (return t)))))
-
+
 ;;;; FDEFINITION
 
 ;;; KLUDGE: Er, it looks as though this means that
@@ -414,7 +414,7 @@
                               new-value))))))
               (t
                (setf (fdefn-fun fdefn) new-value)))))))
-
+
 ;;;; FBOUNDP and FMAKUNBOUND
 
 (defun fboundp (name)

--- a/src/code/filesys.lisp
+++ b/src/code/filesys.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; Unix pathname host support
 
 ;;; FIXME: the below shouldn't really be here, but in documentation
@@ -265,7 +265,7 @@
                   nil
                   :newest)))))
 
-
+
 ;;;; Grabbing the kind of file when we have a namestring.
 (defun native-file-kind (namestring)
   (multiple-value-bind (existsp errno ino mode)
@@ -282,7 +282,7 @@
          #-win32
          (#.sb-unix:s-iflnk :symlink)
          (t :special))))))
-
+
 ;;;; TRUENAME, PROBE-FILE, FILE-AUTHOR, FILE-WRITE-DATE.
 
 ;;; Rewritten in 12/2007 by RMK, replacing 13+ year old CMU code that
@@ -501,7 +501,7 @@ is a wild pathname."
 An error of type FILE-ERROR is signaled if no such file exists,
 or if PATHSPEC is a wild pathname."
   (query-file-system pathspec :write-date))
-
+
 ;;;; miscellaneous other operations
 
 (/show0 "filesys.lisp 700")
@@ -638,7 +638,7 @@ exist or if is a file or a symbolic link."
           (recurse physical)
           (delete-dir physical)))))
 
-
+
 (sb-alien:define-alien-variable ("sbcl_home" *sbcl-home*) c-string)
 
 (defun sbcl-homedir-pathname ()
@@ -693,7 +693,7 @@ system. HOST argument is ignored by SBCL."
     *default-pathname-defaults*
     :as-directory t)))
 
-
+
 ;;;; DIRECTORY
 
 (defun directory (pathspec &key (resolve-symlinks t))
@@ -1222,7 +1222,7 @@ Experimental: interface subject to change."
                 (mapcar (lambda (x) (cons (simple-intersection
                                            (car one) (car two)) x))
                         (intersect-directory-helper (cdr one) (cdr two)))))))))
-
+
 
 (defun directory-pathname-p (pathname)
   (and (pathnamep pathname)

--- a/src/code/float.lisp
+++ b/src/code/float.lisp
@@ -14,7 +14,7 @@
 ;;;; files for more information.
 
 (in-package "SB-KERNEL")
-
+
 ;;;; float predicates and environment query
 
 #-sb-fluid
@@ -203,7 +203,7 @@
   "Return (as an integer) the radix b of its floating-point argument."
   (declare (ignore x) (type float x))
   2)
-
+
 ;;;; INTEGER-DECODE-FLOAT and DECODE-FLOAT
 
 (defconstant-eqx float-decoding-error "Can't decode NaN or infinity: ~S."
@@ -514,7 +514,7 @@
     #+long-float
     ((long-float)
      (decode-long-float f))))
-
+
 ;;;; SCALE-FLOAT
 
 #-sb-fluid (declaim (maybe-inline scale-single-float scale-double-float))
@@ -646,7 +646,7 @@
     #+long-float
     ((long-float)
      (scale-long-float f ex))))
-
+
 ;;;; converting to/from floats
 
 (defun float (number &optional (other () otherp))

--- a/src/code/fop.lisp
+++ b/src/code/fop.lisp
@@ -135,7 +135,7 @@
         (setf (aref string i)
               (sb-xc:code-char (read-varint))))))
   string)
-
+
 ;;;; miscellaneous fops
 
 (define-fop 0 (fop-nop () nil))
@@ -214,7 +214,7 @@
 (define-fop 63 (fop-verify-empty-stack () nil)
   (unless (fop-stack-empty-p (operand-stack))
     (bug "fasl stack not empty when it should be")))
-
+
 ;;;; fops for loading symbols
 
 (defstruct (undefined-package (:copier nil))
@@ -289,7 +289,7 @@
        (simple-package-error (c)
          (make-undefined-package :error (princ-to-string c))))
      (fasl-input))))
-
+
 ;;;; fops for loading numbers
 
 ;;; Load a signed integer LENGTH bytes long from FASL-INPUT-STREAM.
@@ -375,7 +375,7 @@
              (%make-simd-pack tag
                               (fast-read-u-integer 8)
                               (fast-read-u-integer 8)))))))
-
+
 ;;;; loading lists
 
 (defun fop-list (fasl-input n &aux (stack (%fasl-input-stack fasl-input)))
@@ -395,7 +395,7 @@
                (cold-cons (fop-stack-ref i) res)))
          ((= i ptr) res)
       (declare (type index i)))))
-
+
 ;;;; fops for loading arrays
 
 (define-fop 100 :not-host (fop-base-string ((:operands length)))
@@ -483,7 +483,7 @@
 ;;; For LOAD-TIME-VALUE which is used for MAKE-LOAD-FORM
 (define-fop 57 (fop-funcall-no-skip ((:operands n)))
   (fop-funcall* n (operand-stack) nil))
-
+
 ;;;; fops for fixing up circularities
 
 (define-fop 11 (fop-rplaca ((:operands tbl-slot idx) val) nil)
@@ -502,7 +502,7 @@
 
 (define-fop 15 (fop-nthcdr ((:operands n) obj))
   (nthcdr n obj))
-
+
 ;;;; fops for loading functions
 
 ;;; (In CMU CL there was a FOP-CODE-FORMAT (47) which was
@@ -559,7 +559,7 @@
 
 (define-fop 20 :not-host (fop-fun-entry ((:operands fun-index) code-object))
   (%code-entry-point code-object fun-index))
-
+
 ;;;; assemblerish fops
 
 (define-fop 21 (fop-assembler-code)

--- a/src/code/format-directive.lisp
+++ b/src/code/format-directive.lisp
@@ -8,7 +8,7 @@
 ;;;; files for more information.
 
 (in-package "SB-FORMAT")
-
+
 (define-condition format-error (error reference-condition)
   ((complaint :reader format-error-complaint :initarg :complaint)
    (args :reader format-error-args :initarg :args :initform nil)
@@ -52,7 +52,7 @@
 (defun format-error-at (control-string offset complaint &rest args)
   (format-error-at* control-string offset complaint args))
 
-
+
 (defstruct (format-directive (:copier nil)
                              (:constructor %make-directive
                                            (string start end params bits function))

--- a/src/code/gc.lisp
+++ b/src/code/gc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-KERNEL")
-
+
 ;;;; DYNAMIC-USAGE and friends
 
 #+(and relocatable-heap gencgc)
@@ -57,7 +57,7 @@
 
 (defun binding-stack-usage ()
   (sap- (binding-stack-pointer-sap) (descriptor-sap sb-vm:*binding-stack-start*)))
-
+
 ;;;; GET-BYTES-CONSED
 
 ;;; the total number of bytes freed so far (including any freeing
@@ -84,7 +84,7 @@ SB-PROFILE package does), or to design a more microefficient interface
 and submit it as a patch."
   (+ (dynamic-usage)
      *n-bytes-freed-or-purified*))
-
+
 ;;;; GC hooks
 
 (!define-load-time-global *after-gc-hooks* nil
@@ -92,7 +92,7 @@ and submit it as a patch."
 triggered during thread exits. In a multithreaded environment these hooks may
 run in any thread.")
 
-
+
 ;;;; internal GC
 
 (define-alien-routine collect-garbage int
@@ -136,7 +136,7 @@ statistics are appended to it."
 #+gencgc
 (define-symbol-macro sb-vm:dynamic-space-end
   (+ (dynamic-space-size) sb-vm:dynamic-space-start))
-
+
 ;;;; SUB-GC
 
 ;;; SUB-GC does a garbage collection.  This is called from three places:
@@ -338,7 +338,7 @@ guaranteed to be collected."
          (drop-all-hash-caches)))
   #-gencgc
   (drop-all-hash-caches))
-
+
 ;;;; auxiliary functions
 
 (defun bytes-consed-between-gcs ()

--- a/src/code/host-alieneval.lisp
+++ b/src/code/host-alieneval.lisp
@@ -13,7 +13,7 @@
 (in-package "SB-ALIEN")
 
 (/show0 "host-alieneval.lisp 15")
-
+
 ;;;; utility functions
 
 (defun align-offset (offset alignment)
@@ -27,7 +27,7 @@
         ((> bits 8) 16)
         ((> bits 1) 8)
         (t 1)))
-
+
 ;;;; ALIEN-TYPE-INFO stuff
 
 ;;; We define a keyword "BOA" constructor so that we can reference the
@@ -79,7 +79,7 @@
          ,@body)
        (setf (,(method-slot method) (alien-type-class-or-lose ',class))
              #',defun-name))))
-
+
 ;;;; type parsing and unparsing
 
 ;;; CMU CL used COMPILER-LET to bind *AUXILIARY-TYPE-DEFINITIONS*, and
@@ -164,7 +164,7 @@
 ;;; *RECORD-TYPES-ALREADY-UNPARSED*.
 (defun %unparse-alien-type (type)
   (invoke-alien-type-method :unparse type))
-
+
 ;;;; alien type defining stuff
 
 (eval-when (#-sb-xc :compile-toplevel :load-toplevel :execute)
@@ -213,7 +213,7 @@
     (setf (info :alien-type :kind name) :defined)
     (setf (info :source-location :alien-type name) source-location)
     name))
-
+
 ;;;; the root alien type
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -222,7 +222,7 @@
 (defmethod print-object ((type alien-type) stream)
   (print-unreadable-object (type stream :type t)
     (sb-impl:print-type-specifier stream (unparse-alien-type type))))
-
+
 ;;;; the SAP type
 
 (define-alien-type-class (system-area-pointer))
@@ -255,7 +255,7 @@
 (define-alien-type-method (system-area-pointer :extract-gen) (type sap offset)
   (declare (ignore type))
   `(sap-ref-sap ,sap (/ ,offset sb-vm:n-byte-bits)))
-
+
 ;;;; the ALIEN-VALUE type
 
 (define-alien-type-class (alien-value :include system-area-pointer))
@@ -271,7 +271,7 @@
   (declare (ignore type))
   (/noshow "doing alien type method ALIEN-VALUE :DEPORT-GEN" value)
   `(alien-sap ,value))
-
+
 ;;; HEAP-ALIEN-INFO -- defstruct.
 ;;;
 (defmethod print-object ((info heap-alien-info) stream)
@@ -291,7 +291,7 @@
 (defun heap-alien-info-sap (info)
   (foreign-symbol-sap (heap-alien-info-alien-name info)
                       (heap-alien-info-datap info)))
-
+
 ;;;; Interfaces to the different methods
 
 (defun alien-type-= (type1 type2)
@@ -368,7 +368,7 @@
 ;;; details.
 (defun compute-alien-rep-type (type &optional (context :normal))
   (invoke-alien-type-method :alien-rep type context))
-
+
 ;;;; default methods
 
 (defun missing-alien-operation-error (type operation)
@@ -427,7 +427,7 @@
   (declare (ignore state))
   (missing-alien-operation-error "return from CALL-OUT"
                                  (unparse-alien-type type)))
-
+
 ;;;; the INTEGER type
 
 (define-alien-type-class (integer)
@@ -502,7 +502,7 @@
         `(,ref-fun ,sap (/ ,offset sb-vm:n-byte-bits))
         (error "cannot extract ~W-bit integers"
                (alien-integer-type-bits type)))))
-
+
 ;;;; the BOOLEAN type
 
 (define-alien-type-class (boolean :include integer :include-args (signed)))
@@ -528,7 +528,7 @@
 (define-alien-type-method (boolean :deport-gen) (type value)
   (declare (ignore type))
   `(if ,value 1 0))
-
+
 ;;;; the ENUM type
 
 (define-alien-type-class (enum :include (integer (bits 32))
@@ -661,7 +661,7 @@
      ,@(mapcar (lambda (mapping)
                  `(,(car mapping) ,(cdr mapping)))
                (alien-enum-type-from type))))
-
+
 ;;;; the FLOAT types
 
 (define-alien-type-class (float)
@@ -705,7 +705,7 @@
   (declare (ignore type))
   `(sap-ref-double ,sap (/ ,offset sb-vm:n-byte-bits)))
 
-
+
 ;;;; the POINTER type
 
 (define-alien-type-class (pointer :include (alien-value (bits
@@ -761,7 +761,7 @@
       (null
        (int-sap 0)))
    `(or null system-area-pointer (alien ,type))))
-
+
 ;;;; the MEM-BLOCK type
 
 (define-alien-type-class (mem-block :include alien-value))
@@ -777,7 +777,7 @@
     `(sb-kernel:system-area-ub8-copy ,value 0 ,sap
       (truncate ,offset sb-vm:n-byte-bits)
       ',(truncate bits sb-vm:n-byte-bits))))
-
+
 ;;;; the ARRAY type
 
 (define-alien-type-class (array :include mem-block)
@@ -827,7 +827,7 @@
                   (equal dim1 dim2))
               (alien-subtype-p (alien-array-type-element-type type1)
                                (alien-array-type-element-type type2))))))
-
+
 ;;;; the RECORD type
 
 (def!struct (alien-record-field (:copier nil))
@@ -989,7 +989,7 @@
                (or (memq type2 types) (match-fields types)))
              (let ((*alien-type-matches* (make-hash-table :test #'eq)))
                (match-fields))))))
-
+
 ;;;; the FUNCTION and VALUES alien types
 
 ;;; Calling-convention spec, typically one of predefined keywords.
@@ -1094,7 +1094,7 @@
        (every #'alien-type-=
               (alien-values-type-values type1)
               (alien-values-type-values type2))))
-
+
 ;;;; a structure definition needed both in the target and in the
 ;;;; cross-compilation host
 
@@ -1120,7 +1120,7 @@
             "~:[~;(forced to stack) ~]~S"
             (local-alien-info-force-to-memory-p info)
             (unparse-alien-type (local-alien-info-type info)))))
-
+
 ;;;; the ADDR macro
 
 (sb-xc:defmacro addr (expr &environment env)

--- a/src/code/hppa-vm.lisp
+++ b/src/code/hppa-vm.lisp
@@ -1,10 +1,10 @@
 (in-package "SB-VM")
-
+
 #-sb-xc-host
 (defun machine-type ()
   "Returns a string describing the type of the local machine."
   "HPPA")
-
+
 ;;;; FIXUP-CODE-OBJECT
 (defconstant-eqx +fixup-kinds+
     #(:absolute :load :load11u :load-short :hi :branch)
@@ -52,7 +52,7 @@
                         (mask-field (byte 3 13) inst)
                         (mask-field (byte 11 21) inst)))))))
   nil))
-
+
 #-sb-xc-host (progn
 
 ;;; For now.

--- a/src/code/inspect.lisp
+++ b/src/code/inspect.lisp
@@ -128,7 +128,7 @@ evaluated expressions.
                     index name (if (eq value sb-pcl:+slot-unbound+)
                                    "unbound"
                                    value))))))
-
+
 ;;;; INSPECTED-PARTS
 
 ;;; Destructure an object for inspection, returning

--- a/src/code/interr.lisp
+++ b/src/code/interr.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-KERNEL")
-
+
 ;;;; internal errors
 
 (macrolet ((def-it ()
@@ -359,7 +359,7 @@
 
 (deferr failed-aver-error (form)
   (bug "~@<failed AVER: ~2I~_~S~:>" form))
-
+
 ;;;; INTERNAL-ERROR signal handler
 
 ;;; This is needed for restarting XEPs, which do not bind anything but

--- a/src/code/irrat.lisp
+++ b/src/code/irrat.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-KERNEL")
-
+
 ;;;; miscellaneous constants, utility functions, and macros
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -43,7 +43,7 @@
                                            collect 'double-float)))
            ,@args))))))
 
-
+
 #+x86 ;; for constant folding
 (macrolet ((def (name ll)
              `(defun ,name ,ll (,name ,@ll))))
@@ -94,7 +94,7 @@
 #-(or x86 x86-64 arm-vfp arm64 riscv) (def-math-rtn "sqrt" 1)
 #-x86 (def-math-rtn "log1p" 1)
 
-
+
 ;;;; power functions
 
 (defun exp (number)
@@ -418,7 +418,7 @@
                  '(dispatch-type number))))
     ((complex)
      (complex-sqrt number))))
-
+
 ;;;; trigonometic and related functions
 
 (defun abs (number)
@@ -646,7 +646,7 @@
     ((complex)
      (complex-atanh number))))
 
-
+
 ;;;; not-OLD-SPECFUN stuff
 ;;;;
 ;;;; (This was conditional on #-OLD-SPECFUN in the CMU CL sources,

--- a/src/code/late-condition.lisp
+++ b/src/code/late-condition.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-KERNEL")
-
+
 (fmakunbound 'install-condition-slot-reader)
 (fmakunbound 'install-condition-slot-writer)
 

--- a/src/code/late-format.lisp
+++ b/src/code/late-format.lisp
@@ -279,7 +279,7 @@
                             (emit-string (make-string n :initial-element char))))
                         (return)))))
                  (emit-directive item))))))))))
-
+
 ;;;; FORMATTER stuff
 
 (sb-xc:defmacro formatter (control-string)
@@ -456,7 +456,7 @@
              (format-error-at nil (caar ,params)
                               "Too many parameters, expected none"))
            ,@body))))
-
+
 ;;;; format directive machinery
 
 (defmacro def-complex-format-directive (char lambda-list &body body)
@@ -519,7 +519,7 @@
                             (t directives))))
                    kind stop-at-semi)))
             (find-directive (cdr directives) kind stop-at-semi)))))
-
+
 ;;;; format directives for simple output
 
 (def-format-directive #\A (colonp atsignp params)
@@ -573,7 +573,7 @@
                      (*print-length* nil))))
            (output-object ,(expand-next-arg) stream))
         `(output-object ,(expand-next-arg) stream))))
-
+
 ;;;; format directives for integer output
 
 (defun expand-format-integer (base colonp atsignp params)
@@ -621,7 +621,7 @@
                   (if colonp
                       `(format-print-ordinal stream ,n-arg)
                       `(format-print-cardinal stream ,n-arg))))))))
-
+
 ;;;; format directive for pluralization
 
 (def-format-directive #\P (colonp atsignp params end)
@@ -647,7 +647,7 @@
       (if atsignp
           `(write-string (if (eql ,arg 1) "y" "ies") stream)
           `(unless (eql ,arg 1) (write-char #\s stream))))))
-
+
 ;;;; format directives for floating point output
 
 (def-format-directive #\F (colonp atsignp params)
@@ -674,7 +674,7 @@
   (expand-bind-defaults ((d 2) (n 1) (w 0) (pad #\space)) params
     `(format-dollars stream ,(expand-next-arg) ,d ,n ,w ,pad ,colonp
                      ,atsignp)))
-
+
 ;;;; format directives for line/page breaks etc.
 
 (def-format-directive #\% (colonp atsignp params)
@@ -725,7 +725,7 @@
   (check-modifier '("colon" "at-sign") (and colonp atsignp))
   (values (expand-bind-defaults () params)
           (bug "Unreachable ~S" directives)))
-
+
 ;;;; format directives for tabs and simple pretty printing
 
 (def-format-directive #\T (colonp atsignp params)
@@ -754,7 +754,7 @@
   (check-modifier "at-sign" atsignp)
   (expand-bind-defaults ((n 0)) params
     `(pprint-indent ,(if colonp :current :block) ,n stream)))
-
+
 ;;;; format directive for ~*
 
 (def-format-directive #\* (colonp atsignp params end)
@@ -791,7 +791,7 @@
                   `(dotimes (i ,n)
                      ,(expand-next-arg)))
                 (expand-next-arg))))))
-
+
 ;;;; format directive for indirection
 
 (def-format-directive #\? (colonp atsignp params string end)
@@ -812,7 +812,7 @@
                 `(setf args (%format stream ,(expand-next-arg) orig-args args))
                 (throw 'need-orig-args nil))
             `(%format stream ,(expand-next-arg) ,(expand-next-arg))))))
-
+
 ;;;; format directives for capitalization
 
 (def-complex-format-directive #\( (colonp atsignp params directives)
@@ -836,7 +836,7 @@
 
 (def-complex-format-directive #\) ()
   (format-error "No corresponding open parenthesis"))
-
+
 ;;;; format directives and support functions for conditionalization
 
 (def-complex-format-directive #\[ (colonp atsignp params directives)
@@ -964,7 +964,7 @@
 
 (def-complex-format-directive #\] ()
   (format-error "No corresponding open bracket"))
-
+
 ;;;; format directive for up-and-out
 
 (def-format-directive #\^ (colonp atsignp params)
@@ -983,7 +983,7 @@
      ,(if colonp
           '(return-from outside-loop nil)
           '(return))))
-
+
 ;;;; format directives for iteration
 
 (def-complex-format-directive #\{ (colonp atsignp params string end directives)
@@ -1061,7 +1061,7 @@
 
 (def-complex-format-directive #\} ()
   (format-error "No corresponding open brace"))
-
+
 ;;;; format directives and support functions for justification
 
 (defconstant-eqx !illegal-inside-justification
@@ -1287,7 +1287,7 @@
                                      '(nil 0 0))
                                segments ,colonp ,atsignp
                                ,mincol ,colinc ,minpad ,padchar)))))
-
+
 ;;;; format directive and support function for user-defined method
 
 (def-format-directive #\/ (string start end colonp atsignp params)

--- a/src/code/late-type.lisp
+++ b/src/code/late-type.lisp
@@ -224,7 +224,7 @@
                #'delegate-complex-subtypep-arg2)
          (setf (type-class-complex-intersection2 type-class)
                #'delegate-complex-intersection2))))))
-
+
 ;;;; FUNCTION and VALUES types
 ;;;;
 ;;;; Pretty much all of the general type operations are illegal on
@@ -543,7 +543,7 @@
         (if (plusp llks)
             (make-values-type :required required :optional optional :rest rest)
             (make-short-values-type required)))))
-
+
 ;;;; VALUES types interfaces
 ;;;;
 ;;;; We provide a few special operations that can be meaningfully used
@@ -920,7 +920,7 @@
                             (return (values nil nil)))
                           (unless res
                             (return (values nil t))))))))))))
-
+
 ;;;; type method interfaces
 
 ;;; like SUBTYPEP, only works on CTYPE structures
@@ -1210,7 +1210,7 @@
         (setf (info :type :builtin spec) res)
         (setf (info :type :kind spec) :primitive))))
   (values))
-
+
 ;;;; general TYPE-UNION and TYPE-INTERSECTION operations
 ;;;;
 ;;;; These are fully general operations on CTYPEs: they'll always
@@ -1289,7 +1289,7 @@
       (t (make-union-type
           (every #'type-enumerable simplified-types)
           simplified-types)))))
-
+
 ;;;; built-in types
 
 (define-type-method (named :simple-=) (type1 type2)
@@ -1519,7 +1519,7 @@
 
 (define-type-method (named :unparse) (x)
   (named-type-name x))
-
+
 ;;;; hairy and unknown types
 ;;;; DEFINE-TYPE-CLASS HAIRY is in 'early-type'
 
@@ -1615,7 +1615,7 @@
    (keywordp (literal-ctype *satisfies-keywordp-type*))
    (legal-fun-name-p (literal-ctype *fun-name-type*))
    (t (%make-hairy-type whole))))
-
+
 ;;;; negation types
 
 (define-type-method (negation :negate) (x)
@@ -1791,7 +1791,7 @@
 
 (def-type-translator not :list ((:context context) typespec)
   (type-negation (specifier-type-r context typespec)))
-
+
 ;;;; numeric types
 
 (declaim (inline numeric-type-equal))
@@ -2513,7 +2513,7 @@ used for a COMPLEX component.~:@>"
               (t
                (specifier-type 'number))))
       (specifier-type 'number)))
-
+
 ;;;; array types
 
 (define-type-method (array :simple-=) (type1 type2)
@@ -2884,7 +2884,7 @@ used for a COMPLEX component.~:@>"
      dims)
     (t
      (error "Array dimensions is not a list, integer or *:~%  ~S" dims))))
-
+
 ;;;; MEMBER types
 
 (define-type-method (member :negate) (type)
@@ -3018,7 +3018,7 @@ used for a COMPLEX component.~:@>"
                                                 (sort char-codes #'<)))
                (nreverse numbers)))
       *empty-type*))
-
+
 ;;;; intersection types
 ;;;;
 ;;;; Until version 0.6.10.6, SBCL followed the original CMU CL approach
@@ -3177,7 +3177,7 @@ used for a COMPLEX component.~:@>"
   (apply #'type-intersection
          (mapcar (lambda (x) (specifier-type-r context x))
                  type-specifiers)))
-
+
 ;;;; union types
 
 (define-type-class union
@@ -3439,7 +3439,7 @@ used for a COMPLEX component.~:@>"
     (if (union-type-p type)
         (sb-kernel::simplify-array-unions type)
         type)))
-
+
 ;;;; CONS types
 
 (def-type-translator cons ((:context context)
@@ -3583,7 +3583,7 @@ used for a COMPLEX component.~:@>"
                  cdr-int2)))))
 
 (!define-superclasses cons ((cons)) !cold-init-forms)
-
+
 ;;;; CHARACTER-SET types
 
 (def-type-translator character-set
@@ -3732,12 +3732,12 @@ used for a COMPLEX component.~:@>"
         (nreverse res))
     nil))
 
-
+
 ;;; Return the type that describes all objects that are in X but not
 ;;; in Y.
 (defun type-difference (x y)
   (type-intersection x (type-negation y)))
-
+
 (def-type-translator array ((:context context)
                              &optional (element-type '*)
                                        (dimensions '*))
@@ -3761,7 +3761,7 @@ used for a COMPLEX component.~:@>"
                     :element-type eltype
                     :specialized-element-type (%upgraded-array-element-type
                                                eltype))))
-
+
 ;;;; SIMD-PACK types
 #+sb-simd-pack
 (progn
@@ -3878,7 +3878,7 @@ used for a COMPLEX component.~:@>"
            *empty-type*)))
 
   (!define-superclasses simd-pack-256 ((simd-pack-256)) !cold-init-forms))
-
+
 ;;;; utilities shared between cross-compiler and target system
 
 ;;; Does the type derived from compilation of an actual function
@@ -3937,7 +3937,7 @@ used for a COMPLEX component.~:@>"
                          :complexp complexp
                          :low low
                          :high high))))
-
+
 ;;; The following function is a generic driver for approximating
 ;;; set-valued functions over types.  Putting this here because it'll
 ;;; probably be useful for a lot of type analyses.
@@ -4140,7 +4140,7 @@ used for a COMPLEX component.~:@>"
    #'union #'intersection #'set-difference
    '* nil
    over under))
-
+
 (!defun-from-collected-cold-init-forms !late-type-cold-init)
 
 (/show0 "late-type.lisp end of file")

--- a/src/code/list.lisp
+++ b/src/code/list.lisp
@@ -112,7 +112,7 @@
 (defun cons (se1 se2)
   "Return a list with SE1 as the CAR and SE2 as the CDR."
   (cons se1 se2))
-
+
 (declaim (maybe-inline tree-equal-test tree-equal-test-not))
 
 (defun tree-equal-test-not (x y test-not)
@@ -391,7 +391,7 @@
        (result '() (cons initial-element result)))
       ((<= count 0) result)
     (declare (type index count))))
-
+
 (defun append (&rest lists)
   "Construct a new list by concatenating the list arguments"
   (let* ((result (list nil))
@@ -430,7 +430,7 @@
              result)
                     (rplacd (truly-the cons tail) (list (car more)))))))
 
-
+
 ;;;; list copying functions
 
 (defun copy-list (list)
@@ -475,7 +475,7 @@
         result)
       object))
 
-
+
 ;;;; more commonly-used list functions
 
 (defun revappend (x y)
@@ -528,7 +528,7 @@
        (3rd y 2nd))             ;3rd follows 2nd down the list.
       ((atom 2nd) 3rd)
     (rplacd 2nd 3rd)))
-
+
 
 (defun butlast (list &optional (n 1))
   (declare (optimize speed)
@@ -585,7 +585,7 @@
     (if (eql list object)
         (return (cdr result))
         (setq splice (cdr (rplacd splice (list (car list))))))))
-
+
 ;;;; functions to alter list structure
 
 (defun rplaca (cons x)
@@ -613,7 +613,7 @@
            (error "~S is too large an index for SETF of NTH." n))
          (rplaca cons newval)
          newval))))
-
+
 ;;;; :KEY arg optimization to save funcall of IDENTITY
 
 ;;; APPLY-KEY saves us a function call sometimes.
@@ -628,7 +628,7 @@
   `(if ,key
        (funcall (truly-the function ,key) ,element)
        ,element))
-
+
 ;;;; macros for (&KEY (KEY #'IDENTITY) (TEST #'EQL TESTP) (TEST-NOT NIL NOTP))
 
 ;;; Use these with the following &KEY args:
@@ -643,7 +643,7 @@
       (cond (testp (funcall test ,item ,key-tmp))
             (notp (not (funcall test-not ,item ,key-tmp)))
             (t (funcall test ,item ,key-tmp))))))
-
+
 ;;;; substitution of expressions
 
 (defun subst (new old tree &key key (test #'eql testp) (test-not #'eql notp))
@@ -758,7 +758,7 @@
                               (setf (car subtree) (s (car subtree)))))
                         subtree))))
       (s tree))))
-
+
 (defun sublis (alist tree &key key (test #'eql testp) (test-not #'eql notp))
   "Substitute from ALIST into TREE nondestructively."
   (declare (dynamic-extent key test test-not))
@@ -818,7 +818,7 @@
                                 (setf (car subtree) (s (car subtree)))))
                           subtree))))
         (s tree)))))
-
+
 ;;;; functions for using lists as sets
 
 (defun member (item list &key key (test nil testp) (test-not nil notp))
@@ -1185,7 +1185,7 @@
       (unless (funcall member-test elt list2 key test)
         (return-from subsetp nil)))
     t))
-
+
 ;;;; functions that operate on association lists
 
 (defun acons (key datum alist)
@@ -1290,7 +1290,7 @@
     (if key
         (%rassoc-if-not-key predicate alist key)
         (%rassoc-if-not predicate alist))))
-
+
 ;;;; mapping functions
 
 ;;; a helper function for implementation of MAPC, MAPCAR, MAPCAN,

--- a/src/code/load.lisp
+++ b/src/code/load.lisp
@@ -15,7 +15,7 @@
 ;;;; files for more information.
 
 (in-package "SB-FASL")
-
+
 ;;;; miscellaneous load utilities
 
 ;;; Output the current number of semicolons after a fresh-line.
@@ -40,7 +40,7 @@
       (if name
           (format t "loading ~S~%" name)
           (format t "loading stuff from ~S~%" stream-we-are-loading-from)))))
-
+
 ;;;; utilities for reading from fasl files
 
 #-sb-fluid (declaim (inline read-byte))
@@ -118,7 +118,7 @@
   (declare (optimize (speed 0)))
   (read-arg 4 stream))
 
-
+
 ;;;; the fop table
 
 ;;; The table is implemented as a simple-vector indexed by the table
@@ -162,7 +162,7 @@
   #+gencgc
   (fill vector 0))
 
-
+
 ;;;; the fop stack
 
 (declaim (inline fop-stack-empty-p))
@@ -191,7 +191,7 @@
     (setf (svref stack 0) next
           (svref stack next) value)))
 
-
+
 ;;;; Conditions signalled on invalid fasls (wrong fasl version, etc),
 ;;;; so that user code (esp. ASDF) can reasonably handle attempts to
 ;;;; load such fasls by recompiling them, etc. For simplicity's sake
@@ -472,7 +472,7 @@
   t)
 
 (declaim (notinline read-byte)) ; Why is it even *declaimed* inline above?
-
+
 ;;;; stuff for debugging/tuning by collecting statistics on FOPs (?)
 
 #|

--- a/src/code/loop.lisp
+++ b/src/code/loop.lisp
@@ -87,7 +87,7 @@
 ;;;;
 ;;;; KLUDGE: In SBCL, we only really use variant (1), and any generality
 ;;;; for the other variants is wasted. -- WHN 20000121
-
+
 ;;;; list collection macrology
 
 (sb-xc:defmacro with-loop-list-collection-head
@@ -146,7 +146,7 @@
                                                    &optional user-head-var)
   (or user-head-var
       `(cdr ,head-var)))
-
+
 ;;;; maximization technology
 
 #|
@@ -233,7 +233,7 @@ constructed.
        (when ,(if flag-var `(or (not ,flag-var) ,test) test)
          (setq ,@(and flag-var `(,flag-var t))
                ,answer-var ,temp-var)))))
-
+
 ;;;; LOOP keyword tables
 
 #|
@@ -307,7 +307,7 @@ code to be loaded.
       :for-keywords (maketable for-keywords)
       :iteration-keywords (maketable iteration-keywords)
       :path-keywords (maketable path-keywords))))
-
+
 ;;;; SETQ hackery, including destructuring ("DESETQ")
 
 (defun loop-make-psetq (frobs)
@@ -402,7 +402,7 @@ code to be loaded.
                       (loop-desetq-internal (pop var-val-pairs)
                                             (pop var-val-pairs))
                       actions)))))
-
+
 ;;;; LOOP-local variables
 
 (defstruct (macro-state
@@ -513,7 +513,7 @@ code to be loaded.
 ;;; If this is true, we are in some branch of a conditional. Some
 ;;; clauses may be disallowed.
 (defvar *loop-inside-conditional*)
-
+
 ;;;; code analysis stuff
 
 (defun loop-constant-fold-if-possible (form &optional expected-type)
@@ -526,7 +526,7 @@ code to be loaded.
                    form value expected-type)
         (setq constantp nil value nil)))
     (values form constantp value)))
-
+
 (defun gen-loop-body (prologue before-loop main-body after-loop epilogue)
   (unless (= (length before-loop) (length after-loop))
     ;; FIXME: should be (bug) ?
@@ -550,7 +550,7 @@ code to be loaded.
         (go next-loop)
       end-loop
         ,@(remove nil epilogue))))
-
+
 ;;;; loop errors
 
 (defun loop-context (&aux (loop *loop*))
@@ -580,7 +580,7 @@ code to be loaded.
                (loop-error "The specified data type ~S is not a subtype of ~S."
                            specified-type required-type)))
         specified-type)))
-
+
 ;;; Transform the LOOP kind of destructuring into the DESTRUCTURING-BIND kind
 ;;; basically by adding &optional and ignored &rest dotted list
 (defun transform-destructuring (tree)
@@ -675,7 +675,7 @@ code to be loaded.
                                   (car (source-code loop))
                                   (cadr (source-code loop))))
                      (t (loop-error "unknown LOOP keyword: ~S" keyword))))))))
-
+
 (defun loop-pop-source (&aux (loop *loop*))
   (if (source-code loop)
       (pop (source-code loop))
@@ -728,7 +728,7 @@ code to be loaded.
 (defun loop-disallow-aggregate-booleans ()
   (when (loop-tmember (final-value-culprit *loop*) '(always never thereis))
     (loop-error "This anonymous collection LOOP clause is not permitted with aggregate booleans.")))
-
+
 ;;;; loop types
 
 (defun loop-typed-init (data-type &optional step-var-p)
@@ -826,7 +826,7 @@ code to be loaded.
                                (cons (replicate typ (car v))
                                      (replicate typ (cdr v))))))
                   (translate z variable)))))))
-
+
 ;;;; loop variables
 
 (defun loop-bind-block (&aux (loop *loop*))
@@ -978,7 +978,7 @@ code to be loaded.
   (if (constantp form)
       form
       (loop-make-var (gensym "LOOP-BIND-") form data-type)))
-
+
 (defun loop-do-if (for negatep &aux (loop *loop*) (universe (universe loop)))
   (let ((form (loop-get-form))
         (*loop-inside-conditional* t)
@@ -1051,7 +1051,7 @@ code to be loaded.
 
 (defun loop-do-return ()
   (loop-emit-body (loop-construct-return (loop-get-form))))
-
+
 ;;;; value accumulation: LIST
 
 (defstruct (loop-collector
@@ -1141,7 +1141,7 @@ code to be loaded.
         (append (unless (and (consp form) (eq (car form) 'list))
                   (setq form `(copy-list ,form)))))
       (loop-emit-body `(loop-collect-rplacd ,tempvars ,form)))))
-
+
 ;;;; value accumulation: MAX, MIN, SUM, COUNT
 
 (defun loop-sum-collection (specifically required-type default-type);SUM, COUNT
@@ -1183,7 +1183,7 @@ code to be loaded.
       (loop-emit-body `(loop-accumulate-minimax-value ,data
                                                       ,specifically
                                                       ,form)))))
-
+
 ;;;; value accumulation: aggregate booleans
 
 ;;; handling the ALWAYS and NEVER loop keywords
@@ -1206,7 +1206,7 @@ code to be loaded.
   (loop-emit-final-value)
   (loop-emit-body `(when (setq ,(loop-when-it-var) ,(loop-get-form))
                     ,(loop-construct-return (when-it-var *loop*)))))
-
+
 (defun loop-do-while (negate kwd &aux (form (loop-get-form)))
   (loop-disallow-conditional kwd)
   (loop-pseudo-body `(,(if negate 'when 'unless) ,form (go end-loop))))
@@ -1248,7 +1248,7 @@ code to be loaded.
     (if (loop-tequal (car (source-code loop)) :and)
         (loop-pop-source)
         (return (loop-bind-block)))))
-
+
 ;;;; the iteration driver
 
 (defun loop-hack-iteration (entry &aux (loop *loop*))
@@ -1308,7 +1308,7 @@ code to be loaded.
         (loop-bind-block)
         (return nil))
       (loop-pop-source)))) ; Flush the "AND".
-
+
 ;;;; main iteration drivers
 
 ;;; FOR variable keyword ..args..
@@ -1331,7 +1331,7 @@ code to be loaded.
   (or (when-it-var loop)
       (setf (when-it-var loop)
             (loop-make-var (gensym "LOOP-IT-") nil nil))))
-
+
 ;;;; various FOR/AS subdispatches
 
 ;;; ANSI "FOR x = y [THEN z]" is sort of like the old Genera one when
@@ -1371,7 +1371,7 @@ code to be loaded.
              (step `(,var (aref ,vector-var ,index-var)))
              (pstep `(,index-var (1+ ,index-var))))
         `(,test ,step () ,pstep)))))
-
+
 ;;;; list iteration
 
 (defun loop-list-step (listvar)
@@ -1440,7 +1440,7 @@ code to be loaded.
           `(,other-endtest ,step () ,pseudo-step
             ,@(and (neq first-endtest other-endtest)
                    `(,first-endtest ,step () ,pseudo-step))))))))
-
+
 ;;;; iteration paths
 
 (defstruct (loop-path
@@ -1466,7 +1466,7 @@ code to be loaded.
     (dolist (name names)
       (setf (gethash (symbol-name name) ht) lp))
     lp))
-
+
 ;;; Note: Path functions are allowed to use LOOP-MAKE-VAR, hack
 ;;; the prologue, etc.
 (defun loop-for-being (var val data-type &aux (loop *loop*) (universe (universe loop)))
@@ -1520,7 +1520,7 @@ code to be loaded.
           (loop-make-var (car x) (cadr x) (caddr x))))
     (setf (prologue loop) (nconc (reverse (cadr stuff)) (prologue loop)))
     (cddr stuff)))
-
+
 (defun loop-named-var (name &aux (loop *loop*))
   (let ((tem (loop-tassoc name (named-vars loop))))
     (declare (list tem))
@@ -1575,7 +1575,7 @@ code to be loaded.
                          (symbolp (car (source-code loop))))
                  (return nil))))
             (t (return (nreverse prepositional-phrases)))))))
-
+
 ;;;; master sequencer function
 
 (defun loop-sequencer (indexv indexv-type
@@ -1740,7 +1740,7 @@ code to be loaded.
              (setq remaining-tests t)))
          `(() (,indexv ,step)
            ,remaining-tests ,step-hack () () ,first-test ,step-hack)))))
-
+
 ;;;; interfaces to the master sequencer
 
 (defun loop-for-arithmetic (var val data-type kwd)
@@ -1751,7 +1751,7 @@ code to be loaded.
     '((:from :upfrom :downfrom) (:to :upto :downto :above :below) (:by))
     nil (list (list kwd val)))))
 
-
+
 ;;;; builtin LOOP iteration paths
 
 #||
@@ -1835,7 +1835,7 @@ code to be loaded.
                                  ,variable)
              (,next-fn)))
       ())))
-
+
 ;;;; ANSI LOOP
 
 (sb-ext:define-load-time-global *loop-ansi-universe*

--- a/src/code/macroexpand.lisp
+++ b/src/code/macroexpand.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; syntactic environment access
 
 (defun sb-xc:special-operator-p (symbol)

--- a/src/code/macros.lisp
+++ b/src/code/macros.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; ASSERT and CHECK-TYPE
 
 ;;; ASSERT is written this way, to call ASSERT-ERROR, because of how
@@ -144,7 +144,7 @@ invoked. In that case it will store into PLACE and start over."
                    (check-type-error ',place ,value ',type
                                      ,@(and type-string
                                             `(,type-string)))))))))
-
+
 ;;;; DEFINE-SYMBOL-MACRO
 
 (sb-xc:defmacro define-symbol-macro (name expansion)
@@ -174,7 +174,7 @@ invoked. In that case it will store into PLACE and start over."
                              (:global "a global variable")
                              (t kind))))))
   name)
-
+
 ;;;; DEFINE-COMPILER-MACRO
 
 (sb-xc:defmacro define-compiler-macro (name lambda-list &body body)
@@ -201,7 +201,7 @@ invoked. In that case it will store into PLACE and start over."
     ;; respect to parent function?
     (setf (sb-xc:compiler-macro-function name) definition)
     name))
-
+
 ;;;; CASE, TYPECASE, and friends
 
 ;;; Make this a full warning during SBCL build.
@@ -415,7 +415,7 @@ invoked. In that case it will store into PLACE and start over."
                  ;; TRULY-THE allows transforms to take advantage of the type
                  ;; information without need for constraint propagation.
                  collect `(,type (,fun (truly-the ,type ,var))))))))
-
+
 ;;;; WITH-FOO i/o-related macros
 
 (sb-xc:defmacro with-open-stream ((var stream) &body body)
@@ -493,7 +493,7 @@ invoked. In that case it will store into PLACE and start over."
                 (progn ,@forms)
              (close ,var))
            (get-output-stream-string ,var)))))
-
+
 ;;;; miscellaneous macros
 
 (sb-xc:defmacro nth-value (n form &environment env)

--- a/src/code/mips-vm.lisp
+++ b/src/code/mips-vm.lisp
@@ -2,12 +2,12 @@
 ;;;
 (in-package "SB-VM")
 
-
+
 #-sb-xc-host
 (defun machine-type ()
   "Returns a string describing the type of the local machine."
   "MIPS")
-
+
 ;;;; FIXUP-CODE-OBJECT
 
 (defconstant-eqx +fixup-kinds+ #(:absolute :jmp :lui :addi) #'equalp)
@@ -33,7 +33,7 @@
               (ldb (byte 16 0) value)))))
   nil))
 
-
+
 #-sb-xc-host (progn
 
 (define-alien-routine ("os_context_bd_cause" context-bd-cause-int)

--- a/src/code/module.lisp
+++ b/src/code/module.lisp
@@ -14,7 +14,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; exported specials
 
 (defvar *modules* ()
@@ -23,7 +23,7 @@
 
 (defvar *module-provider-functions* (list 'module-provide-contrib)
   "See function documentation for REQUIRE.")
-
+
 ;;;; PROVIDE and REQUIRE
 
 (defun provide (module-name)
@@ -71,7 +71,7 @@
                                 'require module-name)))))
       (set-difference *modules* saved-modules))))
 
-
+
 ;;;; miscellany
 
 (defun module-provide-contrib (name)

--- a/src/code/ntrace.lisp
+++ b/src/code/ntrace.lisp
@@ -14,7 +14,7 @@
 ;;; FIXME: Why, oh why, doesn't the SB-DEBUG package use the SB-DI
 ;;; package? That would let us get rid of a whole lot of stupid
 ;;; prefixes..
-
+
 ;;;; utilities
 
 ;;; Given a function name, a function or a macro name, return the raw
@@ -151,7 +151,7 @@
                     (sb-di:fun-end-cookie-valid-p frame cookie))))
       (return))
     (pop *traced-entries*)))
-
+
 ;;;; hook functions
 
 ;;; Return a closure that can be used for a function start breakpoint
@@ -242,7 +242,7 @@
           (finish-output *trace-output*))
         (apply #'trace-maybe-break info (trace-info-break-after info) "after"
                frame values)))))
-
+
 ;;; This function is called by the trace encapsulation. It calls the
 ;;; breakpoint hook functions with NIL for the breakpoint and cookie,
 ;;; which we have cleverly contrived to work for our hook functions.
@@ -272,7 +272,7 @@
           (let ((vals (multiple-value-list (apply function args))))
             (funcall (trace-end-breakpoint-fun info) frame nil vals nil)
             (values-list vals)))))))
-
+
 ;;; Trace one function according to the specified options. We copy the
 ;;; trace info (it was a quoted constant), fill in the functions, and
 ;;; then install the breakpoints or encapsulation.
@@ -378,7 +378,7 @@
               (trace-1 (sb-pcl::%method-function-fast-function mf) info)))))
 
       function-or-name)))
-
+
 ;;;; the TRACE macro
 
 ;;; Parse leading trace options off of SPECS, modifying INFO
@@ -569,7 +569,7 @@ The -AFTER and -ALL forms can use SB-DEBUG:ARG."
   (if specs
       (expand-trace specs)
       '(%list-traced-funs)))
-
+
 ;;;; untracing
 
 ;;; Untrace one function.

--- a/src/code/numbers.lisp
+++ b/src/code/numbers.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-KERNEL")
-
+
 ;;;; the NUMBER-DISPATCH macro
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -191,7 +191,7 @@
               ,@(generate-number-dispatch vars (error-tags)
                                           (cdr res)))
             ,@(errors))))))
-
+
 ;;;; binary operation dispatching utilities
 
 (eval-when (:compile-toplevel :execute)
@@ -227,7 +227,7 @@
      (,big-op x y))))
 
 ) ; EVAL-WHEN
-
+
 ;;;; canonicalization utilities
 
 ;;; If IMAGPART is 0, return REALPART, otherwise make a complex. This is
@@ -273,7 +273,7 @@
   (if (eql y 1)
       x
       (truncate x y)))
-
+
 ;;;; COMPLEXes
 
 (defun complex (realpart &optional (imagpart 0))
@@ -352,7 +352,7 @@
              (coerce -1 '(dispatch-type number))))
         ((complex)
          (/ number (abs number))))))
-
+
 ;;;; ratios
 
 (defun numerator (number)
@@ -362,7 +362,7 @@
 (defun denominator (number)
   "Return the denominator of NUMBER, which must be rational."
   (denominator number))
-
+
 ;;;; arithmetic operations
 ;;;;
 ;;;; IMPORTANT NOTE: Accessing &REST arguments with NTH is actually extremely
@@ -604,7 +604,7 @@
      (%make-ratio (- (numerator n)) (denominator n)))
     ((complex)
      (complex (- (realpart n)) (- (imagpart n))))))
-
+
 ;;;; TRUNCATE and friends
 
 (defun truncate (number &optional (divisor 1))
@@ -781,7 +781,7 @@
   (multiple-value-bind (res rem)
       (round number divisor)
     (values (float res (if (floatp rem) rem $1.0)) rem)))
-
+
 ;;;; comparisons
 
 (defun = (number &rest more-numbers)
@@ -988,7 +988,7 @@ the first."
     ((complex (or float rational))
      (and (= (realpart x) y)
           (zerop (imagpart x))))))
-
+
 ;;;; logicals
 
 (macrolet ((def (op init doc)
@@ -1116,7 +1116,7 @@ and the number of 0 bits if INTEGER is negative."
      (integer-length (truly-the fixnum integer)))
     (bignum
      (bignum-integer-length integer))))
-
+
 ;;;; BYTE, bytespecs, and related operations
 
 (defun byte (size position)
@@ -1203,7 +1203,7 @@ and the number of 0 bits if INTEGER is negative."
                          word
                          (msf size word))))))
       ((unsigned-byte) (msf size integer)))))
-
+
 ;;;; BOOLE
 
 (defun boole (op integer1 integer2)
@@ -1242,7 +1242,7 @@ and the number of 0 bits if INTEGER is negative."
     (14 (boole 14 integer1 integer2))
     (15 (boole 15 integer1 integer2))
     (t (error 'type-error :datum op :expected-type '(mod 16)))))
-
+
 ;;;; GCD and LCM
 
 (defun gcd (&rest integers)
@@ -1341,7 +1341,7 @@ and the number of 0 bits if INTEGER is negative."
             (bignum-gcd u (make-small-bignum v)))
            ((fixnum bignum)
             (bignum-gcd (make-small-bignum u) v))))))
-
+
 ;;; from Robert Smith; changed not to cons unnecessarily, and tuned for
 ;;; faster operation on fixnum inputs by compiling the central recursive
 ;;; algorithm twice, once using generic and once fixnum arithmetic, and
@@ -1401,7 +1401,7 @@ and the number of 0 bits if INTEGER is negative."
                                ((= n  0) 0))))
                 (fixnum-isqrt n)))
       (bignum (isqrt-recursion n isqrt nil)))))
-
+
 ;;;; miscellaneous number predicates
 
 (macrolet ((def (name doc)
@@ -1413,7 +1413,7 @@ and the number of 0 bits if INTEGER is negative."
   (def minusp "Is this real number strictly negative?")
   (def oddp "Is this integer odd?")
   (def evenp "Is this integer even?"))
-
+
 ;;;; modular functions
 #.
 (collect ((forms))

--- a/src/code/octets.lisp
+++ b/src/code/octets.lisp
@@ -17,7 +17,7 @@
 
 (in-package "SB-IMPL")
 
-
+
 ;;;; conditions
 
 ;;; encoding condition
@@ -123,7 +123,7 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defun make-od-name (sym1 sym2)
     (package-symbolicate (cl:symbol-package sym1) sym1 "-" sym2)))
-
+
 ;;;; to-octets conversions
 
 ;;; to latin (including ascii)
@@ -285,7 +285,7 @@
                              (unless (zerop null-padding)
                                (vector-push-extend 0 new-octets))
                              (copy-seq new-octets)))))))))
-
+
 ;;;; to-string conversions
 
 ;;; from latin (including ascii)
@@ -321,7 +321,7 @@
                                                             array astart aend
                                                             mapper)))))))
 (instantiate-octets-definition define-latin->string)
-
+
 ;;;; external formats
 
 (defvar *default-external-format* nil)
@@ -365,7 +365,7 @@
              (setf external-format :latin-1))))
         (/show0 "/default external format ok")
         (setf *default-external-format* external-format))))
-
+
 ;;;; public interface
 
 (defun maybe-defaulted-external-format (external-format)

--- a/src/code/package.lisp
+++ b/src/code/package.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; the PACKAGE-HASHTABLE structure
 
 ;;; Packages are implemented using a special kind of hashtable -
@@ -52,7 +52,7 @@
   (free (missing-arg) :type index)
   ;; The number of deleted entries.
   (deleted 0 :type index))
-
+
 ;;;; the PACKAGE structure
 
 (sb-xc:defstruct (package

--- a/src/code/pathname.lisp
+++ b/src/code/pathname.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; data types used by pathnames
 
 ;;; The HOST structure holds the functions that both parse the
@@ -38,7 +38,7 @@
 ;;; matches of translations.
 (sb-xc:defstruct (pattern (:constructor make-pattern (pieces)) (:copier nil))
   (pieces nil :type list))
-
+
 ;;;; PATHNAME structures
 
 ;;; the various magic tokens that are allowed to appear in pretty much

--- a/src/code/ppc-vm.lisp
+++ b/src/code/ppc-vm.lisp
@@ -6,7 +6,7 @@
 (defun machine-type ()
   "Returns a string describing the type of the local machine."
   "PowerPC")
-
+
 ;;;; FIXUP-CODE-OBJECT
 
 (defconstant-eqx +fixup-kinds+ #(:absolute :b :ba :ha :l) #'equalp)
@@ -83,7 +83,7 @@
     (unsigned 32)
   (context (* os-context-t)))
 
-
+
 ;;;; INTERNAL-ERROR-ARGS.
 
 ;;; GIVEN a (POSIX) signal context, extract the internal error

--- a/src/code/pprint.lisp
+++ b/src/code/pprint.lisp
@@ -29,7 +29,7 @@
 (defun print-pretty-on-stream-p (stream)
   (and (pretty-stream-p stream)
        *print-pretty*))
-
+
 ;;;; stream interface routines
 
 (defun pretty-out (stream char)
@@ -103,7 +103,7 @@
 
 (defun pretty-misc (stream op &optional arg1 arg2)
   (declare (ignore stream op arg1 arg2)))
-
+
 ;;;; logical blocks
 
 (defstruct (logical-block (:copier nil))
@@ -191,7 +191,7 @@
       (fill (pretty-stream-prefix stream) #\space
             :start old-indent :end new-indent)))
   nil)
-
+
 ;;;; the pending operation queue
 
 (defmacro enqueue (stream type &rest args)
@@ -283,7 +283,7 @@
         (:section-relative (values t t)))
     (enqueue stream tab :sectionp sectionp :relativep relativep
              :colnum colnum :colinc colinc)))
-
+
 ;;;; tab support
 
 (defun compute-tab-size (tab section-start column)
@@ -374,7 +374,7 @@
             (setf end srcpos)))
         (unless (eq new-buffer buffer)
           (replace new-buffer buffer :end1 end :end2 end))))))
-
+
 ;;;; stuff to do the actual outputting
 
 (defun ensure-space-in-buffer (stream want)
@@ -576,7 +576,7 @@
   (write-string (pretty-stream-buffer stream)
                 (pretty-stream-target stream)
                 :end (pretty-stream-buffer-fill-pointer stream)))
-
+
 ;;;; user interface to the pretty printer
 
 (defun pprint-newline (kind &optional stream)
@@ -700,7 +700,7 @@ line break."
       (write-char #\space stream)
       (pprint-tab :section-relative 0 (or tabsize 16) stream)
       (pprint-newline :fill stream))))
-
+
 ;;;; pprint-dispatch tables
 
 (define-load-time-global *standard-pprint-dispatch-table* nil)
@@ -881,7 +881,7 @@ line break."
                     (merge 'list list (list entry) (lambda (a b) (entry< b a)))
                     list)))))
   nil)
-
+
 ;;;; standard pretty-printing routines
 
 (defun pprint-array (stream array)
@@ -1343,7 +1343,7 @@ line break."
        (output-object (pprint-pop) stream)
        (pprint-exit-if-list-exhausted)
        (pprint-newline :mandatory stream)))))
-
+
 ;;;; the interface seen by regular (ugly) printer and initialization routines
 
 (defmacro with-pretty-stream ((stream-var

--- a/src/code/pred.lisp
+++ b/src/code/pred.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; miscellaneous non-primitive predicates
 
 #-sb-fluid (declaim (inline streamp))
@@ -76,7 +76,7 @@
 (defun sequencep (x)
   (declare (inline extended-sequence-p))
   (or (listp x) (vectorp x) (extended-sequence-p x)))
-
+
 ;;;; primitive predicates. These must be supported directly by the
 ;;;; compiler.
 
@@ -181,7 +181,7 @@
 (defun fixnum-mod-p (x limit)
   (and (fixnump x)
        (<= 0 x limit)))
-
+
 ;;; a vector that maps widetags to layouts, used for quickly finding
 ;;; the layouts of built-in classes
 (define-load-time-global **primitive-object-layouts** nil)
@@ -289,7 +289,7 @@
                     (classoid-pcl-class pname)
                     pname))))
            name)))))
-
+
 ;;;; equality predicates
 
 ;;; This is real simple, 'cause the compiler takes care of it.

--- a/src/code/primordial-extensions.lisp
+++ b/src/code/primordial-extensions.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;; Helper for making the DX closure allocation in macros expanding
 ;;; to CALL-WITH-FOO less ugly.
 (defmacro dx-flet (functions &body forms)
@@ -42,7 +42,7 @@
 ;; the old value of I. Formerly in 'setf' but too late to avoid full calls.
 (declaim (inline xsubtract))
 (defun xsubtract (a b) (- b a))
-
+
 ;;;; GENSYM tricks
 
 ;;; Automate an idiom often found in macros:
@@ -70,7 +70,7 @@
 (defun make-gensym-list (n &optional name)
   (let ((arg (if name (string name) "G")))
     (loop repeat n collect (sb-xc:gensym arg))))
-
+
 ;;;; miscellany
 
 ;;; Lots of code wants to get to the KEYWORD package or the
@@ -207,7 +207,7 @@
                              (values id nil))
                        `(defconstant ,sym ,value ,@docstring))))
                  identifiers))))
-
+
 ;;; a helper function for various macros which expect clauses of a
 ;;; given length, etc.
 ;;;

--- a/src/code/print.lisp
+++ b/src/code/print.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; exported printer control variables
 
 ;; NB: all of the following are initialized during genesis
@@ -90,7 +90,7 @@ variable: an unreadable object representing the error is printed instead.")
         (*suppress-print-errors* nil)
         (*print-vector-length* nil))
     (funcall function)))
-
+
 ;;;; routines to print objects
 
 (macrolet ((def (fn doc &rest forms)
@@ -232,7 +232,7 @@ variable: an unreadable object representing the error is printed instead.")
                     sb-vm:n-positive-fixnum-bits
                     (* (%bignum-length object) sb-bignum::digit-size))
                 bits-per-char))))
-
+
 ;;;; support for the PRINT-UNREADABLE-OBJECT macro
 
 (defun print-not-readable-error (object stream)
@@ -286,7 +286,7 @@ variable: an unreadable object representing the error is printed instead.")
                (print-description)
                (write-char #\> stream)))))
   nil)
-
+
 ;;;; OUTPUT-OBJECT -- the main entry point
 
 ;;; Objects whose print representation identifies them EQLly don't
@@ -449,7 +449,7 @@ variable: an unreadable object representing the error is printed instead.")
               (write-string (if (eql (find-external-symbol name package) 0) "::" ":")
                             stream)))))
         (output-token name)))))
-
+
 ;;;; escaping symbols
 
 ;;; When we print symbols we have to figure out if they need to be
@@ -686,7 +686,7 @@ variable: an unreadable object representing the error is printed instead.")
       ;; See ANSI 2.3.1.1 "Potential Numbers as Tokens".)
       (when (test letter) (advance OTHER nil))
       (go DIGIT))))
-
+
 ;;;; case hackery: One of these functions is chosen to output symbol
 ;;;; names according to the values of *PRINT-CASE* and READTABLE-CASE.
 
@@ -786,7 +786,7 @@ variable: an unreadable object representing the error is printed instead.")
     (aref (compute-fun-vector)
           (logior (case print-case (:upcase 0) (:downcase 4) (t 8))
                   (truly-the (mod 4) readtable-case)))))
-
+
 ;;;; recursive objects
 
 (defmethod print-object ((list cons) stream)
@@ -963,7 +963,7 @@ variable: an unreadable object representing the error is printed instead.")
                (incf index count)))
            (write-char #\) stream)))))
 
-
+
 ;;;; integer, ratio, and complex printing (i.e. everything but floats)
 
 (defun %output-radix (base stream)
@@ -1109,7 +1109,7 @@ variable: an unreadable object representing the error is printed instead.")
   (write-char #\space stream)
   (output-object (imagpart complex) stream)
   (write-char #\) stream))
-
+
 ;;;; float printing
 
 ;;; FLONUM-TO-STRING (and its subsidiary function FLOAT-STRING) does
@@ -1406,7 +1406,7 @@ variable: an unreadable object representing the error is printed instead.")
            (print-float-exponent float 0 stream)
            (print-float-exponent float (1- k) stream)))
      float)))
-
+
 ;;; Given a non-negative floating point number, SCALE-EXPONENT returns
 ;;; a new floating point number Z in the range (0.1, 1.0] and an
 ;;; exponent E such that Z * 10^E is (approximately) equal to the
@@ -1465,7 +1465,7 @@ variable: an unreadable object representing the error is printed instead.")
               (declare (long-float d))))))))
 (eval-when (:compile-toplevel :execute)
   (setf *read-default-float-format* 'cl:single-float))
-
+
 ;;;; entry point for the float printer
 
 ;;; the float printer as called by PRINT, PRIN1, PRINC, etc. The
@@ -1550,7 +1550,7 @@ variable: an unreadable object representing the error is printed instead.")
 
 
 
-
+
 ;;;; other leaf objects
 
 ;;; If *PRINT-ESCAPE* is false, just do a WRITE-CHAR, otherwise output
@@ -1705,7 +1705,7 @@ variable: an unreadable object representing the error is printed instead.")
                 (format stream "~S~@{ ~16,'0X~}"
                         'simd-pack-256
                         p0 p1 p2 p3))))))))
-
+
 ;;;; functions
 
 (defmethod print-object ((object function) stream)
@@ -1719,7 +1719,7 @@ variable: an unreadable object representing the error is printed instead.")
               ;; and not #<FUNCTION> before SRC;PCL;PRINT-OBJECT is loaded.
               (if (closurep object) 'closure (type-of object))
               name))))
-
+
 ;;;; catch-all for unknown things
 
 (declaim (inline lowtag-of))

--- a/src/code/profile.lisp
+++ b/src/code/profile.lisp
@@ -16,7 +16,7 @@
   (export 'sb-kernel::profile-deinit "SB-KERNEL"))
 
 (in-package "SB-PROFILE")
-
+
 
 ;;;; COUNTER object
 ;;;;
@@ -64,7 +64,7 @@
 (defun counter-count (counter)
   (+ (counter-word counter)
      (* (counter-overflow counter) (1+ most-positive-word))))
-
+
 ;;;; High resolution timer
 
 ;;; FIXME: High resolution this is not. Build a microsecond-accuracy version
@@ -75,7 +75,7 @@
 (declaim (inline get-internal-ticks))
 (defun get-internal-ticks ()
   (get-internal-run-time))
-
+
 ;;;; global data structures
 
 ;;; We associate a PROFILE-INFO structure with each profiled function
@@ -137,7 +137,7 @@
 (defvar *overhead*)
 (declaim (type overhead *overhead*))
 (makunbound '*overhead*) ; in case we reload this file when tweaking
-
+
 ;;;; profile encapsulations
 
 ;;; Return a collection of closures over the same lexical context,
@@ -236,7 +236,7 @@
              consing (make-counter)
              profiles (make-counter)
              gc-run-time (make-counter))))))
-
+
 ;;;; interfaces
 
 ;;; A symbol or (SETF FOO) list names a function, a string names all
@@ -337,7 +337,7 @@
   (dohash ((name profile-info) *profiled-fun-name->info* :locked t)
     (declare (ignore name))
     (funcall (profile-info-clear-stats-fun profile-info))))
-
+
 ;;;; reporting results
 
 (defstruct (time-info (:copier nil))
@@ -483,7 +483,7 @@ uncalled profiled functions are listed."
               (overhead-total *overhead*)
               (overhead-internal *overhead*)))))
 
-
+
 ;;;; overhead estimation
 
 ;;; We average the timing overhead over this many iterations.

--- a/src/code/reader.lisp
+++ b/src/code/reader.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; miscellaneous global variables
 
 ;;; ANSI: "the floating-point format that is to be used when reading a
@@ -33,7 +33,7 @@
 ;;; In case we get an error trying to parse a symbol, we want to rebind the
 ;;; above stuff so it's cool.
 
-
+
 ;;;; reader errors
 
 (defun reader-eof-error (stream context)
@@ -50,7 +50,7 @@
          :stream stream
          :format-control control
          :format-arguments args))
-
+
 ;;;; macros and functions for character tables
 
 (declaim (ftype (sfunction (character readtable) (unsigned-byte 8))
@@ -163,7 +163,7 @@
 (defun token-delimiterp (char &optional (rt *readtable*))
   ;; depends on actual attribute numbering in readtable.lisp.
   (<= (get-cat-entry char rt) +char-attr-terminating-macro+))
-
+
 ;;;; constituent traits (see ANSI 2.1.4.2)
 
 ;;; There are a number of "secondary" attributes which are constant
@@ -209,7 +209,7 @@
   (if (typep char 'base-char)
       (elt +constituent-trait-table+ (char-code char))
       +char-attr-constituent+))
-
+
 ;;;; Readtable Operations
 
 (defun assert-not-standard-readtable (readtable operation)
@@ -432,7 +432,7 @@ standard Lisp readtable when NIL."
     (!cmt-entry-to-fun-designator
      (get-raw-cmt-dispatch-entry (char-upcase sub-char) dtable))))
 
-
+
 ;;;; definitions to support internal programming conventions
 
 (defconstant +EOF+ 0)
@@ -464,7 +464,7 @@ standard Lisp readtable when NIL."
                   ;; promise to return a character or else signal EOF.
                   (cond ((eq char +EOF+) (error 'end-of-file :stream stream))
                         ((done-p) (return (the character char))))))))))
-
+
 ;;;; temporary initialization hack
 
 ;; Install the (easy) standard macro-chars into *READTABLE*.
@@ -508,7 +508,7 @@ standard Lisp readtable when NIL."
       (set-cmt-entry char nil)))
 
   (/show0 "leaving !cold-init-standard-readtable"))
-
+
 ;;;; implementation of the read buffer
 
 (defstruct (token-buf (:predicate nil) (:copier nil)
@@ -670,7 +670,7 @@ standard Lisp readtable when NIL."
      "~A was invoked with RECURSIVE-P being true outside ~
       of a recursive read operation."
      `(,operator-name))))
-
+
 ;;;; READ-PRESERVING-WHITESPACE, READ-DELIMITED-LIST, and READ
 
 ;;; A list for #=, used to keep track of objects with labels assigned that
@@ -778,7 +778,7 @@ standard Lisp readtable when NIL."
           (unread-char next-char stream))))
     (if (eq result local-eof-val) eof-value result)))
 
-
+
 ;;;; basic readmacro definitions
 ;;;;
 ;;;; Some large, hairy subsets of readmacro definitions (backquotes
@@ -1022,7 +1022,7 @@ standard Lisp readtable when NIL."
                              +char-attr-package-delimiter+))
                (setq colon t))
              (ouch-read-buffer char read-buffer))))))
-
+
 ;;;; character classes
 
 ;;; Return the character class for CHAR.
@@ -1090,7 +1090,7 @@ standard Lisp readtable when NIL."
             ((= att +char-attr-invalid+)
              (simple-reader-error stream "invalid constituent: ~s" char))
             (t att))))))
-
+
 ;;;; token fetching
 
 (defvar *read-suppress* nil
@@ -1602,7 +1602,7 @@ extended <package-name>::<form-in-package> syntax."
     (if (neq first-char +EOF+)
         (values (internal-read-extended-token stream first-char t))
         (reader-eof-error stream "after escape"))))
-
+
 ;;;; number-reading functions
 
 ;; Mapping of read-base to the max input characters in a positive fixnum.
@@ -1789,7 +1789,7 @@ extended <package-name>::<form-in-package> syntax."
                           :error c :stream stream
                           :format-control "failed to build ratio")))))
       (if negativep (- num) num))))
-
+
 ;;;; General reader for dispatch macros
 
 (defun dispatch-char-error (stream sub-char ignore)
@@ -1827,7 +1827,7 @@ extended <package-name>::<form-in-package> syntax."
     (let ((fn (get-raw-cmt-dispatch-entry sub-char dispatch-table)))
       (funcall (!cmt-entry-to-function fn #'dispatch-char-error)
                stream sub-char (if numargp numarg nil)))))
-
+
 ;;;; READ-FROM-STRING
 
 (declaim (ftype (sfunction (string t t index (or null index) t) (values t index))
@@ -1853,7 +1853,7 @@ extended <package-name>::<form-in-package> syntax."
   (declare (string string))
   (maybe-note-read-from-string-signature-issue eof-error-p)
   (%read-from-string string eof-error-p eof-value start end preserve-whitespace)))
-
+
 ;;;; PARSE-INTEGER
 
 (defun parse-integer (string &key (start 0) end (radix 10) junk-allowed)
@@ -1912,12 +1912,12 @@ extended <package-name>::<form-in-package> syntax."
                  nil
                  (parse-error "no digits in string ~S")))
          (- index offset))))))
-
+
 ;;;; reader initialization code
 
 (defun !reader-cold-init ()
   (!cold-init-standard-readtable))
-
+
 (defmethod print-object ((readtable readtable) stream)
   (print-unreadable-object (readtable stream :identity t :type t)))
 

--- a/src/code/riscv-vm.lisp
+++ b/src/code/riscv-vm.lisp
@@ -1,12 +1,12 @@
 ;;; This file contains the RISC-V-specific runtime stuff.
 
 (in-package "SB-VM")
-
+
 #-sb-xc-host
 (defun machine-type ()
   "Return a string describing the type of the local machine."
   #-64-bit "RV32G" #+64-bit "RV64G")
-
+
 ;;; FIXUP-CODE-OBJECT
 
 (defconstant-eqx +fixup-kinds+ #(:absolute :i-type :s-type :u-type) #'equalp)
@@ -48,7 +48,7 @@
           (:u-type
            (setf (ldb (byte 20 12) (sap-ref-32 sap offset)) u)))))
    nil))
-
+
 ;;; CONTEXT-FLOAT-REGISTER
 #-sb-xc-host (progn
 (define-alien-routine ("os_context_float_register_addr" context-float-register-addr)
@@ -85,7 +85,7 @@
            (declare (type (complex double-float) value))
          (setf (sap-ref-double sap 0) (realpart value)
                (sap-ref-double sap 8) (imagpart value))))))))
-
+
 ;;; INTERNAL-ERROR-ARGS
 
 ;;; Given a (POSIX) signal context, extract the internal error
@@ -100,7 +100,7 @@
         (values #.(error-number-or-lose 'invalid-arg-count-error)
                 '(#.arg-count-sc))
         (sb-kernel::decode-internal-error-args (sap+ pc 5) trap-number))))
-
+
 ;;; CONTEXT-CALL-FUNCTION
 
 ;;; Undo the effects of XEP-ALLOCATE-FRAME

--- a/src/code/room.lisp
+++ b/src/code/room.lisp
@@ -13,7 +13,7 @@
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (export 'sb-sys::get-page-size "SB-SYS"))
-
+
 ;;;; type format database
 
 (defstruct (room-info (:constructor make-room-info (mask name kind))
@@ -128,7 +128,7 @@
 (defconstant-eqx +heap-space-keywords+ (mapcar #'first +heap-spaces+) #'equal)
 (deftype spaces () `(member . ,+heap-space-keywords+))
 
-
+
 ;;;; MAP-ALLOCATED-OBJECTS
 
 ;;; Return the lower limit and current free-pointer of SPACE as fixnums
@@ -586,7 +586,7 @@ We could try a few things to mitigate this:
                 (+ (sb-thread::thread-primitive-thread sb-thread:*current-thread*)
                    (ash thread-alloc-region-slot word-shift)))
      1)))
-
+
 ;;;; MEMORY-USAGE
 
 #+immobile-space
@@ -774,7 +774,7 @@ We could try a few things to mitigate this:
     (when print-summary (print-summary spaces totals)))
 
   (values))
-
+
 ;;; Print a breakdown by instance type of all the instances allocated
 ;;; in SPACE. If TOP-N is true, print only information for the
 ;;; TOP-N types with largest usage.
@@ -846,7 +846,7 @@ We could try a few things to mitigate this:
             (type-usage "Other types" residual-objects residual-bytes)))
         (type-usage totals-label total-objects total-bytes))))
   (values))
-
+
 ;;;; PRINT-ALLOCATED-OBJECTS
 
 ;;; This notion of page-size is completely arbitrary - it affects 2 things:
@@ -934,7 +934,7 @@ We could try a few things to mitigate this:
                               (subseq str 0 (min (length str) 60))))))))))
          space))))
   (values))
-
+
 ;;;; LIST-ALLOCATED-OBJECTS, LIST-REFERENCING-OBJECTS
 
 (defvar *ignore-after* nil)

--- a/src/code/run-program.lisp
+++ b/src/code/run-program.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; hacking the Unix environment
 ;;;;
 ;;;; In the original CMU CL code that LOAD-FOREIGN is derived from, the
@@ -102,7 +102,7 @@
        (declare (type keyword key) (string val))
        (concatenate 'simple-string (symbol-name key) "=" val)))
    cmucl))
-
+
 #-win32
 (define-alien-routine ("waitpid" c-waitpid) int
   (pid int)
@@ -150,7 +150,7 @@
 #-win32
 (define-alien-routine wifstopped boolean
   (status int))
-
+
 ;;;; process control stuff
 (define-load-time-global *active-processes* nil
   "List of process structures for all active processes.")
@@ -401,7 +401,7 @@ status slot."
     (dolist (proc changed)
       (let ((hook (process-status-hook proc)))
         (funcall hook proc)))))
-
+
 ;;;; RUN-PROGRAM and close friends
 
 ;;; list of file descriptors to close when RUN-PROGRAM exits due to an error
@@ -1071,7 +1071,7 @@ Users Manual for details about the PROCESS structure.
   #+win32 (or (sb-ext:posix-getenv "TEMP")
               "C:/Temp"))
 
-
+
 ;;; Find a file descriptor to use for object given the direction.
 ;;; Returns the descriptor. If object is :STREAM, returns the created
 ;;; stream as the second value.

--- a/src/code/save.lisp
+++ b/src/code/save.lisp
@@ -14,7 +14,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; SAVE-LISP-AND-DIE itself
 
 #-gencgc

--- a/src/code/sc-offset.lisp
+++ b/src/code/sc-offset.lisp
@@ -8,7 +8,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; SC+OFFSET
 ;;;;
 ;;;; We represent the place where some value is stored with an

--- a/src/code/seq.lisp
+++ b/src/code/seq.lisp
@@ -17,7 +17,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; utilities
 
 (defun %check-generic-sequence-bounds (seq start end)
@@ -339,7 +339,7 @@
          :datum list
          :type '(and list (satisfies list-length))))
 
-
+
 
 (defun emptyp (sequence)
   "Returns T if SEQUENCE is an empty sequence and NIL
@@ -466,7 +466,7 @@
                       (sb-sequence:make-sequence-like
                        prototype length)))))
           (t (bad-sequence-type-error (type-specifier type))))))
-
+
 ;;;; SUBSEQ
 ;;;;
 
@@ -548,7 +548,7 @@
     (list-subseq* sequence start end)
     (vector-subseq* sequence start end)
     (sb-sequence:subseq sequence start end)))
-
+
 ;;;; COPY-SEQ
 
 (defun copy-seq (sequence)
@@ -563,7 +563,7 @@
 
 (defun list-copy-seq* (sequence)
   (copy-list-macro sequence :check-proper-list t))
-
+
 ;;;; FILL
 
 (defun list-fill* (sequence item start end)
@@ -693,7 +693,7 @@
    (sb-sequence:fill sequence item
                      :start start
                      :end (%check-generic-sequence-bounds sequence start end))))
-
+
 
 (defmacro word-specialized-vector-tag-p (tag)
   `(or
@@ -879,7 +879,7 @@ many elements are copied."
     (the sequence
       (values (apply #'sb-sequence:replace target-sequence1
                      (the sequence source-sequence2) args)))))
-
+
 ;;;; REVERSE
 (defun reverse (sequence)
   "Return a new sequence containing the same elements but in reverse order."
@@ -942,7 +942,7 @@ many elements are copied."
                    (funcall setter new-vector forward-index
                             (funcall getter vector backward-index))))))
         new-vector))))
-
+
 ;;;; NREVERSE
 
 (defun list-nreverse (list)
@@ -1004,7 +1004,7 @@ many elements are copied."
     ;; meaning it should return definitely an EXTENDED-SEQUENCE
     ;; and not a list or vector.
     (the extended-sequence (values (sb-sequence:nreverse sequence)))))
-
+
 
 (defmacro sb-sequence:dosequence ((element sequence &optional return) &body body)
   "Executes BODY with ELEMENT subsequently bound to each element of
@@ -1030,7 +1030,7 @@ many elements are copied."
                    (tagbody
                       ,@forms))))))))))
 
-
+
 ;;;; CONCATENATE
 
 (defun concatenate (result-type &rest sequences)
@@ -1156,7 +1156,7 @@ many elements are copied."
           (funcall setter result index e)
           (incf index)))
       result)))
-
+
 ;;;; MAP
 
 ;;; helper functions to handle arity-1 subcases of MAP
@@ -1421,7 +1421,7 @@ many elements are copied."
            (setf iter (sb-sequence:iterator-step result-sequence
                                                            iter from-end)))))))
   result-sequence)
-
+
 ;;;; REDUCE
 
 (defmacro mumble-reduce (function
@@ -1518,7 +1518,7 @@ many elements are copied."
                 (mumble-reduce function sequence key start end
                                initial-value aref)))))
     (apply #'sb-sequence:reduce function sequence args)))
-
+
 ;;;; DELETE
 
 (defmacro mumble-delete (pred)
@@ -1715,7 +1715,7 @@ many elements are copied."
           (if-not-mumble-delete-from-end)
           (if-not-mumble-delete)))
     (apply #'sb-sequence:delete-if-not predicate sequence args)))
-
+
 ;;;; REMOVE
 
 ;;; MUMBLE-REMOVE-MACRO does not include (removes) each element that
@@ -1915,7 +1915,7 @@ many elements are copied."
           (if-not-mumble-remove-from-end)
           (if-not-mumble-remove)))
     (apply #'sb-sequence:remove-if-not predicate sequence args)))
-
+
 ;;;; REMOVE-DUPLICATES
 
 ;;; Remove duplicates from a list. If from-end, remove the later duplicates,
@@ -2067,7 +2067,7 @@ many elements are copied."
                                  start end key from-end))
     (vector-remove-duplicates* sequence test test-not start end key from-end)
     (apply #'sb-sequence:remove-duplicates sequence args)))
-
+
 ;;;; DELETE-DUPLICATES
 (defun list-delete-duplicates* (list test test-not key from-end start end)
   (declare (index start)
@@ -2143,7 +2143,7 @@ many elements are copied."
                                key from-end start end))
     (vector-delete-duplicates* sequence test test-not key from-end start end)
     (apply #'sb-sequence:delete-duplicates sequence args)))
-
+
 ;;;; SUBSTITUTE
 
 (defun list-substitute* (pred new list start end count key test test-not old)
@@ -2276,7 +2276,7 @@ many elements are copied."
            (explicit-check sequence :result)
            (truly-dynamic-extent args))
   (subst-dispatch 'normal))
-
+
 ;;;; SUBSTITUTE-IF, SUBSTITUTE-IF-NOT
 
 (define-sequence-traverser substitute-if
@@ -2302,7 +2302,7 @@ many elements are copied."
         (test-not nil)
         old)
     (subst-dispatch 'if-not)))
-
+
 ;;;; NSUBSTITUTE
 
 (define-sequence-traverser nsubstitute
@@ -2369,7 +2369,7 @@ many elements are copied."
                   test)
           (funcall setter sequence index new)
           (decf count))))))
-
+
 ;;;; NSUBSTITUTE-IF, NSUBSTITUTE-IF-NOT
 
 (define-sequence-traverser nsubstitute-if
@@ -2483,7 +2483,7 @@ many elements are copied."
       (when (not (funcall test (apply-key key (funcall getter sequence index))))
         (funcall setter sequence index new)
         (decf count)))))
-
+
 ;;;; FIND, POSITION, and their -IF and -IF-NOT variants
 
 (defun effective-find-position-test (test test-not)
@@ -2651,7 +2651,7 @@ many elements are copied."
                   sequence from-end start end
                   (effective-find-position-key key)))
     (apply #'sb-sequence:position-if-not predicate sequence args)))
-
+
 ;;;; COUNT-IF, COUNT-IF-NOT, and COUNT
 
 (defmacro vector-count-if (notp from-end-p predicate sequence
@@ -2760,7 +2760,7 @@ many elements are copied."
               (vector-count-if test-not-p t test sequence :two-arg-predicate item)
               (vector-count-if test-not-p nil test sequence :two-arg-predicate item)))
         (apply #'sb-sequence:count item sequence args))))
-
+
 ;;;; MISMATCH
 
 (defmacro match-vars (&rest body)
@@ -2810,7 +2810,7 @@ many elements are copied."
        (())
      (declare (fixnum index1 index2))
      (if-mismatch (aref sequence1 index1) (pop sequence2))))
-
+
 (defmacro list-mumble-mismatch ()
   `(do ((index1 start1 (+ index1 (the fixnum inc)))
         (index2 start2 (+ index2 (the fixnum inc))))
@@ -2881,7 +2881,7 @@ many elements are copied."
   (the (or index null)
     (values (apply #'sb-sequence:mismatch sequence1
                    (the sequence sequence2) args))))
-
+
 ;;; search comparison functions
 
 ;;; Compare two elements and return if they don't match.
@@ -2934,7 +2934,7 @@ many elements are copied."
          (search-compare-vector-list ,main ,sub ,index)
          (search-compare-vector-vector ,main ,sub ,index)
          (return-from search (apply #'sb-sequence:search ,sub ,main args)))))
-
+
 ;;;; SEARCH
 
 (defmacro list-search (main sub)

--- a/src/code/serve-event.lisp
+++ b/src/code/serve-event.lisp
@@ -187,7 +187,7 @@
           :report "Go on, leaving handlers marked as bogus.")))
   nil))
 
-
+
 ;;;; SERVE-ALL-EVENTS, SERVE-EVENT, and friends
 
 ;;; When a *periodic-polling-function* is defined the server will not
@@ -262,7 +262,7 @@ waiting."
                    else
                    do (when to-sec (maybe-update-timeout))
                    #+win32 (sb-thread:thread-yield)))))))
-
+
 ;;; Wait for up to timeout seconds for an event to happen. Make sure all
 ;;; pending events are processed before returning.
 (defun serve-all-events (&optional timeout)

--- a/src/code/setf.lisp
+++ b/src/code/setf.lisp
@@ -122,7 +122,7 @@
        (if macro-p
            (setq place expansion) ; iterate
            (return place)))))
-
+
 ;;;; SETF itself
 
 ;; Code shared by SETF, PSETF, SHIFTF attempting to minimize the expansion.
@@ -394,7 +394,7 @@
   "The first argument is some location holding a number. This number is
   decremented by the second argument, DELTA, which defaults to 1."
     (expand place delta env 'xsubtract)))
-
+
 ;;;; DEFINE-MODIFY-MACRO stuff
 
 (sb-xc:defmacro sb-xc:define-modify-macro (name lambda-list function &optional doc-string)
@@ -414,7 +414,7 @@
        ,@(when doc-string (list (the string doc-string)))
        (expand-rmw-macro ',function '() ,place
                          (list* ,@args ,(car rest)) t ,env ',args))))
-
+
 ;;;; DEFSETF
 
 (eval-when (#-sb-xc :compile-toplevel :load-toplevel :execute)
@@ -571,7 +571,7 @@
                         newval-binding
                         (cdr stores)))))
          (if bindings `(let* ,bindings ,setter) setter))))
-
+
 ;;;; DEFMACRO DEFINE-SETF-EXPANDER and various DEFINE-SETF-EXPANDERs
 
 ;;; DEFINE-SETF-EXPANDER is a lot like DEFMACRO.

--- a/src/code/sharpm.lisp
+++ b/src/code/sharpm.lisp
@@ -8,14 +8,14 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 (declaim (special *read-suppress*))
 
 ;;; FIXME: Is it standard to ignore numeric args instead of raising errors?
 (defun ignore-numarg (sub-char numarg)
   (when numarg
     (warn "A numeric argument was ignored in #~W~A." numarg sub-char)))
-
+
 ;;;; reading arrays and vectors: the #(, #*, and #A readmacros
 
 (defun sharp-left-paren (stream ignore length)
@@ -130,7 +130,7 @@
                              standard form #<rank>A<contents> nor the ~
                              SBCL-specific form #A(dimensions ~
                              element-type . contents).~@:>")))))
-
+
 ;;;; reading structure instances: the #S readmacro
 
 (defun sharp-S (stream sub-char numarg)
@@ -200,7 +200,7 @@
                                   (list (car body) slot-name))))
                      collect (intern (string (car tail)) *keyword-package*)
                      collect (cadr tail)))))))
-
+
 ;;;; reading numbers: the #B, #C, #O, #R, and #X readmacros
 
 (defun sharp-B (stream sub-char numarg)
@@ -249,7 +249,7 @@
 (defun sharp-X (stream sub-char numarg)
   (ignore-numarg sub-char numarg)
   (sharp-R stream sub-char 16))
-
+
 ;;;; reading circular data: the #= and ## readmacros
 
 (defconstant +sharp-equal-marker+ '+sharp-equal-marker+)
@@ -350,7 +350,7 @@
            entry)
           (t
            (sharp-equal-wrapper-value entry)))))
-
+
 ;;;; conditional compilation: the #+ and #- readmacros
 
 ;;; If X is a symbol, see whether it is present in *FEATURES*. Also
@@ -385,7 +385,7 @@
         (let ((*read-suppress* t))
           (read stream t nil t)
           (values))))
-
+
 ;;;; reading miscellaneous objects: the #P, #\, and #| readmacros
 
 (defun sharp-P (stream sub-char numarg)
@@ -437,7 +437,7 @@
               (munch (fast-read-char) (done-with-fast-read-char)))
             ;; fundamental-stream
             (munch (read-char stream t)))))))
-
+
 ;;;; a grab bag of other sharp readmacros: #', #:, and #.
 
 (defun sharp-quote (stream sub-char numarg)
@@ -495,7 +495,7 @@
         (unless *read-eval*
           (simple-reader-error stream "can't read #. while *READ-EVAL* is NIL"))
         (eval expr)))))
-
+
 (defun sharp-illegal (stream sub-char ignore)
   (declare (ignore ignore))
   (simple-reader-error stream "illegal sharp macro character: ~S" sub-char))

--- a/src/code/show.lisp
+++ b/src/code/show.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-INT")
-
+
 ;;;; various SB-SHOW-dependent forms
 ;;;;
 ;;;; In general, macros named /FOO

--- a/src/code/signal.lisp
+++ b/src/code/signal.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-UNIX")
-
+
 ;;;; macros for dynamically enabling and disabling signal handling
 
 ;;; Notes on how the without-interrupts/with-interrupts stuff works:

--- a/src/code/sort.lisp
+++ b/src/code/sort.lisp
@@ -38,7 +38,7 @@
           (sort-vector vector start end predicate-fun key-fun-or-nil))
         sequence)
       (apply #'sb-sequence:sort sequence predicate args))))
-
+
 ;;;; stable sorting
 (defun stable-sort (sequence predicate &rest args &key key)
   "Destructively sort SEQUENCE. PREDICATE should return non-NIL if
@@ -58,7 +58,7 @@
                               predicate-fun
                               (and key (%coerce-callable-to-fun key))))
       (apply #'sb-sequence:stable-sort sequence predicate args))))
-
+
 ;;; FUNCALL-USING-KEY saves us a function call sometimes.
 (eval-when (:compile-toplevel :execute)
   (sb-xc:defmacro funcall2-using-key (pred key one two)
@@ -67,7 +67,7 @@
                   (funcall ,key  ,two))
          (funcall ,pred ,one ,two)))
 ) ; EVAL-WHEN
-
+
 ;;;; stable sort of lists
 (declaim (maybe-inline merge-lists* stable-sort-list))
 
@@ -204,7 +204,7 @@
                     (values list list (shiftf (cdr list) nil))))))
     (when list
       (values (recur list (length list))))))
-
+
 ;;;; stable sort of vectors
 
 ;;; Stable sorting vectors is done with the same algorithm used for
@@ -333,7 +333,7 @@
   (declare (explicit-check))
   (declare (dynamic-extent pred key))
   (vector-merge-sort vector pred key aref))
-
+
 ;;;; merging
 
 (eval-when (:compile-toplevel :execute)

--- a/src/code/sparc-vm.lisp
+++ b/src/code/sparc-vm.lisp
@@ -9,13 +9,13 @@
 ;;;; provided with absolutely no warranty. See the COPYING and CREDITS
 ;;;; files for more information.
 (in-package "SB-VM")
-
+
 ;;; See x86-vm.lisp for a description of this.
 #-sb-xc-host
 (defun machine-type ()
   "Returns a string describing the type of the local machine."
   "SPARC")
-
+
 (defconstant-eqx +fixup-kinds+ #(:call :sethi :add :absolute) #'equalp)
 (!with-bigvec-or-sap
 (defun fixup-code-object (code offset fixup kind flavor)
@@ -38,7 +38,7 @@
               fixup))))
   nil))
 
-
+
 ;;;; "Sigcontext" access functions, cut & pasted from alpha-vm.lisp.
 ;;;;
 ;;;; See also x86-vm for commentary on signed vs unsigned.
@@ -79,7 +79,7 @@
   (declare (ignore context))
   (warn "stub CONTEXT-FLOATING-POINT-MODES")
   0)
-
+
 (defun internal-error-args (context)
   (declare (type (alien (* os-context-t)) context))
   (/show0 "entering INTERNAL-ERROR-ARGS")

--- a/src/code/stream.lisp
+++ b/src/code/stream.lisp
@@ -84,7 +84,7 @@
   (error 'closed-stream-error :stream stream))
 (defun no-op-placeholder (&rest ignore)
   (declare (ignore ignore)))
-
+
 ;;; stream manipulation functions
 
 (defstruct (broadcast-stream (:include ansi-stream
@@ -188,7 +188,7 @@
   (setf (ansi-stream-bout stream) #'closed-flame)
   (setf (ansi-stream-sout stream) #'closed-flame)
   (setf (ansi-stream-misc stream) #'closed-flame))
-
+
 ;;;; for file position and file length
 (defun external-format-char-size (external-format)
   (ef-char-size (get-external-format external-format)))
@@ -278,7 +278,7 @@
 
 (defun file-string-length (stream object)
   (funcall (ansi-stream-misc stream) stream :file-string-length object))
-
+
 ;;;; input functions
 
 (defun ansi-stream-read-line-from-frc-buffer (stream eof-error-p eof-value)
@@ -476,7 +476,7 @@
         ;; must be Gray streams FUNDAMENTAL-STREAM
         (stream-clear-input stream)))
   nil)
-
+
 #-sb-fluid (declaim (inline ansi-stream-read-byte))
 (defun ansi-stream-read-byte (stream eof-error-p eof-value recursive-p)
   ;; Why the "recursive-p" parameter?  a-s-r-b is funcall'ed from
@@ -655,7 +655,7 @@
                             count))
            (setf (ansi-stream-in-index stream) (1+ start))
            (aref ibuf start)))))
-
+
 ;;; output functions
 
 (defun write-char (character &optional (stream *standard-output*))
@@ -750,7 +750,7 @@
   ;; The STREAM argument is not allowed to be a designator.
   (%with-out-stream stream (ansi-stream-bout integer) (stream-write-byte integer))
   integer)
-
+
 
 ;;; Meta: the following comment is mostly true, but gray stream support
 ;;;   is already incorporated into the definitions within this file.
@@ -819,7 +819,7 @@
     (t
      (stream-element-type-stream-element-mode
       (stream-element-type stream)))))
-
+
 ;;;; broadcast streams
 
 (defun make-broadcast-stream (&rest streams)
@@ -920,7 +920,7 @@
                      (funcall (ansi-stream-misc stream) stream operation
                               arg1 arg2)
                      (stream-misc-dispatch stream operation arg1 arg2)))))))))
-
+
 ;;;; synonym streams
 
 (defmethod print-object ((x synonym-stream) stream)
@@ -966,7 +966,7 @@
           (t
            (funcall (ansi-stream-misc syn) syn operation arg1 arg2)))
         (stream-misc-dispatch syn operation arg1 arg2))))
-
+
 ;;;; two-way streams
 
 (defstruct (two-way-stream
@@ -1052,7 +1052,7 @@
            (if out-ansi-stream-p
                (funcall (ansi-stream-misc out) out operation arg1 arg2)
                (stream-misc-dispatch out operation arg1 arg2)))))))
-
+
 ;;;; concatenated streams
 
 (defstruct (concatenated-stream
@@ -1149,7 +1149,7 @@
          (if (ansi-stream-p current)
              (funcall (ansi-stream-misc current) current operation arg1 arg2)
              (stream-misc-dispatch current operation arg1 arg2)))))))
-
+
 ;;;; echo streams
 
 (defstruct (echo-stream
@@ -1237,7 +1237,7 @@
                        :start start :end (+ start bytes-read))
        (aver (= numbytes (+ start bytes-read)))
        numbytes))))
-
+
 ;;;; STRING-INPUT-STREAM stuff
 
 (defstruct (string-input-stream
@@ -1346,7 +1346,7 @@
       (%make-string-input-stream
        string ;; now simple
        start end))))
-
+
 ;;;; STRING-OUTPUT-STREAM stuff
 ;;;;
 ;;;; FIXME: This, like almost none of the stream code is particularly
@@ -1811,7 +1811,7 @@ benefit of the function GET-OUTPUT-STREAM-STRING."
 (defun finite-base-string-out-misc (stream operation &optional arg1 arg2)
   (declare (ignore stream operation arg1 arg2))
   (error "finite-base-string-out-misc needs an implementation"))
-
+
 ;;;; fill-pointer streams
 
 ;;; Fill pointer STRING-OUTPUT-STREAMs are not explicitly mentioned in
@@ -1949,7 +1949,7 @@ benefit of the function GET-OUTPUT-STREAM-STRING."
       (array-element-type
        (fill-pointer-output-stream-string stream)))
     (:element-mode 'character)))
-
+
 ;;;; case frobbing streams, used by FORMAT ~(...~)
 
 (defstruct (case-frob-stream
@@ -2187,7 +2187,7 @@ benefit of the function GET-OUTPUT-STREAM-STRING."
     (if (ansi-stream-p target)
         (funcall (ansi-stream-sout target) target str 0 len)
         (stream-write-string target str 0 len))))
-
+
 ;;;; Shared {READ,WRITE}-SEQUENCE support functions
 
 (declaim (inline stream-compute-io-function
@@ -2229,7 +2229,7 @@ benefit of the function GET-OUTPUT-STREAM-STRING."
            t)
       (and (typep vector '(simple-array (signed-byte 8) (*)))
            (eq (stream-element-mode stream) 'signed-byte))))
-
+
 ;;;; READ-SEQUENCE
 
 (defun read-sequence (seq stream &key (start 0) end)
@@ -2372,7 +2372,7 @@ benefit of the function GET-OUTPUT-STREAM-STRING."
           (return-from ansi-stream-read-string-from-frc-buffer start))
         (loop (add-chunk))))))
 
-
+
 ;;;; WRITE-SEQUENCE
 
 (defun write-sequence (seq stream &key (start 0) (end nil))

--- a/src/code/symbol.lisp
+++ b/src/code/symbol.lisp
@@ -449,7 +449,7 @@ distinct from the global value. Can also be SETF."
   "Return true if Object is a symbol in the \"KEYWORD\" package."
   (and (symbolp object)
        (eq (sb-xc:symbol-package object) *keyword-package*)))
-
+
 ;;;; GENSYM and friends
 
 (defvar *gentemp-counter* 0)

--- a/src/code/sysmacs.lisp
+++ b/src/code/sysmacs.lisp
@@ -70,7 +70,7 @@ maintained."
                          *gc-pending*
                          #+sb-thread *stop-for-gc-pending*)
                  (sb-unix::receive-pending-interrupt))))))))
-
+
 ;;; EOF-OR-LOSE is a useful macro that handles EOF.
 (defmacro eof-or-lose (stream eof-error-p eof-value)
   `(if ,eof-error-p
@@ -152,7 +152,7 @@ maintained."
                      (,slot ,@args)
                      ,stream-dispatch))
 
-
+
 ;;;; These are hacks to make the reader win.
 
 ;;; This macro sets up some local vars for use by the

--- a/src/code/target-alieneval.lisp
+++ b/src/code/target-alieneval.lisp
@@ -13,7 +13,7 @@
 (in-package "SB-ALIEN")
 
 (/show0 "target-alieneval.lisp 15")
-
+
 ;;;; alien variables
 
 ;;; Make a string out of the symbol, converting all uppercase letters to
@@ -187,7 +187,7 @@ This is SETFable."
                   ,@body)))
              (t
               body))))))
-
+
 ;;;; runtime C values that don't correspond directly to Lisp types
 
 (defmethod print-object ((value alien-value) stream)
@@ -215,7 +215,7 @@ This is SETFable."
   "Return a System-Area-Pointer pointing to Alien's data."
   (declare (type alien-value alien))
   (alien-value-sap alien))
-
+
 ;;;; allocation/deallocation of heap aliens
 
 (defmacro make-alien (type &optional size &environment env)
@@ -367,7 +367,7 @@ null byte."
   `(multiple-value-bind (sap bytes) (%make-alien-string ,@args)
      (values (%sap-alien sap ',(parse-alien-type '(* char) nil))
              bytes)))
-
+
 ;;;; the SLOT operator
 
 ;;; Find the field named SLOT, or die trying.
@@ -425,7 +425,7 @@ null byte."
               (field-type (alien-record-field-type field)))
          (%sap-alien (sap+ (alien-sap alien) (/ offset sb-vm:n-byte-bits))
                      (make-alien-pointer-type :to field-type)))))))
-
+
 ;;;; the DEREF operator
 
 ;;; This function does most of the work of the different DEREF
@@ -495,7 +495,7 @@ null byte."
   (multiple-value-bind (target-type offset) (deref-guts alien indices)
     (%sap-alien (sap+ (alien-value-sap alien) (/ offset sb-vm:n-byte-bits))
                 (make-alien-pointer-type :to target-type))))
-
+
 ;;;; accessing heap alien variables
 
 (defun %heap-alien (info)
@@ -515,7 +515,7 @@ null byte."
   (declare (type heap-alien-info info))
   (%sap-alien (heap-alien-info-sap info)
               (make-alien-pointer-type :to (heap-alien-info-type info))))
-
+
 ;;;; accessing local aliens
 
 (defun make-local-alien (info)
@@ -570,7 +570,7 @@ null byte."
   (unless (local-alien-info-force-to-memory-p info)
     (error "~S isn't forced to memory. Something went wrong." alien))
   alien)
-
+
 ;;;; the CAST macro
 
 (defmacro cast (alien type &environment env)
@@ -592,7 +592,7 @@ null byte."
             (naturalize (alien-value-sap alien) target-type)
             (error "~S cannot be casted." alien)))
       (error "cannot cast to alien type ~S" (unparse-alien-type target-type))))
-
+
 ;;;; the ALIEN-SIZE macro
 
 (defmacro alien-size (type &optional (units :bits) &environment env)
@@ -608,7 +608,7 @@ null byte."
                            (:words sb-vm:n-word-bits))))
         (error "unknown size for alien type ~S"
                (unparse-alien-type alien-type)))))
-
+
 ;;;; NATURALIZE, DEPORT, EXTRACT-ALIEN-VALUE, DEPOSIT-ALIEN-VALUE
 
 ;;; There is little cost to making an interpreted function,
@@ -658,7 +658,7 @@ null byte."
            (type alien-type type))
   (funcall (coerce-to-interpreted-function (compute-deposit-lambda type))
            value sap offset type))
-
+
 ;;;; ALIEN-FUNCALL, DEFINE-ALIEN-ROUTINE
 
 (defun alien-funcall (alien &rest args)
@@ -798,7 +798,7 @@ way that the argument is passed.
                      (values nil ,@(results)))
                    `((values (alien-funcall ,lisp-name ,@(alien-args))
                              ,@(results))))))))))
-
+
 (defun alien-typep (object type)
   "Return T iff OBJECT is an alien of type TYPE."
   (let ((lisp-rep-type (compute-lisp-rep-type type)))

--- a/src/code/target-c-call.lisp
+++ b/src/code/target-c-call.lisp
@@ -16,7 +16,7 @@
 ;;;; files for more information.
 
 (in-package "SB-ALIEN")
-
+
 ;;;; extra types
 
 (define-alien-type char (integer 8))
@@ -46,7 +46,7 @@
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (define-alien-type-translator void ()
     (parse-alien-type '(values) (sb-kernel:make-null-lexenv))))
-
+
 
 (defun default-c-string-external-format ()
   (or *default-c-string-external-format*

--- a/src/code/target-char.lisp
+++ b/src/code/target-char.lisp
@@ -369,7 +369,7 @@
     (#x9D "Operating-System-Command")
     (#x9E "Privacy-Message")
     (#x9F "Application-Program-Command"))) ; *** See Note above
-
+
 ;;;; UCD accessor functions
 
 ;;; The character database is made of several arrays.
@@ -544,7 +544,7 @@ name is that string, if one exists. Otherwise, NIL is returned."
                                                      **unicode-1-name-char-database**))))
                  (and char-code
                       (code-char char-code)))))))))
-
+
 ;;;; predicates
 
 (defun standard-char-p (char)
@@ -786,7 +786,7 @@ Case is ignored." t)
     "Return T if the arguments are in strictly non-increasing alphabetic order.
 Case is ignored." t))
 
-
+
 (defun digit-char-p (char &optional (radix 10.))
   "If char is a digit in the specified radix, returns the fixnum for which
 that digit stands, else returns NIL."

--- a/src/code/target-defstruct.lisp
+++ b/src/code/target-defstruct.lisp
@@ -10,7 +10,7 @@
 (in-package "SB-KERNEL")
 
 (/show0 "target-defstruct.lisp 12")
-
+
 ;;;; structure frobbing primitives
 
 ;;; Return the value from the INDEXth slot of INSTANCE. This is SETFable.
@@ -48,7 +48,7 @@
                   (incf value-index)
                   (make-case))))))))
 
-
+
 ;;;; target-only parts of the DEFSTRUCT top level code
 
 ;;; A list of hooks designating functions of one argument, the
@@ -100,7 +100,7 @@
       (funcall fun classoid)))
 
   (dd-name dd))
-
+
 ;;; Copy any old kind of structure.
 (defun copy-structure (structure)
   "Return a copy of STRUCTURE with the same (EQL) slot values."
@@ -140,7 +140,7 @@
                 (t ; bignum - use LOGBITP to avoid consing more bignums
                  (copy-loop (logbitp i bitmap))))))
       res)))
-
+
 ;;; default PRINT-OBJECT method
 
 ;;; Printing formerly called the auto-generated accessor functions,
@@ -244,5 +244,5 @@
              ,(+ (- sb-vm:instance-pointer-lowtag)
                  (* (+ sb-vm:instance-slots-offset index)
                     sb-vm:n-word-bytes))))))))
-
+
 (/show0 "target-defstruct.lisp end of file")

--- a/src/code/target-error.lisp
+++ b/src/code/target-error.lisp
@@ -223,7 +223,7 @@ with that condition (or with no condition) will be returned."
           (cerror cerror-arg condition)
           (funcall function condition)))))
 
-
+
 (defun assert-error (assertion &rest rest)
   (let* ((rest rest)
          (n-args-and-values (if (fixnump (car rest))

--- a/src/code/target-exception.lisp
+++ b/src/code/target-exception.lisp
@@ -19,7 +19,7 @@
 ;;; This file is based on target-signal.lisp, but most of that went
 ;;; away. Some of it might want to be put back or emulated.
 ;;;
-
+
 ;;; SIGINT is handled like BREAK, except that ANSI BREAK ignores
 ;;; *DEBUGGER-HOOK*, but we want SIGINT's BREAK to respect it, so that
 ;;; SIGINT in --disable-debugger mode will cleanly terminate the system
@@ -40,7 +40,7 @@
            (apply #'%break 'sigint format-string format-arguments)))
     (sb-thread:interrupt-thread (sb-thread::foreground-thread) #'break-it)))
 ||#
-
+
 ;;; Map Windows Exception code to condition names: symbols or strings
 (defvar *exception-code-map*
   (macrolet ((cons-name (symbol)
@@ -131,7 +131,7 @@
            (cerror "Return from the exception handler"
                    'exception :context context-sap :record exception-record-sap
                               :code code)))))
-
+
 
 (in-package "SB-UNIX")
 

--- a/src/code/target-extensions.lisp
+++ b/src/code/target-extensions.lisp
@@ -16,7 +16,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;; like (DELETE .. :TEST #'EQ):
 ;;;   Delete all LIST entries EQ to ITEM (destructively modifying
 ;;;   LIST), and return the modified LIST.
@@ -80,7 +80,7 @@ these hooks.")
             (warn "Problem running ~A hook ~S:~%  ~A" kind hook c)
             (with-simple-restart (continue "Skip this ~A hook." kind)
               (error "Problem running ~A hook ~S:~%  ~A" kind hook c)))))))
-
+
 ;;; Binary search for simple vectors
 (defun binary-search* (value seq key)
   (declare (simple-vector seq))
@@ -122,7 +122,7 @@ these hooks.")
                         (svref vector (truly-the index (1+ (* 2 i))))))))))
     (recurse 0 (truncate (length vector) 2))))
 
-
+
 ;;;; helpers for C library calls
 
 ;;; Signal a SIMPLE-CONDITION/ERROR condition associated with an ANSI C

--- a/src/code/target-format.lisp
+++ b/src/code/target-format.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-FORMAT")
-
+
 ;;;; FORMAT
 
 ;;; This funcallable instance is used only as plain-old-data (conveying
@@ -157,7 +157,7 @@
                          (cdr directives) orig-args args)
                 (format-error "Unknown format directive ~@[(character: ~A)~]"
                               (directive-char-name directive)))))))))))
-
+
 ;;;; FORMAT directive definition macros and runtime support
 
 ;;; This macro is used to extract the next argument from the current arg list.
@@ -218,7 +218,7 @@
             nil (caar ,params)
             "Too many parameters, expected no more than ~W" ,(length specs)))
          ,@body))))
-
+
 ;;;; format interpreters and support functions for simple output
 
 (defun format-write-field (stream string mincol colinc minpad padchar padleft)
@@ -311,7 +311,7 @@
           (*print-level* (unless atsignp *print-level*))
           (*print-length* (unless atsignp *print-length*)))
       (output-object (next-arg) stream))))
-
+
 ;;;; format interpreters and support functions for integer output
 
 ;;; FORMAT-PRINT-NUMBER does most of the work for the numeric printing
@@ -519,7 +519,7 @@
                             (- i (- cur-val cur-sub-val)))
                            (t i))))))
           ((zerop start))))
-
+
 ;;;; plural
 
 (def-format-interpreter #\P (colonp atsignp params)
@@ -534,7 +534,7 @@
       (if atsignp
           (write-string (if (eql arg 1) "y" "ies") stream)
           (unless (eql arg 1) (write-char #\s stream))))))
-
+
 ;;;; format interpreters and support functions for floating point output
 
 (defun decimal-string (n)
@@ -801,7 +801,7 @@
         (format-write-field stream
                             (princ-to-string number)
                             w 1 0 #\space t))))
-
+
 ;;;; FORMAT interpreters and support functions for line/page breaks etc.
 
 (def-format-interpreter #\% (colonp atsignp params)
@@ -840,7 +840,7 @@
   (check-modifier '("colon" "at-sign") (and colonp atsignp))
   (interpret-bind-defaults () params)
   (bug "Unreachable ~S" directives))
-
+
 ;;;; format interpreters and support functions for tabs and simple pretty
 ;;;; printing
 
@@ -900,7 +900,7 @@
   (check-modifier "at-sign" atsignp)
   (interpret-bind-defaults ((n 0)) params
     (pprint-indent (if colonp :current :block) n stream)))
-
+
 ;;;; format interpreter for ~*
 
 (def-format-interpreter #\* (colonp atsignp params)
@@ -926,7 +926,7 @@
             (interpret-bind-defaults ((n 1)) params
               (dotimes (i n)
                 (next-arg)))))))
-
+
 ;;;; format interpreter for indirection
 
 (def-format-interpreter #\? (colonp atsignp params string end)
@@ -942,7 +942,7 @@
       (if atsignp
           (setf args (%format stream (next-arg) orig-args args))
           (%format stream (next-arg) (next-arg))))))
-
+
 ;;;; format interpreters for capitalization
 
 (def-complex-format-interpreter #\( (colonp atsignp params directives)
@@ -965,7 +965,7 @@
 
 (def-complex-format-interpreter #\) ()
   (format-error "no corresponding open paren"))
-
+
 ;;;; format interpreters and support functions for conditionalization
 
 (def-complex-format-interpreter #\[ (colonp atsignp params directives)
@@ -1014,7 +1014,7 @@
 
 (def-complex-format-interpreter #\] ()
   (format-error "No corresponding open bracket"))
-
+
 ;;;; format interpreter for up-and-out
 
 (defvar *outside-args*)
@@ -1032,7 +1032,7 @@
                        (null args)))))
     (throw (if colonp 'up-up-and-out 'up-and-out)
            args)))
-
+
 ;;;; format interpreters for iteration
 
 (def-complex-format-interpreter #\{
@@ -1089,7 +1089,7 @@
 
 (def-complex-format-interpreter #\} ()
   (format-error "No corresponding open brace"))
-
+
 ;;;; format interpreters and support functions for justification
 
 (def-complex-format-interpreter #\<
@@ -1216,7 +1216,7 @@
                                         (if atsignp orig-args arg)
                                         arg))))))
   (if atsignp nil args))
-
+
 ;;;; format interpreter and support functions for user-defined method
 
 (def-format-interpreter #\/ (string start end colonp atsignp params)

--- a/src/code/target-hash-table.lisp
+++ b/src/code/target-hash-table.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; utilities
 
 ;;;; TODOs:
@@ -220,7 +220,7 @@
 (defun pointer-hash->bucket (hash mask)
   (declare (type hash hash mask))
   (truly-the index (logand mask (prefuzz-hash hash))))
-
+
 ;;;; user-defined hash table tests
 
 (defun register-hash-table-test (name hash-fun)
@@ -306,7 +306,7 @@ Examples:
              `(register-hash-table-test ',name #',hash-function))
             (t
              (error "Malformed HASH-FUNCTION: ~S" hash-function)))))
-
+
 ;;;; construction and simple accessors
 
 ;;; The smallest table holds 14 items distributed among 16 buckets.
@@ -561,7 +561,7 @@ Examples:
 multiple threads accessing the same hash-table without locking."
          hash-table))
 
-
+
 ;;;; accessing functions
 
 ;;; Make new vectors for the table, extending the table based on the
@@ -1721,7 +1721,7 @@ table itself."
               (kv-vector-high-water-mark kv-vector) 0))))
   hash-table)
 
-
+
 ;;;; methods on HASH-TABLE
 
 ;;; Return a list of keyword args and values to use for MAKE-HASH-TABLE

--- a/src/code/target-load.lisp
+++ b/src/code/target-load.lisp
@@ -20,7 +20,7 @@
   "the TRUENAME of the file that LOAD is currently loading")
 (defvar *load-pathname* nil
   "the defaulted pathname that LOAD is currently loading")
-
+
 ;;;; LOAD-AS-SOURCE
 
 ;;; something not EQ to anything we might legitimately READ
@@ -87,7 +87,7 @@
                     do (sb-c::with-source-paths
                          (eval-form form nil))))))))
   t)
-
+
 ;;;; LOAD itself
 
 (define-condition fasl-header-missing (invalid-fasl)
@@ -274,7 +274,7 @@
                      defaulted-fasl-pathname)))
           (defaulted-fasl-truename defaulted-fasl-pathname)
           (defaulted-source-truename defaulted-source-pathname))))
-
+
 ;;;; linkage fixups
 
 ;;; Lisp assembler routines are named by Lisp symbols, not strings,

--- a/src/code/target-misc.lisp
+++ b/src/code/target-misc.lisp
@@ -57,7 +57,7 @@ are running on, or NIL if we can't find any useful information."
 (defun long-site-name ()
   "Return a string with the long form of the site name, or NIL if not known."
   *long-site-name*)
-
+
 ;;;; ED
 (declaim (type list *ed-functions*))
 (defvar *ed-functions* '()
@@ -76,7 +76,7 @@ the file system."
                   :references '((:sbcl :variable *ed-functions*))))
     (when (funcall fun x)
       (return t))))
-
+
 ;;;; dribble stuff
 
 ;;; Each time we start dribbling to a new stream, we put it in

--- a/src/code/target-package.lisp
+++ b/src/code/target-package.lisp
@@ -219,7 +219,7 @@
   `(let ((,table-var *package-names*))
      (sb-thread::with-recursive-system-lock ((info-env-mutex ,table-var))
        ,@body)))
-
+
 (defmethod make-load-form ((p package) &optional environment)
   (declare (ignore environment))
   `(find-undeleted-package-or-lose ,(package-name p)))
@@ -351,7 +351,7 @@ of :INHERITED :EXTERNAL :INTERNAL."
           (package-hashtable-size table) (package-hashtable-size temp-table)
           (package-hashtable-free table) (package-hashtable-free temp-table)
           (package-hashtable-deleted table) 0)))
-
+
 ;;;; package locking operations, built unconditionally now
 
 (defun package-locked-p (package)
@@ -527,7 +527,7 @@ error if any of PACKAGES is not a valid package designator."
                               :format-arguments (cons name format-arguments))))
   name)
 
-
+
 ;;;; miscellaneous PACKAGE operations
 
 (defmethod print-object ((package package) stream)
@@ -731,7 +731,7 @@ Experimental: interface subject to change."
 
 (defun package-external-symbol-count (package)
   (%package-hashtable-symbol-count (package-external-symbols package)))
-
+
 (defvar *package* (error "*PACKAGE* should be initialized in cold load!")
   "the current package")
 
@@ -806,7 +806,7 @@ REMOVE-PACKAGE-LOCAL-NICKNAME, and the DEFPACKAGE option :LOCAL-NICKNAMES."
 ;;; FIND-UNDELETED-PACKAGE-OR-LOSE.
 (defun package-name (package-designator)
   (package-%name (%find-package-or-lose package-designator)))
-
+
 ;;;; operations on package hashtables
 
 ;;; Add a symbol to a package hashtable. The symbol MUST NOT be present.
@@ -950,7 +950,7 @@ REMOVE-PACKAGE-LOCAL-NICKNAME, and the DEFPACKAGE option :LOCAL-NICKNAMES."
     (declare (type fixnum size deleted used))
     (when (< used (truncate size 4))
       (resize-package-hashtable table (* used 2)))))
-
+
 ;;; Enter any new NICKNAMES for PACKAGE into *PACKAGE-NAMES*. If there is a
 ;;; conflict then give the user a chance to do something about it.
 ;;; Package names do not affect the uses/used-by relation,
@@ -1192,7 +1192,7 @@ implementation it is ~S." *!default-package-use-list*)
   (let ((result ()))
     (do-packages (package) (push package result))
     result))
-
+
 ;;; Check internal and external symbols, then scan down the list
 ;;; of hashtables for inherited symbols.
 (defun %find-symbol (string length package)
@@ -1336,7 +1336,7 @@ implementation it is ~S." *!default-package-use-list*)
     (with-symbol ((symbol) (package-external-symbols package) string length hash)
       (return-from find-external-symbol symbol)))
   0)
-
+
 (define-condition name-conflict (reference-condition package-error)
   ((function :initarg :function :reader name-conflict-function)
    (datum :initarg :datum :reader name-conflict-datum)
@@ -1493,7 +1493,7 @@ uninterned."
                      (%set-symbol-package symbol nil))
                  t)
                 (t nil)))))))
-
+
 ;;; Take a symbol-or-list-of-symbols and return a list, checking types.
 (defun symbol-listify (thing)
   (cond ((listp thing)
@@ -1510,7 +1510,7 @@ uninterned."
 
 (defun string-listify (thing)
   (mapcar #'string (ensure-list thing)))
-
+
 (defun export (symbols &optional (package (sane-package)))
   "Exports SYMBOLS from PACKAGE, checking that no name conflicts result."
   (with-package-graph ()
@@ -1564,7 +1564,7 @@ uninterned."
             (add-symbol external sym)
             (nuke-symbol internal sym))))
       t)))
-
+
 ;;; Check that all symbols are accessible, then move from external to internal.
 (defun unexport (symbols &optional (package (sane-package)))
   "Makes SYMBOLS no longer exported from PACKAGE."
@@ -1590,7 +1590,7 @@ uninterned."
             (add-symbol internal sym)
             (nuke-symbol external sym))))
       t)))
-
+
 ;;; Check for name conflict caused by the import and let the user
 ;;; shadowing-import if there is.
 ;;;
@@ -1643,7 +1643,7 @@ the importation, then a correctable error is signalled."
         (dolist (sym homeless)
           (%set-symbol-package sym package))
         t))))
-
+
 ;;; If a conflicting symbol is present, unintern it, otherwise just
 ;;; stick the symbol in.
 (defun shadowing-import (symbols &optional (package (sane-package)))
@@ -1700,7 +1700,7 @@ it is not already present."
                 (add-symbol internal s))
               (pushnew s (package-%shadowing-symbols package))))))))
   t)
-
+
 ;;; Do stuff to use a package, with all kinds of fun name-conflict checking.
 (defun use-package (packages-to-use &optional (package (sane-package)))
   "Add all the PACKAGES-TO-USE to the use list for PACKAGE so that the
@@ -1791,7 +1791,7 @@ PACKAGE."
       (multiple-value-bind (symbol found) (find-symbol string package)
         (when found (pushnew symbol result))))
     result))
-
+
 ;;;; APROPOS and APROPOS-LIST
 
 (defun briefly-describe-symbol (symbol)
@@ -1838,7 +1838,7 @@ PACKAGE."
   (dolist (symbol (apropos-list string-designator package external-only))
     (briefly-describe-symbol symbol))
   (values))
-
+
 ;;;; final initialization
 
 ;;;; Due to the relative difficulty - but not impossibility - of manipulating

--- a/src/code/target-pathname.lisp
+++ b/src/code/target-pathname.lisp
@@ -228,7 +228,7 @@
                                            escape-char :escape-dot t))))
       (apply #'concatenate 'simple-string (strings)))))
 
-
+
 ;;; To be initialized in unix/win32-pathname.lisp
 (define-load-time-global *physical-host* nil)
 
@@ -237,7 +237,7 @@
 ;;; initialized (at which time we can't safely call e.g. #'PATHNAME).
 (defun make-trivial-default-pathname ()
   (%%make-pathname *physical-host* nil nil nil nil :newest))
-
+
 ;;; pathname methods
 
 ;;; SXHASH does a really poor job on pathname directory, especially if in your
@@ -273,7 +273,7 @@
 
 (defmethod make-load-form ((pathname pathname) &optional environment)
   (make-load-form-saving-slots pathname :environment environment))
-
+
 ;;; A pathname is logical if the host component is a logical host.
 ;;; This constructor is used to make an instance of the correct type
 ;;; from parsed arguments.
@@ -299,7 +299,7 @@
 ;;; physical pathname translation.
 (define-load-time-global *logical-hosts*
     (make-hash-table :test 'equal :synchronized t))
-
+
 ;;;; patterns
 
 (defmethod make-load-form ((pattern pattern) &optional environment)
@@ -448,7 +448,7 @@
          (and (consp that)
               (compare-component (car this) (car that))
               (compare-component (cdr this) (cdr that)))))))
-
+
 ;;;; pathname functions
 
 (defun pathname= (pathname1 pathname2)
@@ -917,7 +917,7 @@ a host-structure or string."
   "Return PATHNAME's version."
   (with-pathname (pathname pathname)
     (%pathname-version pathname)))
-
+
 ;;;; namestrings
 
 ;;; Handle the case for PARSE-NAMESTRING parsing a potentially
@@ -1230,7 +1230,7 @@ relative to DEFAULTS."
       (let ((host (pathname-host-or-no-namestring pathname)))
         (with-pathname (defaults defaults)
           (funcall (host-unparse-enough host) pathname defaults))))))
-
+
 ;;;; wild pathnames
 
 (defun wild-pathname-p (pathname &optional field-key)
@@ -1493,7 +1493,7 @@ unspecified elements into a completed to-pathname based on the to-wildname."
                        (%pathname-version source)
                        (%pathname-version to))
                    (frob %pathname-version)))))))))
-
+
 ;;;;  logical pathname support. ANSI 92-102 specification.
 ;;;;
 ;;;;  As logical-pathname translations are loaded they are
@@ -1580,7 +1580,7 @@ unspecified elements into a completed to-pathname based on the to-wildname."
                (new (make-logical-host :name name)))
           (setf (gethash name *logical-hosts*) new)
           new))))
-
+
 ;;;; logical pathname parsing
 
 ;;; Deal with multi-char wildcards in a logical pathname token.
@@ -1760,7 +1760,7 @@ unspecified elements into a completed to-pathname based on the to-wildname."
                     (%pathname-host *logical-pathname-defaults*))
             (oops "no host specified"))
           res))))
-
+
 ;;;; logical pathname unparsing
 
 (defun unparse-logical-directory (pathname)
@@ -1868,7 +1868,7 @@ unspecified elements into a completed to-pathname based on the to-wildname."
                (logical-host-name (%pathname-host pathname)) ":"
                (unparse-logical-directory pathname)
                (unparse-logical-file pathname)))
-
+
 ;;;; logical pathname translations
 
 ;;; Verify that the list of translations consists of lists and prepare

--- a/src/code/target-random.lisp
+++ b/src/code/target-random.lisp
@@ -16,7 +16,7 @@
 ;;;; files for more information.
 
 (in-package "SB-KERNEL")
-
+
 ;;;; Constants
 (defconstant mt19937-n 624)
 (defconstant mt19937-m 397)
@@ -240,7 +240,7 @@ http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
          (incf i) (when (>= i mt19937-n) (setf (aref s 3) (aref s (+ 2 mt19937-n)) i 1)))
        (setf (aref s 3) #x80000000) ;; MSB is 1; assuring non-zero initial array
        (%make-random-state s))))))
-
+
 ;;;; random entries
 
 ;;; This function generates a 32bit integer between 0 and #xffffffff
@@ -307,7 +307,7 @@ http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
   (declare (type random-state state))
   (logior (ash (random-chunk state) 32)
           (random-chunk state)))
-
+
 ;;; Handle the single or double float case of RANDOM. We generate a
 ;;; float between 0.0 and 1.0 by clobbering the significand of 1.0
 ;;; with random bits, then subtracting 1.0. This hides the fact that
@@ -367,7 +367,7 @@ http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
            (sb-vm::random-mt19937 state-vector))
           $1d0))))
 
-
+
 ;;;; random fixnums
 
 ;;; Generate and return a pseudo random fixnum less than ARG. To achieve

--- a/src/code/target-signal.lisp
+++ b/src/code/target-signal.lisp
@@ -45,7 +45,7 @@
     (alien-funcall %unblock-gc-signals 0 0)
     nil))
 
-
+
 ;;;; C routines that actually do all the work of establishing signal handlers
 (define-alien-routine ("install_handler" install-handler)
   unsigned-long
@@ -111,7 +111,7 @@
 
 (defun ignore-interrupt (signal)
   (enable-interrupt signal :ignore))
-
+
 ;;;; Support for signal handlers which aren't.
 ;;;;
 ;;;; On safepoint builds, user-defined Lisp signal handlers do not run
@@ -134,7 +134,7 @@
                 (funcall run-handler signal info context)))
       (sb-thread::new-lisp-thread-trampoline thread nil #'callback nil))))
 
-
+
 ;;;; default LISP signal handlers
 ;;;;
 ;;;; Most of these just call ERROR to report the presence of the signal.
@@ -247,7 +247,7 @@
   #-sb-safepoint (unblock-gc-signals)
   (unblock-deferrable-signals)
   (values))
-
+
 ;;;; etc.
 
 ;;; extract si_code from siginfo_t

--- a/src/code/target-sxhash.lisp
+++ b/src/code/target-sxhash.lisp
@@ -18,7 +18,7 @@
 ;;; when we descend into a compound object or when we step through elements of
 ;;; a compound object.
 (defconstant +max-hash-depthoid+ 4)
-
+
 ;;;; mixing hash values
 
 ;;; a function for mixing hash values
@@ -109,7 +109,7 @@
   (logand (setf (aref state 0) (mix (address-based-counter-val) (aref state 0)))
           mask))
 
-
+
 ;;;; hashing strings
 ;;;;
 ;;;; Note that this operation is used in compiler symbol table
@@ -183,7 +183,7 @@
     ;; The generated code seems tight enough, and the comment is, after all,
     ;; >14 years old.
     (%sxhash-simple-substring string start end)))
-
+
 ;;;; the SXHASH function
 
 ;; simple cases
@@ -408,7 +408,7 @@
                     9550684))
                (t 42))))
     (sxhash-recurse x +max-hash-depthoid+)))
-
+
 ;;;; the PSXHASH function
 
 ;;;; FIXME: This code does a lot of unnecessary full calls. It could be made

--- a/src/code/target-thread.lisp
+++ b/src/code/target-thread.lisp
@@ -344,7 +344,7 @@ See also: RETURN-FROM-THREAD and SB-EXT:EXIT."
            ;; We /could/ use TOPLEVEL-CATCHER or %END-OF-THE-WORLD as well, but
            ;; this seems tidier. Those to are a bit too overloaded already.
            (throw '%abort-thread t)))))
-
+
 
 ;;;; Aliens, low level stuff
 
@@ -413,7 +413,7 @@ See also: RETURN-FROM-THREAD and SB-EXT:EXIT."
          ;; previous wait marks using WITHOUT-DEADLOCKS below.
          (setf (thread-waiting-for ,n-thread) nil)
          (barrier (:write))))))
-
+
 ;;;; Mutexes
 
 (setf (documentation 'make-mutex 'function) "Create a mutex."
@@ -834,7 +834,7 @@ IF-NOT-OWNER is :FORCE)."
           (with-pinned-objects (mutex)
             (futex-wake (mutex-state-address mutex) 1))))
       nil)))
-
+
 
 ;;;; Waitqueues/condition variables
 
@@ -1096,7 +1096,7 @@ must be held by this thread during this call."
                     ;; results in -1, which wakes up only one thread.
                     (ldb (byte 29 0)
                          sb-xc:most-positive-fixnum)))
-
+
 
 ;;;; Semaphores
 
@@ -1262,7 +1262,7 @@ on this semaphore, then N of them is woken up."
           (count (incf (semaphore-%count semaphore) n)))
       (when (plusp waitcount)
         (condition-notify (semaphore-queue semaphore) (min waitcount count))))))
-
+
 
 ;;;; Job control, independent listeners
 
@@ -1512,7 +1512,7 @@ session."
                         (sb-impl::toplevel-repl nil)
                      (flush-standard-output-streams))))))
       (make-thread #'thread-repl))))
-
+
 
 ;;;; The beef
 
@@ -1993,7 +1993,7 @@ mechanism for inter-thread communication."
                  :info (list :write :unbound-in-thread))
           (values nil nil))))
 
-
+
 
 ;;;; Stepping
 

--- a/src/code/target-type.lisp
+++ b/src/code/target-type.lisp
@@ -12,7 +12,7 @@
 (in-package "SB-KERNEL")
 
 (!begin-collecting-cold-init-forms)
-
+
 ;;; If TYPE is a type that we can do a compile-time test on, then
 ;;; return whether the object is of that type as the first value and
 ;;; second value true. Otherwise return NIL, NIL.
@@ -114,7 +114,7 @@
             (multiple-value-bind (ok result)
                 (sb-c::constant-function-call-p form nil nil)
               (values (not (null result)) ok)))))))))
-
+
 ;;;; miscellaneous interfaces
 
 ;;; Clear memoization of all type system operations that can be
@@ -232,7 +232,7 @@
                      :complexp (not (simple-array-p array))
                      :element-type etype
                      :specialized-element-type etype)))
-
+
 (!defun-from-collected-cold-init-forms !target-type-cold-init)
 
 ;;;; Some functions for examining the type system

--- a/src/code/target-unicode.lisp
+++ b/src/code/target-unicode.lisp
@@ -363,7 +363,7 @@ disappears when accents are placed on top of it. and NIL otherwise"
           #(#x0600 #x0604 #x06DD #x06DD #x070F #x070F #xFFF9 #xFFFB
             #x110BD #x110BD)))))))
 
-
+
 ;;; Implements UAX#15: Normalization Forms
 (declaim (inline char-decomposition-info))
 (defun char-decomposition-info (char)
@@ -614,7 +614,7 @@ only characters for which it returns T are collected."
   ;; FIXME: can be optimized
   (string= string (normalize-string string form)))
 
-
+
 ;;; Unicode case algorithms
 ;; FIXME: Make these parts less redundant (macro?)
 (sb-ext:define-load-time-global **special-titlecases**
@@ -826,7 +826,7 @@ for case-insensitive comparisons.
 The result is not guaranteed to have the same length as the input."
   (string-somethingcase #'char-foldcase string (constantly nil)))
 
-
+
 ;;; Unicode break algorithms
 ;;; In all the breaking methods:
 ;;; (brk) establishes a break between `first` and `second`
@@ -1353,7 +1353,7 @@ it defaults to 80 characters"
       (setf last-break-distance nil))
    next))
 
-
+
 ;;; Collation
 (defconstant +maximum-variable-primary-element+
   #.(sb-cold:read-from-file "output/other-collation-info.lisp-expr"))
@@ -1527,7 +1527,7 @@ with variable-weight characters, as described in UTS #10"
    (unicode> string1 string2 :start1 start1 :end1 end1
              :start2 start2 :end2 end2)))
 
-
+
 ;;; Confusable detection
 
 (defun canonically-deconfuse (string)

--- a/src/code/time.lisp
+++ b/src/code/time.lisp
@@ -24,7 +24,7 @@ time format. (See INTERNAL-TIME-UNITS-PER-SECOND.)")
 INTERNAL-TIME-UNITS-PER-SECOND.) This is useful for finding CPU usage.
 Includes both \"system\" and \"user\" time."
   (system-internal-run-time))
-
+
 ;;;; Encode and decode universal times.
 
 ;;; In August 2003, work was done in this file for more plausible
@@ -241,7 +241,7 @@ format."
                   (truncate-to-unix-range guess))))
           (setf encoded-time (+ guess (- secwest secwest-guess)))))
     encoded-time))
-
+
 ;;;; TIME
 
 (defvar *gc-run-time* 0

--- a/src/code/toplevel.lisp
+++ b/src/code/toplevel.lisp
@@ -41,7 +41,7 @@ pathname designator or a stream for the default userinit file, or NIL.
 If the function returns NIL, no userinit file is used unless one has
 been specified on the command-line.")
 
-
+
 ;;;; miscellaneous utilities for working with with TOPLEVEL
 
 ;;; Execute BODY in a context where any %END-OF-THE-WORLD (thrown e.g.
@@ -92,7 +92,7 @@ means to wait indefinitely.")
                  (sb-thread::%exit-other-threads)
                  (setf ok t))
             (os-exit code :abort (not ok)))))))
-
+
 ;;;; miscellaneous external functions
 
 (declaim (inline split-ratio-for-sleep))
@@ -204,7 +204,7 @@ any non-negative real number."
           (sleep-for-a-bit timeout)))
       (%sleep seconds))
   nil)
-
+
 ;;;; the default toplevel function
 
 (defvar / nil
@@ -654,7 +654,7 @@ that provides the REPL for the system. Assumes that *STANDARD-INPUT* and
                 (prin1 result)))))
      ;; If we started stepping in the debugger we want to stop now.
      (disable-stepping))))
-
+
 ;;; a convenient way to get into the assembly-level debugger
 (defun %halt ()
   (%primitive sb-c:halt))

--- a/src/code/unix.lisp
+++ b/src/code/unix.lisp
@@ -38,7 +38,7 @@
         (if c-string
             (push c-string reversed-result)
             (return (nreverse reversed-result)))))))
-
+
 ;;;; Lisp types used by syscalls
 
 (deftype unix-pathname () 'simple-string)
@@ -48,7 +48,7 @@
 (deftype unix-pid () '(unsigned-byte 32))
 (deftype unix-uid () '(unsigned-byte 32))
 (deftype unix-gid () '(unsigned-byte 32))
-
+
 ;;;; system calls
 
 (/show0 "unix.lisp 74")
@@ -106,7 +106,7 @@ SYSCALL-FORM. Repeat evaluation of SYSCALL-FORM if it is interrupted."
 #+win32
 (progn
   (defconstant espipe 29))
-
+
 ;;;; hacking the Unix environment
 
 #-win32
@@ -114,7 +114,7 @@ SYSCALL-FORM. Repeat evaluation of SYSCALL-FORM if it is interrupted."
   "Return the \"value\" part of the environment string \"name=value\" which
 corresponds to NAME, or NIL if there is none."
   (name (c-string :not-null t)))
-
+
 ;;; from stdio.h
 
 ;;; Rename the file with string NAME1 to the string NAME2. NIL and an
@@ -125,7 +125,7 @@ corresponds to NAME, or NIL if there is none."
   (void-syscall ("rename" (c-string :not-null t)
                           (c-string :not-null t))
                 name1 name2))
-
+
 ;;; from sys/types.h and gnu/types.h
 
 (/show0 "unix.lisp 220")
@@ -143,8 +143,8 @@ corresponds to NAME, or NIL if there is none."
                                         sb-vm:n-machine-word-bits)))))
 
 (/show0 "unix.lisp 304")
-
-
+
+
 ;;;; fcntl.h
 ;;;;
 ;;;; POSIX Standard: 6.5 File Control Operations        <fcntl.h>
@@ -178,7 +178,7 @@ corresponds to NAME, or NIL if there is none."
   #+win32 (sb-win32:unixlike-close fd)
   #-win32 (declare (type unix-fd fd))
   #-win32 (void-syscall ("close" int) fd))
-
+
 ;;;; stdlib.h
 
 ;;; There are good reasons to implement some OPEN options with an
@@ -202,7 +202,7 @@ corresponds to NAME, or NIL if there is none."
             (values nil (get-errno))
             (values #-win32 fd #+win32 (sb-win32::duplicate-and-unwrap-fd fd)
                     (octets-to-string template-buffer)))))))
-
+
 ;;;; resourcebits.h
 
 (defconstant rusage_self 0) ; the calling process
@@ -227,7 +227,7 @@ corresponds to NAME, or NIL if there is none."
     (ru-nsignals long)              ; signals received
     (ru-nvcsw long)                 ; voluntary context switches
     (ru-nivcsw long)))              ; involuntary context switches
-
+
 ;;;; unistd.h
 
 ;;; Given a file path (a string) and one of four constant modes,
@@ -534,7 +534,7 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
   (declare (type unix-fd fd)
            (type word cmd))
   (void-syscall ("ioctl" int unsigned-long (* char)) fd cmd arg))
-
+
 ;;;; sys/resource.h
 
 ;;; FIXME: All we seem to need is the RUSAGE_SELF version of this.
@@ -586,7 +586,7 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
                       (slot usage 'ru-nvcsw)
                       (slot usage 'ru-nivcsw))
               who (addr usage))))
-
+
 (defvar *on-dangerous-wait* :warn)
 
 ;;; Calling select in a bad place can hang in a nasty manner, so it's better
@@ -609,7 +609,7 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
                type)
        (sb-debug:print-backtrace)))
     nil))
-
+
 ;;;; poll.h
 #+os-provides-poll
 (progn
@@ -649,7 +649,7 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
                 (or (and (eql 1 count) (logtest events revents))
                     (logtest pollhup revents)))
               (error "Syscall poll(2) failed: ~A" (strerror))))))))
-
+
 ;;;; sys/select.h
 
 (defmacro with-fd-setsize ((n) &body body)
@@ -802,7 +802,7 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
         ((0) nil)
         (otherwise
          (error "Syscall select(2) failed on fd ~D: ~A" fd (strerror)))))))
-
+
 ;;;; sys/stat.h
 
 ;;; This is a structure defined in src/runtime/wrap.c, to look
@@ -916,7 +916,7 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
       (#.s-iflnk :link)
       (#.s-ififo :fifo)
       (t :unknown))))
-
+
 ;;;; time.h
 
 ;; used by other time functions
@@ -956,7 +956,7 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
   (alien-funcall (extern-alien "sb_nanosleep_float" (function (values) float))
                  seconds)
   nil)
-
+
 ;;;; sys/time.h
 
 ;;; Structure crudely representing a timezone. KLUDGE: This is
@@ -965,7 +965,7 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
   (struct timezone
     (tz-minuteswest int)                ; minutes west of Greenwich
     (tz-dsttime int)))                  ; type of dst correction
-
+
 
 ;; Type of the second argument to `getitimer' and
 ;; the second and third arguments `setitimer'.
@@ -1035,14 +1035,14 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
                         (slot (slot itvo 'it-value) 'tv-usec))
                 which (alien-sap (addr itvn))(alien-sap (addr itvo))))))
 
-
+
 ;;; FIXME: Many Unix error code definitions were deleted from the old
 ;;; CMU CL source code here, but not in the exports of SB-UNIX. I
 ;;; (WHN) hope that someday I'll figure out an automatic way to detect
 ;;; unused symbols in package exports, but if I don't, there are
 ;;; enough of them all in one place here that they should probably be
 ;;; removed by hand.
-
+
 (defconstant micro-seconds-per-internal-time-unit
   (/ 1000000 sb-xc:internal-time-units-per-second))
 
@@ -1157,7 +1157,7 @@ the UNIX epoch (January 1st 1970.)"
                                  (floor micro-seconds-per-internal-time-unit 2))
                               micro-seconds-per-internal-time-unit))))
         result))))
-
+
 ;;; FIXME, KLUDGE: GET-TIME-OF-DAY used to be UNIX-GETTIMEOFDAY, and had a
 ;;; primary return value indicating sucess, and also returned timezone
 ;;; information -- though the timezone data was not there on Darwin.
@@ -1169,7 +1169,7 @@ the UNIX epoch (January 1st 1970.)"
   #+win32 (declare (notinline get-time-of-day)) ; forward ref
   (multiple-value-bind (sec usec) (get-time-of-day)
     (values t sec usec nil nil)))
-
+
 ;;;; opendir, readdir, closedir, and dirent-name
 
 (declaim (inline unix-opendir))
@@ -1216,7 +1216,7 @@ the UNIX epoch (January 1st 1970.)"
   (alien-funcall
    (extern-alien "sb_dirent_name" (function c-string system-area-pointer))
    ent))
-
+
 ;;;; A magic constant for wait3().
 ;;;;
 ;;;; FIXME: This used to be defined in run-program.lisp as

--- a/src/code/warm-mswin.lisp
+++ b/src/code/warm-mswin.lisp
@@ -1,6 +1,6 @@
 ;;;; Windows API bindings not needed for cold initialization.
 (in-package "SB-WIN32")
-
+
 ;;;; CreateProcess and surrounding data structures provide a way to implement
 ;;;; RUN-PROGRAM while using handles rather than file descriptors.
 

--- a/src/code/x86-64-vm.lisp
+++ b/src/code/x86-64-vm.lisp
@@ -13,7 +13,7 @@
 (defun machine-type ()
   "Return a string describing the type of the local machine."
   "X86-64")
-
+
 ;;;; :CODE-OBJECT fixups
 
 ;;; This gets called by LOAD to resolve newly positioned objects
@@ -74,7 +74,7 @@
        ;; but core relocation can't - it can't find all the call sites.
        (if (eq kind :relative) :relative))))
   nil) ; non-immobile-space builds never record code fixups
-
+
 #+(or darwin linux openbsd win32 sunos)
 (define-alien-routine ("os_context_float_register_addr" context-float-register-addr)
   (* unsigned) (context (* os-context-t)) (index int))
@@ -146,7 +146,7 @@
 
 (defun (setf floating-point-modes) (val) (%floating-point-modes-setter val))
 
-
+
 ;;;; INTERNAL-ERROR-ARGS
 
 ;;; Given a (POSIX) signal context, extract the internal error
@@ -160,7 +160,7 @@
         (values #.(error-number-or-lose 'invalid-arg-count-error)
                 '(#.arg-count-sc))
         (sb-kernel::decode-internal-error-args (sap+ pc 1) trap-number))))
-
+
 
 #+immobile-code
 (progn

--- a/src/code/x86-vm.lisp
+++ b/src/code/x86-vm.lisp
@@ -14,7 +14,7 @@
 (defun machine-type ()
   "Return a string describing the type of the local machine."
   "X86")
-
+
 ;;;; :CODE-OBJECT fixups
 
 ;;; This gets called by LOAD to resolve newly positioned objects
@@ -48,7 +48,7 @@
        ;; Relative fixups point outside of this object. Keep them all.
        (aver (or (< fixup obj-start-addr) (> fixup code-end-addr)))
        t))))
-
+
 ;;;; low-level signal context access functions
 ;;;;
 ;;;; Note: In CMU CL, similar functions were hardwired to access
@@ -111,7 +111,7 @@
 (define-alien-routine ("os_context_fp_control" context-floating-point-modes)
     (sb-alien:unsigned 32)
   (context (* os-context-t)))
-
+
 ;;;; INTERNAL-ERROR-ARGS
 
 ;;; Given a (POSIX) signal context, extract the internal error
@@ -122,7 +122,7 @@
          (trap-number (sap-ref-8 pc 0)))
     (declare (type system-area-pointer pc))
     (sb-kernel::decode-internal-error-args (sap+ pc 1) trap-number)))
-
+
 ;;; This is used in error.lisp to insure that floating-point exceptions
 ;;; are properly trapped. The compiler translates this to a VOP.
 (defun float-wait ()

--- a/src/cold/ansify.lisp
+++ b/src/cold/ansify.lisp
@@ -9,7 +9,7 @@
 ;;;; public domain. The software is in the public domain and is
 ;;;; provided with absolutely no warranty. See the COPYING and CREDITS
 ;;;; files for more information.
-
+
 ;;;; CLISP issues
 
 ;;; as explained on #lisp ca. October 2003:
@@ -37,7 +37,7 @@
 #+clisp
 (ext:without-package-lock ("SYSTEM")
   (setf system::*inhibit-floating-point-underflow* t))
-
+
 ;;;; CMU CL issues
 
 ;;; CMU CL, at least as of 18b, doesn't support PRINT-OBJECT. In
@@ -65,7 +65,7 @@
 
 #+(and cmu sparc)
 (ext:set-floating-point-modes :traps '(:overflow :invalid :divide-by-zero))
-
+
 ;;;; OpenMCL issues
 
 ;;; This issue in OpenMCL led to some SBCL bug reports ca. late 2003.

--- a/src/cold/compile-cold-sbcl.lisp
+++ b/src/cold/compile-cold-sbcl.lisp
@@ -69,7 +69,7 @@
 (setf *target-compile-file* #'sb-xc:compile-file)
 (setf *target-assemble-file* #'sb-c:assemble-file)
 (setf *in-target-compilation-mode-fn* #'in-target-cross-compilation-mode)
-
+
 ;; Update the xc-readtable
 (set-macro-character #\` #'sb-impl::backquote-charmacro nil *xc-readtable*)
 (set-macro-character #\, #'sb-impl::comma-charmacro nil *xc-readtable*)

--- a/src/cold/shared.lisp
+++ b/src/cold/shared.lisp
@@ -103,7 +103,7 @@
 ;;; SB-C:ASSEMBLE-FILE, to be used to translate assembly files into target
 ;;; object files
 (defvar *target-assemble-file*)
-
+
 ;;;; some tools
 
 ;;; Take the file named X and make it into a file named Y. Sorta like
@@ -173,7 +173,7 @@
             (satisfies unable-to-optimize-note-p)
             (satisfies optional+key-style-warning-p)
             sb-ext:code-deletion-note)))
-
+
 ;;;; special read-macros for building the cold system (and even for
 ;;;; building some of our tools for building the cold system)
 
@@ -307,7 +307,7 @@
   (when failed-test-descriptions
     (error "Feature compatibility check failed, ~S"
            failed-test-descriptions)))
-
+
 ;;;; cold-init-related PACKAGE and SYMBOL tools
 
 ;;; Once we're done with possibly ANSIfying the COMMON-LISP package,
@@ -320,7 +320,7 @@
 (when (member :sb-show sb-xc:*features*)
   (load "src/cold/snapshot.lisp")
   (setq *cl-snapshot* (take-snapshot "COMMON-LISP")))
-
+
 ;;;; master list of source files and their properties
 
 ;;; flags which can be used to describe properties of source files
@@ -470,7 +470,7 @@
           (error "found unexpected flag(s) in *STEMS-AND-FLAGS*: ~S"
                  set-difference)))))
   (cdr *stems-and-flags*))
-
+
 ;;;; tools to compile SBCL sources to create the cross-compiler
 
 ;;; a wrapper for compilation/assembly, used mostly to centralize
@@ -633,7 +633,7 @@
    (with-simple-restart (recompile "Reload")
      (return (load (stem-object-path stem flags :host-compile))))))
 (compile 'host-load-stem)
-
+
 ;;;; tools to compile SBCL sources to create object files which will
 ;;;; be used to create the target SBCL .core file
 

--- a/src/cold/shebang.lisp
+++ b/src/cold/shebang.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-COLD")
-
+
 ;;;; definition of #+ and #- as a mechanism analogous to #+/#-, but
 ;;;; for SB-XC:*FEATURES* instead of CL:*FEATURES*. (This is handy
 ;;;; when cross-compiling, so that we can make a distinction between
@@ -138,7 +138,7 @@
                            (funcall 'read-target-float stream char))
                      t ; non-terminating so that symbols may contain a dollar sign
                      *xc-readtable*)
-
+
 ;;;; variables like SB-XC:*FEATURES* but different
 
 ;;; This variable is declared here (like SB-XC:*FEATURES*) so that
@@ -151,7 +151,7 @@
 (export '*shebang-backend-subfeatures*)
 (declaim (type list *shebang-backend-subfeatures*))
 (defvar *shebang-backend-subfeatures*)
-
+
 ;;;; string checker, for catching non-portability early
 
 ;;; A note about CLISP compatibility:

--- a/src/cold/warm.lisp
+++ b/src/cold/warm.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "COMMON-LISP-USER")
-
+
 ;;;; general warm init compilation policy
 
 ;;;; Use the same settings as PROCLAIM-TARGET-OPTIMIZATION
@@ -74,7 +74,7 @@
                  "FLOAT CACHE LINE ~S vs COMPUTED ~S~%"
                  expr actual)))))))))
 
-
+
 ;;;; compiling and loading more of the system
 
 ;;; FIXME: CMU CL's pclcom.lisp had extra optional stuff wrapped around

--- a/src/compiler/aliencomp.lisp
+++ b/src/compiler/aliencomp.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; DEFKNOWNs
 
 (defknown %sap-alien (system-area-pointer alien-type) alien-value
@@ -76,7 +76,7 @@
     (movable flushable))
 (defknown sb-alien::c-string-external-format * *
         (movable flushable))
-
+
 ;;;; cosmetic transforms
 
 (deftransform slot ((object slot)
@@ -90,7 +90,7 @@
 (deftransform %slot-addr ((object slot)
                           ((alien (* t)) symbol))
   '(%slot-addr (deref object) slot))
-
+
 ;;;; SLOT support
 
 (defun find-slot-offset-and-type (alien slot)
@@ -165,7 +165,7 @@
     (/noshow "in DEFTRANSFORM %SLOT-ADDR, creating %SAP-ALIEN")
     `(%sap-alien (sap+ (alien-sap alien) (/ ,slot-offset sb-vm:n-byte-bits))
                  ',(make-alien-pointer-type :to slot-type))))
-
+
 ;;;; DEREF support
 
 (defun find-deref-alien-type (alien)
@@ -290,7 +290,7 @@
     `(lambda (alien ,@indices-args)
        (%sap-alien (sap+ (alien-sap alien) (/ ,offset-expr sb-vm:n-byte-bits))
                    ',(make-alien-pointer-type :to element-type)))))
-
+
 ;;;; support for aliens on the heap
 
 (defun heap-alien-sap-and-type (info)
@@ -341,7 +341,7 @@
     (/noshow "in DEFTRANSFORM %HEAP-ALIEN-ADDR, creating %SAP-ALIEN")
     `(%sap-alien ,sap ',(make-alien-pointer-type :to type))))
 
-
+
 ;;;; support for local (stack or register) aliens
 
 (defun alien-info-constant-or-abort (info)
@@ -432,7 +432,7 @@
     (if (local-alien-info-force-to-memory-p info)
         `(%sap-alien var ',(make-alien-pointer-type :to alien-type))
         (error "This shouldn't happen."))))
-
+
 ;;;; %CAST
 
 (defoptimizer (%cast derive-type) ((alien type))
@@ -454,7 +454,7 @@
            `(naturalize (alien-sap alien) ',target-type))
           (t
            (abort-ir1-transform "cannot cast to alien type ~S" target-type)))))
-
+
 ;;;; ALIEN-SAP, %SAP-ALIEN, %ADDR, etc.
 
 (deftransform alien-sap ((alien))
@@ -478,7 +478,7 @@
   "optimize away %SAP-ALIEN"
   (give-up-ir1-transform
    "forced to do runtime allocation of alien-value structure"))
-
+
 ;;;; NATURALIZE/DEPORT/EXTRACT/DEPOSIT magic
 
 (flet ((%computed-lambda (compute-lambda type)
@@ -502,7 +502,7 @@
     (%computed-lambda #'compute-extract-lambda type))
   (deftransform (setf %alien-value) ((value sap offset type))
     (%computed-lambda #'compute-deposit-lambda type)))
-
+
 ;;;; a hack to clean up divisions
 
 (defun count-low-order-zeros (thing)
@@ -589,7 +589,7 @@
                          ,(1- (ash 1 (+ width (lvar-value amount))))))
               `(lambda (value amount1 amount2)
                  (ash value (+ amount1 amount2)))))))))
-
+
 ;;;; ALIEN-FUNCALL support
 
 (deftransform alien-funcall ((function &rest args)

--- a/src/compiler/alpha/alloc.lisp
+++ b/src/compiler/alpha/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; LIST and LIST*
 (define-vop (list-or-list*)
   (:args (things :more t))
@@ -73,7 +73,7 @@
 
 (define-vop (list* list-or-list*)
   (:variant t))
-
+
 ;;;; special purpose inline allocators
 
 (define-vop (make-fdefn)
@@ -122,7 +122,7 @@
     (with-fixed-allocation
         (result temp value-cell-widetag value-cell-size)
       (storew value result value-cell-value-slot other-pointer-lowtag))))
-
+
 ;;;; automatic allocators for primitive objects
 
 (define-vop (make-unbound-marker)

--- a/src/compiler/alpha/arith.lisp
+++ b/src/compiler/alpha/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; unary operations
 
 (define-vop (fixnum-unop)
@@ -48,7 +48,7 @@
   (:translate lognot)
   (:generator 2
     (inst not x res)))
-
+
 ;;;; binary fixnum operations
 
 ;;; Assume that any constant operand is the second arg...
@@ -179,7 +179,7 @@
     (ecase y
       (#xffffffff (inst mskll x 4 r))
       (#xffffffff00000000 (inst mskll x 0 r)))))
-
+
 ;;;; shifting
 
 (define-vop (fast-ash/unsigned=>unsigned)
@@ -362,7 +362,7 @@
     (inst and num mask num)
     (inst and temp mask temp)
     (inst addq num temp res)))
-
+
 ;;;; multiplying
 
 (define-vop (fast-*/fixnum=>fixnum fast-fixnum-binop)
@@ -381,7 +381,7 @@
   (:translate *)
   (:generator 3
     (inst mulq x y r)))
-
+
 ;;;; Modular functions:
 (define-modular-fun lognot-mod64 (x) lognot :untagged nil 64)
 (define-vop (lognot-mod64/unsigned=>unsigned)
@@ -431,7 +431,7 @@
   `(lognot (logand ,x ,y)))
 (define-source-transform lognor (x y)
   `(lognot (logior ,x ,y)))
-
+
 ;;;; binary conditional VOPs
 
 (define-vop (fast-conditional)
@@ -591,7 +591,7 @@
   (:arg-types * (:constant (signed-byte 6)))
   (:variant-cost 6))
 
-
+
 ;;;; 32-bit logical operations
 
 (define-vop (shift-towards-someplace)
@@ -617,7 +617,7 @@
   (:generator 1
     (inst and amount #x1f temp)
     (inst sll num temp r)))
-
+
 ;;;; bignum stuff
 
 (define-vop (bignum-length get-header-data)

--- a/src/compiler/alpha/array.lisp
+++ b/src/compiler/alpha/array.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; allocator for the array header
 (define-vop (make-array-header)
   (:policy :fast-safe)
@@ -35,7 +35,7 @@
       (inst bis alloc-tn other-pointer-lowtag result)
       (storew header result 0 other-pointer-lowtag)
       (inst addq alloc-tn bytes alloc-tn))))
-
+
 ;;;; additional accessors and setters for the array header
 (define-full-reffer %array-dimension *
   array-dimensions-offset other-pointer-lowtag
@@ -56,7 +56,7 @@
     (inst sra temp n-widetag-bits temp)
     (inst subq temp (1- array-dimensions-offset) temp)
     (inst sll temp n-fixnum-tag-bits res)))
-
+
 ;;;; bounds checking routine
 (define-vop (check-bound)
   (:translate %check-bound)
@@ -73,7 +73,7 @@
       (%test-fixnum index temp error t)
       (inst cmpult index bound temp)
       (inst beq temp error))))
-
+
 ;;;; accessors/setters
 
 ;;; Variants built on top of word-index-ref, etc. I.e. those vectors
@@ -413,7 +413,7 @@
              other-pointer-lowtag) lip)
     (unless (location= result value)
       (inst fmove value result))))
-
+
 ;;; complex float arrays
 
 (define-vop (data-vector-ref/simple-array-complex-single-float)
@@ -524,7 +524,7 @@
       (unless (location= result-imag value-imag)
         (inst fmove value-imag result-imag)))))
 
-
+
 ;;; These vops are useful for accessing the bits of a vector irrespective of
 ;;; what type of vector it is.
 ;;;

--- a/src/compiler/alpha/call.lisp
+++ b/src/compiler/alpha/call.lisp
@@ -54,7 +54,7 @@
 ;;; passed when we are using non-standard conventions.
 (defun make-arg-count-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn nargs-offset))
-
+
 ;;;; frame hackery
 
 ;;; Return the number of bytes needed for the current non-descriptor
@@ -298,7 +298,7 @@ default-value-8
         (when lra-label
           (inst compute-code-from-lra code-tn code-tn lra-label temp))))
   (values))
-
+
 ;;;; unknown values receiving
 
 ;;; Emit code needed at the return point for an unknown-values call
@@ -361,7 +361,7 @@ default-value-8
                :from :eval :to (:result 1))
               nvals)
   (:temporary (:scs (non-descriptor-reg)) temp))
-
+
 ;;; This hook by the codegen lets us insert code before fall-thru entry points,
 ;;; local-call entry points, and tail-call entry points.  The default does
 ;;; nothing.
@@ -371,7 +371,7 @@ default-value-8
     (emit-label trampoline-label))
   (emit-label start-label))
 
-
+
 ;;;; local call with unknown values convention return
 
 ;;; Non-TR local call for a fixed number of values passed according to the
@@ -457,7 +457,7 @@ default-value-8
       (receive-unknown-values values-start nvals start count label temp)
       (maybe-load-stack-nfp-tn cur-nfp nfp-save temp))))
 
-
+
 ;;;; local call with known values return
 
 ;;; Non-TR local call with known return locations. Known-value return
@@ -524,7 +524,7 @@ default-value-8
     (inst subq return-pc-temp (- other-pointer-lowtag n-word-bytes) lip)
     (move ocfp-temp cfp-tn)
     (inst ret zero-tn lip 1)))
-
+
 ;;;; full call:
 ;;;;
 ;;;; There is something of a cross-product effect with full calls.
@@ -851,7 +851,7 @@ default-value-8
     ;; And jump to the assembly-routine that does the bliting.
     (inst li (make-fixup 'tail-call-variable :assembly-routine) temp)
     (inst jmp zero-tn temp)))
-
+
 ;;;; unknown values return
 
 ;;; Return a single value using the unknown-values convention.
@@ -992,7 +992,7 @@ default-value-8
       (move nvals-arg nvals)
       (inst li (make-fixup 'return-multiple :assembly-routine) temp)
       (inst jmp zero-tn temp))))
-
+
 ;;;; XEP hackery
 
 ;;; Get the lexical environment from its passing location.

--- a/src/compiler/alpha/cell.lisp
+++ b/src/compiler/alpha/cell.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; data object ref/set stuff
 
 (define-vop (slot)
@@ -39,7 +39,7 @@
 (define-vop (init-slot set-slot)
   (:info name dx-p offset lowtag)
   (:ignore name dx-p))
-
+
 ;;;; symbol hacking VOPs
 
 ;;; The compiler likes to be able to directly SET symbols.
@@ -111,7 +111,7 @@
   (:translate sym-global-val))
 (define-vop (fast-symbol-global-value fast-symbol-value)
   (:translate sym-global-val))
-
+
 ;;;; fdefinition (FDEFN) objects
 
 (define-vop (fdefn-fun cell-ref)
@@ -167,7 +167,7 @@
     (inst li (make-fixup 'undefined-tramp :assembly-routine) temp)
     (move fdefn result)
     (storew temp fdefn fdefn-raw-addr-slot other-pointer-lowtag)))
-
+
 ;;;; binding and Unbinding
 
 ;;; Establish VAL as a binding for SYMBOL. Save the old value and the
@@ -228,7 +228,7 @@
       (inst beq temp loop)
 
       (emit-label done))))
-
+
 ;;;; closure indexing
 
 (define-full-reffer closure-index-ref *
@@ -262,7 +262,7 @@
   (:info offset)
   (:generator 4
     (storew cfp-tn object (+ closure-info-offset offset) fun-pointer-lowtag)))
-
+
 ;;;; value cell hackery
 
 (define-vop (value-cell-ref cell-ref)
@@ -270,7 +270,7 @@
 
 (define-vop (value-cell-set cell-set)
   (:variant value-cell-value-slot other-pointer-lowtag))
-
+
 ;;;; instance hackery
 
 (define-vop (instance-length)
@@ -288,7 +288,7 @@
 
 (define-full-setter instance-index-set * instance-slots-offset
   instance-pointer-lowtag (descriptor-reg any-reg null zero) * %instance-set)
-
+
 ;;;; code object frobbing
 
 (define-full-reffer code-header-ref * 0 other-pointer-lowtag
@@ -296,7 +296,7 @@
 
 (define-full-setter code-header-set * 0 other-pointer-lowtag
   (descriptor-reg any-reg null zero) * code-header-set)
-
+
 ;;;; mutator accessing
 
 #+gengc
@@ -407,7 +407,7 @@
 ); #+gengc progn
 
 
-
+
 ;;;; raw instance slot accessors
 
 (define-vop (raw-instance-ref/word)

--- a/src/compiler/alpha/char.lisp
+++ b/src/compiler/alpha/char.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; moves and coercions
 
 ;;; Move a tagged char to an untagged representation.
@@ -65,7 +65,7 @@
 ;;;
 (define-move-vop move-arg :move-arg
   (character-reg) (any-reg descriptor-reg))
-
+
 ;;;; other operations
 (define-vop (char-code)
   (:translate char-code)
@@ -86,7 +86,7 @@
   (:result-types character)
   (:generator 1
     (inst srl code n-fixnum-tag-bits res)))
-
+
 ;;;; comparison of CHARACTERs
 
 (define-vop (character-compare)

--- a/src/compiler/alpha/float.lisp
+++ b/src/compiler/alpha/float.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; float move functions
 
 (define-move-fun (load-fp-zero 1) (vop x y)
@@ -37,7 +37,7 @@
   (let ((nfp (current-nfp-tn vop))
         (offset (tn-byte-offset y)))
     (inst stt x offset nfp)))
-
+
 ;;;; float move VOPs
 
 (macrolet ((frob (vop sc)
@@ -122,7 +122,7 @@
                   (,sc descriptor-reg) (,sc)))))
   (frob move-single-float-arg single-reg single-stack nil)
   (frob move-double-float-arg double-reg double-stack t))
-
+
 ;;;; complex float move functions
 
 (defun complex-single-reg-real-tn (x)
@@ -361,7 +361,7 @@
   (single-reg double-reg complex-single-reg complex-double-reg)
   (descriptor-reg))
 
-
+
 ;;;; float arithmetic VOPs
 
 (define-vop (float-op)
@@ -429,7 +429,7 @@
   (frob %negate/single-float fneg %negate single-reg single-float)
   (frob %negate/double-float fneg %negate double-reg double-float))
 
-
+
 ;;;; float comparison
 
 (define-vop (float-compare)
@@ -477,7 +477,7 @@
   (frob > t >/single-float >/double-float nil)
   (frob = nil =/single-float =/double-float t))
 
-
+
 ;;;; float conversion
 
 (macrolet
@@ -741,10 +741,10 @@
               other-pointer-lowtag)))
     (inst mskll lo-bits 4 lo-bits)))
 
-
+
 ;;;; float mode hackery has moved to alpha-vm.lisp
 
-
+
 ;;;; complex float VOPs
 
 (define-vop (make-complex-single-float)

--- a/src/compiler/alpha/insts.lisp
+++ b/src/compiler/alpha/insts.lisp
@@ -20,7 +20,7 @@
             sb-vm::zero-tn sb-vm::fp-single-zero-tn sb-vm::fp-double-zero-tn
             sb-vm::zero-offset sb-vm::null-offset sb-vm::code-offset)))
 
-
+
 ;;;; utility functions
 
 (defun reg-tn-encoding (tn)
@@ -42,7 +42,7 @@
      (unless (eq (sb-name (sc-sb (tn-sc tn))) 'float-registers)
        (error "~S isn't a floating-point register." tn))
      (tn-offset tn))))
-
+
 ;;;; initial disassembler setup
 
 (defvar *disassem-use-lisp-reg-names* t)
@@ -97,7 +97,7 @@
                (declare (type (signed-byte 21) value)
                         (type disassem-state dstate))
                (+ 4 (ash value 2) (dstate-cur-addr dstate))))
-
+
 ;;;; DEFINE-INSTRUCTION-FORMATs for the disassembler
 
 (define-instruction-format (memory 32
@@ -165,7 +165,7 @@
   ;; semi-traditional prefilter approach.
   (code :prefilter (lambda (dstate) (read-suffix 32 dstate))
         :reader bugchk-trap-code))
-
+
 ;;;; emitters
 
 (define-bitfield-emitter emit-word 16
@@ -195,7 +195,7 @@
 
 (define-bitfield-emitter emit-pal 32
   (byte 6 26) (byte 26 0))
-
+
 ;;;; macros for instructions
 
 (macrolet ((define-memory (name op &optional fixup float)
@@ -577,7 +577,7 @@
 (define-instruction-macro li (value reg)
   `(%li ,value ,reg))
 
-
+
 ;;;;
 
 (define-instruction lword (segment lword)

--- a/src/compiler/alpha/macros.lisp
+++ b/src/compiler/alpha/macros.lisp
@@ -19,7 +19,7 @@
          ((,gensym ()
             ,expr))
        (,gensym))))
-
+
 ;;; instruction-like macros
 
 ;;; c.f. x86 backend:
@@ -112,7 +112,7 @@
      (inst lra-header-word)))
 
 
-
+
 ;;;; stack TN's
 
 ;;;    Move a stack TN to a register and vice-versa.
@@ -157,7 +157,7 @@
             (loadw ,n-reg cfp-tn (tn-offset ,n-stack))
             (inst mskll nsp-tn 0 ,temp)
             (inst bis ,temp ,n-reg ,n-reg))))))))
-
+
 ;;;; storage allocation
 
 ;;; Do stuff to allocate an other-pointer object of fixed SIZE with a
@@ -185,7 +185,7 @@
     (inst addq csp-tn n-word-bytes csp-tn)
     (storew zero-tn csp-tn -1)
     (emit-label aligned)))
-
+
 ;;;; error code
 (defun emit-error-break (vop kind code values)
   (assemble ()
@@ -204,7 +204,7 @@
       (emit-label start-lab)
       (apply #'error-call vop error-code values)
       start-lab)))
-
+
 ;;; a handy macro for making sequences look atomic
 (defmacro pseudo-atomic ((&key (extra 0)) &rest forms)
   `(progn
@@ -212,7 +212,7 @@
      ,@forms
      (inst lda alloc-tn (1- ,extra) alloc-tn)
      (inst stl zero-tn 0 alloc-tn)))
-
+
 ;;;; memory accessor vop generators
 
 (sb-xc:deftype load/store-index (scale lowtag min-offset

--- a/src/compiler/alpha/move.lisp
+++ b/src/compiler/alpha/move.lisp
@@ -74,7 +74,7 @@
    (unsigned-reg) (unsigned-stack))
   (let ((nfp (current-nfp-tn vop)))
     (storeq x nfp (tn-offset y))))
-
+
 ;;;; the MOVE VOP
 
 (define-vop (move)
@@ -113,7 +113,7 @@
 (define-move-vop move-arg :move-arg
   (any-reg descriptor-reg null zero)
   (any-reg descriptor-reg))
-
+
 ;;;; moves and coercions
 ;;;;
 ;;;; These MOVE-TO-WORD VOPs move a tagged integer to a raw full-word

--- a/src/compiler/alpha/nlx.lisp
+++ b/src/compiler/alpha/nlx.lisp
@@ -16,7 +16,7 @@
 ;;; non-local entry.
 (defun make-nlx-entry-arg-start-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn ocfp-offset))
-
+
 ;;;; save and restoring the dynamic environment
 ;;;;
 ;;;; These VOPs are used in the reentered function to restore the
@@ -73,7 +73,7 @@
   (:args (nsp :scs (any-reg descriptor-reg)))
   (:generator 1
     (move nsp-tn nsp)))
-
+
 ;;;; unwind block hackery
 
 ;;; Compute the address of the catch block from its TN, then store
@@ -144,7 +144,7 @@
     (load-symbol-value block *current-unwind-protect-block*)
     (loadw block block unwind-block-uwp-slot)
     (store-symbol-value block *current-unwind-protect-block*)))
-
+
 ;;;; NLX entry VOPs
 
 (define-vop (nlx-entry)

--- a/src/compiler/alpha/parms.lisp
+++ b/src/compiler/alpha/parms.lisp
@@ -103,7 +103,7 @@
 ); eval-when
 
 
-
+
 ;;;; Description of the target address space.
 
 ;;; Where to put the different spaces.
@@ -132,7 +132,7 @@
 ;;; the X86 port defines *nil-value* as (+ *target-static-space-start* #xB)
 ;;; here, but it seems to be the only port that needs to know the
 ;;; location of NIL from lisp.
-
+
 ;;;; other miscellaneous constants
 
 (defenum (:start 8)
@@ -148,7 +148,7 @@
   single-step-around-trap
   single-step-before-trap
   error-trap)
-
+
 ;;;; static symbols
 
 ;;; These symbols are loaded into static space directly after NIL so

--- a/src/compiler/alpha/pred.lisp
+++ b/src/compiler/alpha/pred.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; the Branch VOP
 
 ;;; The unconditional branch, emitted when we can't drop through to
@@ -21,7 +21,7 @@
   (:generator 5
     (inst br zero-tn dest)))
 
-
+
 ;;;; Generic conditional VOPs
 
 ;;; The generic conditional branch, emitted immediately after test
@@ -37,7 +37,7 @@
   (declare (ignore node dst-tn x-tn y-tn))
   nil)
 
-
+
 ;;;; conditional VOPs
 
 (define-vop (if-eq)

--- a/src/compiler/alpha/sap.lisp
+++ b/src/compiler/alpha/sap.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; moves and coercions
 
 ;;; Move a tagged SAP to an untagged representation.
@@ -69,7 +69,7 @@
 ;;; descriptor passing location.
 (define-move-vop move-arg :move-arg
   (sap-reg) (descriptor-reg))
-
+
 ;;;; SAP-INT and INT-SAP
 
 (define-vop (sap-int)
@@ -91,7 +91,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move int sap)))
-
+
 ;;;; POINTER+ and POINTER-
 
 (define-vop (pointer+)
@@ -119,7 +119,7 @@
   (:result-types signed-num)
   (:generator 1
     (inst subq ptr1 ptr2 res)))
-
+
 ;;;; mumble-SYSTEM-REF and mumble-SYSTEM-SET
 
 (macrolet ((def-system-ref-and-set
@@ -340,7 +340,7 @@
     single-reg single-float :single)
   (def-system-ref-and-set sap-ref-double %set-sap-ref-double
     double-reg double-float :double))
-
+
 ;;; noise to convert normal Lisp data objects into SAPs
 
 (define-vop (vector-sap)

--- a/src/compiler/alpha/subprim.lisp
+++ b/src/compiler/alpha/subprim.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; LENGTH
 
 (define-vop (length/list)

--- a/src/compiler/alpha/system.lisp
+++ b/src/compiler/alpha/system.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; type frobbing VOPs
 
 (define-vop (widetag-of)
@@ -123,7 +123,7 @@
     (inst sll ptr 35 res)
     (inst srl res 33 res)))
 
-
+
 ;;;; allocation
 
 (define-vop (dynamic-space-free-pointer)
@@ -150,7 +150,7 @@
   (:generator 1
     (move csp-tn int)))
 
-
+
 ;;;; code object frobbing
 
 (define-vop (code-instructions)
@@ -178,7 +178,7 @@
     (inst addq ndescr offset ndescr)
     (inst subq ndescr (- other-pointer-lowtag fun-pointer-lowtag) ndescr)
     (inst addq code ndescr func)))
-
+
 ;;;; other random VOPs.
 
 (defknown sb-unix::receive-pending-interrupt () (values))
@@ -196,7 +196,7 @@
 (define-vop (istream-memory-barrier)
   (:generator 1
     (inst imb)))
-
+
 ;;;; dynamic vop count collection support
 
 (define-vop (count-me)

--- a/src/compiler/alpha/type-vops.lisp
+++ b/src/compiler/alpha/type-vops.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (defun %test-fixnum (value temp target not-p)
   (assemble ()
     (inst and value fixnum-tag-mask temp)
@@ -164,7 +164,7 @@
             (inst blt temp target)
             (inst bge temp target))))
     NOT-TARGET))
-
+
 ;;;; List/symbol types:
 ;;;
 ;;; symbolp (or symbol (eq nil))

--- a/src/compiler/alpha/vm.lisp
+++ b/src/compiler/alpha/vm.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; defining the registers
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -224,7 +224,7 @@
 
   (catch-block control-stack :element-size catch-block-size)
   (unwind-block control-stack :element-size unwind-block-size))
-
+
 ;;; Make some random tns for important registers.
 (macrolet ((defregtn (name sc)
              (let ((offset-sym (symbolicate name "-OFFSET"))
@@ -260,7 +260,7 @@
   (make-random-tn :kind :normal
                   :sc (sc-or-lose 'double-reg)
                   :offset 31))
-
+
 ;;; If value can be represented as an immediate constant, then return
 ;;; the appropriate SC number, otherwise return NIL.
 (defun immediate-constant-sc (value)
@@ -290,7 +290,7 @@
       (eql sc null-sc-number)
       (eql sc immediate-sc-number)))
 
-
+
 ;;;; function call parameters
 
 ;;; the SC numbers for register and stack arguments/return values
@@ -322,7 +322,7 @@
 
 ;;; This is used by the debugger.
 (defconstant single-value-return-byte-offset 4)
-
+
 ;;; This function is called by debug output routines that want a
 ;;; pretty name for a TN's location. It returns a thing that can be
 ;;; printed with PRINC.

--- a/src/compiler/arm/alloc.lisp
+++ b/src/compiler/arm/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (define-vop (list-or-list*)
   (:args (things :more t :scs (control-stack)))
   (:temporary (:scs (descriptor-reg)) ptr)
@@ -66,7 +66,7 @@
 
 (define-vop (list* list-or-list*)
   (:variant t))
-
+
 ;;;; Special purpose inline allocators.
 
 (define-vop (make-fdefn)
@@ -120,7 +120,7 @@
     (with-fixed-allocation (result pa-flag value-cell-widetag
                             value-cell-size :stack-allocate-p stack-allocate-p)
       (storew value result value-cell-value-slot other-pointer-lowtag))))
-
+
 ;;;; Automatic allocators for primitive objects.
 
 (define-vop (make-unbound-marker)

--- a/src/compiler/arm/arith.lisp
+++ b/src/compiler/arm/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; unary operations.
 
 (define-vop (fast-safe-arith-op)
@@ -66,7 +66,7 @@
   (:generator 2
     (inst mvn res x)))
 
-
+
 ;;;; Binary fixnum operations.
 
 ;;; Assume that any constant operand is the second arg...
@@ -247,7 +247,7 @@
   `(logior (lognot ,x) ,y))
 (define-source-transform logorc2 (x y)
   `(logior ,x (lognot ,y)))
-
+
 ;;; Shifting
 
 (define-vop (fast-ash-left-c/fixnum=>fixnum)

--- a/src/compiler/arm/array.lisp
+++ b/src/compiler/arm/array.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Allocator for the array header.
 
 (define-vop (make-array-header)
@@ -62,7 +62,7 @@
         (load-immediate-word pa-flag header-bits)
         (storew pa-flag header 0 other-pointer-lowtag)))
     (move result header)))
-
+
 ;;;; Additional accessors and setters for the array header.
 (define-full-reffer %array-dimension *
   array-dimensions-offset other-pointer-lowtag
@@ -323,7 +323,7 @@
     (inst fstd value (@ lip))
     (unless (location= result value)
       (inst fcpyd result value))))
-
+
 ;;; Complex float arrays.
 
 (define-vop (data-vector-ref/simple-array-complex-single-float)
@@ -417,7 +417,7 @@
       (inst fstd value-imag (@ lip (* 2 n-word-bytes)))
       (unless (location= result-imag value-imag)
         (inst fcpyd result-imag value-imag)))))
-
+
 ;;; These vops are useful for accessing the bits of a vector irrespective of
 ;;; what type of vector it is.
 (define-full-reffer vector-raw-bits * vector-data-offset other-pointer-lowtag

--- a/src/compiler/arm/c-call.lisp
+++ b/src/compiler/arm/c-call.lisp
@@ -161,7 +161,7 @@
               (invoke-alien-type-method :result-tn
                                         (alien-fun-type-result-type type)
                                         (make-result-state))))))
-
+
 (define-vop (foreign-symbol-sap)
   (:translate foreign-symbol-sap)
   (:policy :fast-safe)
@@ -339,7 +339,7 @@
                                               :result-type result-type)
                                            ,@(new-args))))))
         (sb-c::give-up-ir1-transform))))
-
+
 ;;; Callback
 #-sb-xc-host
 (defun alien-callback-accessor-form (type sap offset)

--- a/src/compiler/arm/call.lisp
+++ b/src/compiler/arm/call.lisp
@@ -62,7 +62,7 @@
 ;;; passed when we are using non-standard conventions.
 (defun make-arg-count-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn nargs-offset))
-
+
 ;;;; Frame hackery:
 
 ;;; Return the number of bytes needed for the current non-descriptor
@@ -261,7 +261,7 @@
         ;; Deallocate the callee stack frame.
         (store-csp ocfp-tn))))
   (values))
-
+
 ;;;; Unknown values receiving:
 
 ;;;    Emit code needed at the return point for an unknown-values call for an
@@ -311,7 +311,7 @@
                :from :eval :to (:result 1))
               nvals)
   (:temporary (:scs (non-descriptor-reg)) temp))
-
+
 ;;; This hook in the codegen pass lets us insert code before fall-thru entry
 ;;; points, local-call entry points, and tail-call entry points.  The default
 ;;; does nothing.
@@ -321,7 +321,7 @@
     (emit-label trampoline-label))
   (emit-label start-label))
 
-
+
 ;;;; XEP hackery:
 
 ;;; Get the lexical environment from its passing location.
@@ -600,7 +600,7 @@
              ((plusp min)
               (inst cmp nargs (maybe-load-immediate min))
               (inst b :lo err-lab)))))))
-
+
 ;;;; Local call with unknown values convention return:
 
 ;;; Non-TR local call for a fixed number of values passed according to the
@@ -694,7 +694,7 @@
       (receive-unknown-values values-start nvals start count label temp lip)
       (when cur-nfp
         (load-stack-tn cur-nfp nfp-save)))))
-
+
 ;;;; Local call with known values return:
 
 ;;; Non-TR local call with known return locations.  Known-value return works
@@ -760,7 +760,7 @@
         (move nsp-tn cur-nfp)))
     (move cfp-tn old-fp-temp)
     (lisp-return return-pc-temp :known)))
-
+
 ;;;; Full call:
 ;;;
 ;;; There is something of a cross-product effect with full calls.
@@ -1051,7 +1051,7 @@
         (emit-label fixup-lab)
         (inst word (make-fixup 'tail-call-variable :assembly-routine)))
       (inst load-from-label pc-tn lip fixup-lab))))
-
+
 ;;;; Unknown values return:
 
 ;;; Return a single value using the unknown-values convention.
@@ -1177,7 +1177,7 @@
     (inst ldr pc-tn (@ fixup))
     FIXUP
     (inst word (make-fixup 'return-multiple :assembly-routine))))
-
+
 ;;; Single-stepping
 
 (define-vop (step-instrument-before-vop)

--- a/src/compiler/arm/cell.lisp
+++ b/src/compiler/arm/cell.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Data object ref/set stuff.
 
 (define-vop (slot)
@@ -34,7 +34,7 @@
 (define-vop (init-slot set-slot)
   (:info name dx-p offset lowtag)
   (:ignore name dx-p))
-
+
 ;;;; Symbol hacking VOPs:
 
 ;;; The compiler likes to be able to directly SET symbols.
@@ -105,7 +105,7 @@
   (:translate sym-global-val))
 (define-vop (fast-symbol-global-value fast-symbol-value)
   (:translate sym-global-val))
-
+
 ;;;; Fdefinition (fdefn) objects.
 
 (define-vop (fdefn-fun cell-ref)
@@ -165,7 +165,7 @@
       (move result fdefn))))
 
 
-
+
 ;;;; Binding and Unbinding.
 
 ;;; BIND -- Establish VAL as a binding for SYMBOL.  Save the old value and
@@ -227,7 +227,7 @@
 
     DONE
     (store-symbol-value bsp-temp *binding-stack-pointer*)))
-
+
 ;;;; Closure indexing.
 
 (define-full-reffer closure-index-ref *
@@ -261,7 +261,7 @@
   (:info offset)
   (:generator 4
     (storew cfp-tn object (+ closure-info-offset offset) fun-pointer-lowtag)))
-
+
 ;;;; Value Cell hackery.
 
 (define-vop (value-cell-ref cell-ref)
@@ -269,7 +269,7 @@
 
 (define-vop (value-cell-set cell-set)
   (:variant value-cell-value-slot other-pointer-lowtag))
-
+
 ;;;; Instance hackery:
 
 (define-vop (instance-length)
@@ -288,7 +288,7 @@
 
 (define-full-setter instance-index-set * instance-slots-offset
   instance-pointer-lowtag (descriptor-reg any-reg null) * %instance-set)
-
+
 ;;;; Code object frobbing.
 
 (define-full-reffer code-header-ref * 0 other-pointer-lowtag

--- a/src/compiler/arm/char.lisp
+++ b/src/compiler/arm/char.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged char to an untagged representation.

--- a/src/compiler/arm/float.lisp
+++ b/src/compiler/arm/float.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Move functions:
 
 (define-move-fun (load-single 1) (vop x y)
@@ -32,7 +32,7 @@
   (let ((nfp (current-nfp-tn vop))
         (offset (tn-byte-offset y)))
     (inst fstd x (@ nfp offset))))
-
+
 ;;;; Move VOPs:
 
 (macrolet ((frob (vop sc move-macro)
@@ -110,7 +110,7 @@
                   (,sc descriptor-reg) (,sc)))))
   (frob move-single-float-arg single-reg single-stack nil)
   (frob move-double-float-arg double-reg double-stack t))
-
+
 ;;;; Complex float move functions
 
 (defun complex-single-reg-real-tn (x)
@@ -155,7 +155,7 @@
         (offset (tn-byte-offset y)))
     (inst add lr-tn nfp offset)
     (inst store-complex-double x (@ lr-tn))))
-
+
 ;;;
 ;;; Complex float register to register moves.
 ;;;
@@ -282,7 +282,7 @@
          (inst store-complex-double x (@ lip)))))))
 (define-move-vop move-complex-double-float-arg :move-arg
   (complex-double-reg descriptor-reg) (complex-double-reg))
-
+
 ;;;; Unboxed-to-boxed MOVE-ARG handling:
 
 ;; This little gem here says to use the VOP MOVE-ARG to move any float
@@ -292,7 +292,7 @@
 (define-move-vop move-arg :move-arg
   (single-reg double-reg complex-single-reg complex-double-reg)
   (descriptor-reg))
-
+
 ;;;; Arithmetic VOPs:
 
 (define-vop (float-op)
@@ -370,7 +370,7 @@
   (:save-p :compute-only)
   (:generator 1
     (inst fsqrts y x)))
-
+
 ;;;; Comparison:
 
 (define-vop (float-compare)
@@ -459,7 +459,7 @@
   (frob < :mi </single-float-zero </double-float-zero nil)
   (frob > :gt >/single-float-zero >/double-float-zero nil)
   (frob = :eq eql/single-float-zero eql/double-float-zero t))
-
+
 ;;;; Conversion:
 
 (macrolet ((frob (name translate inst from-sc from-type to-sc to-type)
@@ -658,7 +658,7 @@
                                 (if (eq *backend-byte-order* :big-endian)
                                     1 0))
                other-pointer-lowtag)))))
-
+
 ;;;; Float mode hackery:
 
 (sb-xc:deftype float-modes () '(unsigned-byte 32))
@@ -684,7 +684,7 @@
   (:generator 3
     (inst fmxr :fpscr new)
     (move res new)))
-
+
 ;;;; Complex float VOPs
 
 (define-vop (make-complex-single-float)

--- a/src/compiler/arm/insts.lisp
+++ b/src/compiler/arm/insts.lisp
@@ -21,7 +21,7 @@
   (import '(sb-vm:nil-value sb-vm::registers sb-vm::null-tn sb-vm::null-offset
             sb-vm::pc-tn sb-vm::pc-offset sb-vm::code-offset)))
 
-
+
 
 (defconstant-eqx +conditions+
   '((:eq . 0)
@@ -49,7 +49,7 @@
 
 (defun conditional-opcode (condition)
   (cdr (assoc condition +conditions+ :test #'eq)))
-
+
 ;;;; disassembler field definitions
 
 (define-arg-type condition-code :printer #'print-condition)
@@ -75,7 +75,7 @@
 (define-arg-type load/store-register :printer #'print-load/store-register)
 
 (define-arg-type msr-field-mask :printer #'print-msr-field-mask)
-
+
 ;;;; disassembler instruction format definitions
 
 (define-instruction-format (dp-shift-immediate 32
@@ -308,7 +308,7 @@
 (define-instruction-format (conditional 32 :default-printer '(:name cond))
   (cond :field (byte 4 28) :type 'condition-code)
   (op :field (byte 28 0)))
-
+
 ;;;; primitive emitters
 
 ;(define-bitfield-emitter emit-word 16
@@ -316,7 +316,7 @@
 
 (define-bitfield-emitter emit-word 32
   (byte 32 0))
-
+
 ;;;; miscellaneous hackery
 
 (defun register-p (thing)
@@ -366,7 +366,7 @@
 (define-instruction lra-header-word (segment)
   (:emitter
    (emit-header-data segment return-pc-widetag)))
-
+
 ;;;; Addressing mode 1 support
 
 ;;; Addressing mode 1 has some 11 formats.  These are immediate,
@@ -541,7 +541,7 @@
                     (progn ,@(composite))))
               (composite))))))
 
-
+
 ;;;; Addressing mode 2 support
 
 ;;; Addressing mode 2 ostensibly has 9 formats.  These are formed from
@@ -591,7 +591,7 @@
                         :up))
          (offset (if (eq direction :down) (cadr offset) offset)))
     `(%@ ,base ,offset ,direction ,mode)))
-
+
 ;;;; Data-processing instructions
 
 ;;; Data processing instructions have a 4-bit opcode field and a 1-bit
@@ -689,7 +689,7 @@
 (define-data-processing-instruction movs #x1b t nil)
 (define-data-processing-instruction mvn  #x1e t nil)
 (define-data-processing-instruction mvns #x1f t nil)
-
+
 ;;;; Exception-generating instructions
 
 ;;; There are two exception-generating instructions.  One, BKPT, is
@@ -729,7 +729,7 @@
             :default :control #'debug-trap-control)
   (:emitter
    (emit-word segment #+linux #xe7f001f0 #+netbsd #xe7ffdefe)))
-
+
 ;;;; Miscellaneous arithmetic instructions
 
 (define-bitfield-emitter emit-clz-instruction 32
@@ -750,7 +750,7 @@
                            (tn-offset dest)
                            #b11110001
                            (tn-offset src)))))
-
+
 ;;;; Branch instructions
 
 (define-bitfield-emitter emit-branch-instruction 32
@@ -805,7 +805,7 @@
                                        (conditional-opcode condition)
                                        #b00010010 #b1111 #b1111
                                        #b1111 #b0011 (tn-offset dest)))))
-
+
 ;;;; Semaphore instructions
 
 (defun emit-semaphore-instruction (segment opcode condition dest value address)
@@ -830,7 +830,7 @@
    (with-condition-defaulted (args (condition dest value address))
      (emit-semaphore-instruction segment #b10100
                                  condition dest value address))))
-
+
 ;;;; Status-register instructions
 
 (define-instruction mrs (segment &rest args)
@@ -886,7 +886,7 @@
                             (if (logbitp 4 field-mask) #b10110 #b10010)
                             field-mask #b1111
                             (ldb (byte 12 0) encoded-src))))))
-
+
 ;;;; Multiply instructions
 
 (define-bitfield-emitter emit-multiply-instruction 32
@@ -954,7 +954,7 @@
 
   (define-multiply-instruction smulwb :dzsm #b00010010 #b1010)
   (define-multiply-instruction smulwt :dzsm #b00010010 #b1110))
-
+
 ;;;; Load/store instructions
 
 ;;; Emit a load/store instruction.  CONDITION is a condition code
@@ -1136,7 +1136,7 @@
   (define-misc-load/store-instruction ldrh 1 #b1011 nil)
   (define-misc-load/store-instruction ldrsb 1 #b1101 nil)
   (define-misc-load/store-instruction ldrsh 1 #b1111 nil))
-
+
 ;;;; Boxed-object computation instructions (for LRA and CODE)
 
 ;;; Compute the address of a CODE object by parsing the header of a

--- a/src/compiler/arm/macros.lisp
+++ b/src/compiler/arm/macros.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Instruction-like macros.
 
 (defmacro move (dst src &optional (predicate :al))
@@ -127,7 +127,7 @@
      (emit-label ,label)
      (inst lra-header-word)))
 
-
+
 ;;;; Stack TN's
 
 ;;; Move a stack TN to a register and vice-versa.
@@ -181,7 +181,7 @@
            (move ,n-reg ,n-stack))
           ((control-stack)
            (load-stack-offset ,n-reg cfp-tn ,n-stack)))))))
-
+
 ;;;; Storage allocation:
 
 
@@ -293,7 +293,7 @@
          (load-immediate-word ,flag-tn (compute-object-header ,size ,type-code))
          (storew ,flag-tn ,result-tn 0 ,lowtag))
        ,@body)))
-
+
 ;;;; Error Code
 (defun emit-error-break (vop kind code values)
   (assemble ()
@@ -313,7 +313,7 @@
       (emit-label start-lab)
       (emit-error-break vop error-trap (error-number-or-lose error-code) values)
       start-lab)))
-
+
 ;;;; PSEUDO-ATOMIC
 
 
@@ -338,7 +338,7 @@
        ,(if link
             `(inst blx :ne ,flag-tn)
             `(inst bx :ne ,flag-tn)))))
-
+
 ;;;; memory accessor vop generators
 
 (defmacro define-full-reffer (name type offset lowtag scs el-type

--- a/src/compiler/arm/memory.lisp
+++ b/src/compiler/arm/memory.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Cell-Ref and Cell-Set are used to define VOPs like CAR, where the
 ;;; offset to be read or written is a property of the VOP used.
 

--- a/src/compiler/arm/move.lisp
+++ b/src/compiler/arm/move.lisp
@@ -109,7 +109,7 @@
    (unsigned-reg) (unsigned-stack))
   (store-stack-offset x (current-nfp-tn vop) y))
 
-
+
 ;;;; The Move VOP:
 (define-vop (move)
   (:args (x :target y
@@ -146,7 +146,7 @@
 (define-move-vop move-arg :move-arg
   (any-reg descriptor-reg)
   (any-reg descriptor-reg))
-
+
 ;;;; Moves and coercions:
 
 ;;; These MOVE-TO-WORD VOPs move a tagged integer to a raw full-word

--- a/src/compiler/arm/nlx.lisp
+++ b/src/compiler/arm/nlx.lisp
@@ -16,7 +16,7 @@
 ;;; non-local entry.
 (defun make-nlx-entry-arg-start-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn r8-offset))
-
+
 ;;; Save and restore dynamic environment.
 ;;;
 ;;; These VOPs are used in the reentered function to restore the appropriate
@@ -69,7 +69,7 @@
   (:args (nsp :scs (any-reg descriptor-reg)))
   (:generator 1
     (move nsp-tn nsp)))
-
+
 ;;;; Unwind block hackery:
 
 ;;; Compute the address of the catch block from its TN, then store into the
@@ -142,7 +142,7 @@
     (load-symbol-value block *current-unwind-protect-block*)
     (loadw block block unwind-block-uwp-slot)
     (store-symbol-value block *current-unwind-protect-block*)))
-
+
 ;;;; NLX entry VOPs:
 
 (define-vop (nlx-entry)

--- a/src/compiler/arm/parms.lisp
+++ b/src/compiler/arm/parms.lisp
@@ -95,7 +95,7 @@
 ;; conditional.
 #-arm-vfp
 (error "Don't know how to set the FPU control word layout on non-VFP systems")
-
+
 ;;;; Where to put the different spaces.
 
 ;;; On non-gencgc we need large dynamic and static spaces for PURIFY
@@ -120,7 +120,7 @@
   (progn
     (defparameter dynamic-0-space-start #x4f000000)
     (defparameter dynamic-0-space-end   #x66fff000)))
-
+
 ;;;; other miscellaneous constants
 
 (defenum (:start 8)
@@ -132,7 +132,7 @@
   single-step-around-trap
   single-step-before-trap
   error-trap)
-
+
 ;;;; Static symbols.
 
 ;;; These symbols are loaded into static space directly after NIL so
@@ -166,7 +166,7 @@
     sb-kernel:%negate)
   #'equalp)
 
-
+
 ;;;; Assembler parameters:
 
 ;;; The number of bits per element in the assemblers code vector.

--- a/src/compiler/arm/pred.lisp
+++ b/src/compiler/arm/pred.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; The Branch VOP.
 
 ;;; The unconditional branch, emitted when we can't drop through to the desired
@@ -22,7 +22,7 @@
   (:generator 5
     (inst b dest)))
 
-
+
 ;;;; Generic conditional VOPs
 
 ;;; The generic conditional branch, emitted immediately after test
@@ -44,7 +44,7 @@
   (declare (ignore node dst-tn x-tn y-tn))
   nil)
 
-
+
 ;;;; Conditional VOPs:
 
 (define-vop (if-eq)

--- a/src/compiler/arm/sap.lisp
+++ b/src/compiler/arm/sap.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged SAP to an untagged representation.
@@ -76,7 +76,7 @@
 ;;; descriptor passing location.
 (define-move-vop move-arg :move-arg
   (sap-reg) (descriptor-reg))
-
+
 ;;;; SAP-INT and INT-SAP
 (define-vop (sap-int)
   (:args (sap :scs (sap-reg) :target int))
@@ -97,7 +97,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move sap int)))
-
+
 ;;;; POINTER+ and POINTER-
 (define-vop (pointer+)
   (:translate sap+)
@@ -142,7 +142,7 @@
   (:result-types signed-num)
   (:generator 1
     (inst sub res ptr1 ptr2)))
-
+
 ;;;; mumble-SYSTEM-REF and mumble-SYSTEM-SET
 (macrolet ((def-system-ref-and-set
                ;; NOTE: The -C VOPs have been disabled, as the allowed
@@ -271,7 +271,7 @@
     single-reg single-float :single :use-lip t)
   (def-system-ref-and-set sap-ref-double %set-sap-ref-double
     double-reg double-float :double :use-lip t))
-
+
 ;;; Noise to convert normal lisp data objects into SAPs.
 (define-vop (vector-sap)
   (:translate vector-sap)

--- a/src/compiler/arm/system.lisp
+++ b/src/compiler/arm/system.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Type frobbing VOPs
 
 (define-vop (widetag-of)
@@ -128,7 +128,7 @@
   (:generator 1
     (inst bic res ptr lowtag-mask)
     (inst mov res (lsr res 1))))
-
+
 ;;;; Allocation
 
 (define-vop (dynamic-space-free-pointer)
@@ -154,7 +154,7 @@
   (:policy :fast-safe)
   (:generator 1
     (load-csp int)))
-
+
 ;;;; Code object frobbing.
 
 (define-vop (code-instructions)
@@ -230,7 +230,7 @@
     (loadw res res cons-car-slot list-pointer-lowtag)
     (inst tst res fixnum-tag-mask)
     (inst mov :eq res null-tn)))
-
+
 ;;;; other miscellaneous VOPs
 
 (defknown sb-unix::receive-pending-interrupt () (values))

--- a/src/compiler/arm/type-vops.lisp
+++ b/src/compiler/arm/type-vops.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (defun %test-fixnum (value temp target not-p)
   (declare (ignore temp))
   (assemble ()
@@ -103,7 +103,7 @@
                           (inst b (if not-p :gt :le) target)
                           (inst b :le when-true))))))))))
         (emit-label drop-through)))))
-
+
 ;;;; Other integer ranges.
 
 ;;; A (signed-byte 32) can be represented with either fixnum or a bignum with
@@ -186,7 +186,7 @@
      (unsigned-byte-32-test value temp not-p target not-target)
      (emit-label not-target))))
 
-
+
 ;;; MOD type checks
 (defun power-of-two-limit-p (x)
   (and (fixnump x)

--- a/src/compiler/arm/vm.lisp
+++ b/src/compiler/arm/vm.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; register specs
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -67,7 +67,7 @@
   (defregset *register-arg-offsets*  r0 r1 r2)
   (defparameter *register-arg-names* '(r0 r1 r2)))
 
-
+
 ;;;; SB and SC definition:
 
 (!define-storage-bases
@@ -203,7 +203,7 @@
 
   (catch-block control-stack :element-size catch-block-size)
   (unwind-block control-stack :element-size unwind-block-size))
-
+
 ;;;; Make some random tns for important registers.
 
 (macrolet ((defregtn (name sc)
@@ -223,7 +223,7 @@
   (defregtn cfp any-reg)
   (defregtn lr interior-reg)
   (defregtn pc any-reg))
-
+
 ;;; If VALUE can be represented as an immediate constant, then return the
 ;;; appropriate SC number, otherwise return NIL.
 (defun immediate-constant-sc (value)
@@ -241,7 +241,7 @@
 (defun boxed-immediate-sc-p (sc)
   (or (eql sc null-sc-number)
       (eql sc immediate-sc-number)))
-
+
 ;;;; function call parameters
 
 ;;; the SC numbers for register and stack arguments/return values
@@ -266,7 +266,7 @@
                               :sc (sc-or-lose 'descriptor-reg)
                               :offset n))
           *register-arg-offsets*))
-
+
 ;;; This function is called by debug output routines that want a pretty name
 ;;; for a TN's location.  It returns a thing that can be printed with PRINC.
 (defun location-print-name (tn)

--- a/src/compiler/arm64/alloc.lisp
+++ b/src/compiler/arm64/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (define-vop (list-or-list*)
   (:args (things :more t :scs (control-stack)))
   (:temporary (:scs (descriptor-reg)) ptr)
@@ -67,7 +67,7 @@
 
 (define-vop (list* list-or-list*)
   (:variant t))
-
+
 ;;;; Special purpose inline allocators.
 
 (define-vop (make-fdefn)
@@ -120,7 +120,7 @@
                             value-cell-size :stack-allocate-p stack-allocate-p
                             :lip lip)
       (storew value result value-cell-value-slot other-pointer-lowtag))))
-
+
 ;;;; Automatic allocators for primitive objects.
 
 (define-vop (make-unbound-marker)

--- a/src/compiler/arm64/arith.lisp
+++ b/src/compiler/arm64/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; unary operations.
 
 (define-vop (fast-safe-arith-op)
@@ -73,7 +73,7 @@
   (:generator 2
     (inst mvn res x)))
 
-
+
 ;;;; Binary fixnum operations.
 
 ;;; Assume that any constant operand is the second arg...
@@ -317,7 +317,7 @@
   `(logior (lognot ,x) ,y))
 (define-source-transform logorc2 (x y)
   `(logior ,x (lognot ,y)))
-
+
 ;;; Shifting
 
 (define-vop (fast-ash-left-c/fixnum=>fixnum)
@@ -615,7 +615,7 @@
   (:arg-types signed-num)
   (:variant t)
   (:variant-cost 29))
-
+
 (defknown %%ldb (integer unsigned-byte unsigned-byte) unsigned-byte
   (movable foldable flushable always-translatable))
 

--- a/src/compiler/arm64/array.lisp
+++ b/src/compiler/arm64/array.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Allocator for the array header.
 
 (define-vop (make-array-header)
@@ -64,7 +64,7 @@
         (load-immediate-word pa-flag header-bits)
         (storew pa-flag header 0 other-pointer-lowtag)))
     (move result header)))
-
+
 ;;;; Additional accessors and setters for the array header.
 (define-full-reffer %array-dimension *
   array-dimensions-offset other-pointer-lowtag
@@ -418,7 +418,7 @@
     (inst str value (@ object offset))
     (unless (location= result value)
       (inst fmov result value))))
-
+
 ;;; Complex float arrays.
 
 (define-vop (data-vector-ref/simple-array-complex-single-float)
@@ -492,14 +492,14 @@
     (inst str value (@ object offset))
     (unless (location= result value)
       (inst s-mov result value))))
-
+
 ;;; These vops are useful for accessing the bits of a vector irrespective of
 ;;; what type of vector it is.
 (define-full-reffer vector-raw-bits * vector-data-offset other-pointer-lowtag
   (unsigned-reg) unsigned-num %vector-raw-bits)
 (define-full-setter set-vector-raw-bits * vector-data-offset other-pointer-lowtag
   (unsigned-reg) unsigned-num %set-vector-raw-bits)
-
+
 (define-vop (%compare-and-swap-svref word-index-cas)
   (:note "inline array compare-and-swap")
   (:policy :fast-safe)

--- a/src/compiler/arm64/c-call.lisp
+++ b/src/compiler/arm64/c-call.lisp
@@ -143,7 +143,7 @@
               (invoke-alien-type-method :result-tn
                                         (alien-fun-type-result-type type)
                                         (make-result-state))))))
-
+
 (define-vop (foreign-symbol-sap)
   (:translate foreign-symbol-sap)
   (:policy :fast-safe)
@@ -284,7 +284,7 @@
 ;;                                               :result-type result-type)
 ;;                                            ,@(new-args))))))
 ;;         (sb-c::give-up-ir1-transform))))
-
+
 ;;; Callback
 #-sb-xc-host
 (defun alien-callback-accessor-form (type sap offset)

--- a/src/compiler/arm64/call.lisp
+++ b/src/compiler/arm64/call.lisp
@@ -65,7 +65,7 @@
 ;;; passed when we are using non-standard conventions.
 (defun make-arg-count-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn nargs-offset))
-
+
 ;;;; Frame hackery:
 
 ;;; Return the number of bytes needed for the current non-descriptor
@@ -257,7 +257,7 @@
         ;; Deallocate the callee stack frame.
         (move csp-tn ocfp-tn))))
   (values))
-
+
 ;;;; Unknown values receiving:
 
 ;;;    Emit code needed at the return point for an unknown-values call for an
@@ -307,7 +307,7 @@
   (:temporary (:sc any-reg :offset nargs-offset :from :result) nvals)
   ;; Avoid being clobbered by RECEIVE-UNKNOWN-VALUES
   (:temporary (:sc descriptor-reg :offset r0-offset :from :result) r0-temp))
-
+
 ;;; This hook in the codegen pass lets us insert code before fall-thru entry
 ;;; points, local-call entry points, and tail-call entry points.  The default
 ;;; does nothing.
@@ -317,7 +317,7 @@
     (emit-label trampoline-label))
   (emit-label start-label))
 
-
+
 ;;;; XEP hackery:
 
 ;;; Get the lexical environment from its passing location.
@@ -604,7 +604,7 @@
                (inst b :hi err-lab))
               (t
                (check-min)))))))
-
+
 ;;;; Local call with unknown values convention return:
 
 ;;; Non-TR local call for a fixed number of values passed according to the
@@ -694,7 +694,7 @@
       (receive-unknown-values values-start nvals start count label lip)
       (when cur-nfp
         (load-stack-tn cur-nfp nfp-save)))))
-
+
 ;;;; Local call with known values return:
 
 ;;; Non-TR local call with known return locations.  Known-value return works
@@ -762,7 +762,7 @@
         (inst mov-sp nsp-tn cur-nfp)))
     (move cfp-tn old-fp-temp)
     (lisp-return return-pc-temp lip :known)))
-
+
 ;;;; Full call:
 ;;;
 ;;; There is something of a cross-product effect with full calls.
@@ -1059,7 +1059,7 @@
         (inst mov-sp nsp-tn cur-nfp)))
     (load-inline-constant tmp-tn '(:fixup tail-call-variable :assembly-routine) lip)
     (inst br tmp-tn)))
-
+
 ;;;; Unknown values return:
 
 ;;; Return a single value using the unknown-values convention.
@@ -1183,7 +1183,7 @@
     (move nvals nvals-arg)
     (load-inline-constant tmp-tn '(:fixup return-multiple :assembly-routine) lip)
     (inst br tmp-tn)))
-
+
 ;;; Single-stepping
 
 (define-vop (step-instrument-before-vop)

--- a/src/compiler/arm64/cell.lisp
+++ b/src/compiler/arm64/cell.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Data object ref/set stuff.
 
 (define-vop (slot)
@@ -55,7 +55,7 @@
     EXIT
     (inst clrex)
     (inst dmb)))
-
+
 ;;;; Symbol hacking VOPs:
 
 ;;; Do a cell ref with an error check for being unbound.
@@ -228,7 +228,7 @@
     (inst dmb)
     (inst cmp result unbound-marker-widetag)
     (inst b :eq (generate-error-code vop 'unbound-symbol-error symbol))))
-
+
 ;;;; Fdefinition (fdefn) objects.
 
 (define-vop (fdefn-fun cell-ref)
@@ -283,7 +283,7 @@
     (move result fdefn)))
 
 
-
+
 ;;;; Binding and Unbinding.
 
 ;;; BIND -- Establish VAL as a binding for SYMBOL.  Save the old value and
@@ -395,7 +395,7 @@
                                           n-word-bytes)
                                        :pre-index))
      (store-symbol-value bsp-temp *binding-stack-pointer*))))
-
+
 ;;;; Closure indexing.
 
 (define-full-reffer closure-index-ref *
@@ -429,7 +429,7 @@
   (:info offset)
   (:generator 4
     (storew cfp-tn object (+ closure-info-offset offset) fun-pointer-lowtag)))
-
+
 ;;;; Value Cell hackery.
 
 (define-vop (value-cell-ref cell-ref)
@@ -437,7 +437,7 @@
 
 (define-vop (value-cell-set cell-set)
   (:variant value-cell-value-slot other-pointer-lowtag))
-
+
 ;;;; Instance hackery:
 
 (define-vop (instance-length)
@@ -463,7 +463,7 @@
   (:translate %instance-cas)
   (:variant instance-slots-offset instance-pointer-lowtag)
   (:arg-types instance tagged-num * *))
-
+
 ;;;; Code object frobbing.
 
 (define-full-reffer code-header-ref * 0 other-pointer-lowtag

--- a/src/compiler/arm64/char.lisp
+++ b/src/compiler/arm64/char.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged char to an untagged representation.

--- a/src/compiler/arm64/float.lisp
+++ b/src/compiler/arm64/float.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Move functions:
 
 (define-move-fun (load-single 1) (vop x y)
@@ -28,7 +28,7 @@
 (define-move-fun (store-double 2) (vop x y)
                  ((double-reg) (double-stack))
   (storew x (current-nfp-tn vop) (tn-offset y)))
-
+
 ;;;; Move VOPs:
 
 (macrolet ((frob (vop sc)
@@ -112,7 +112,7 @@
                   (,sc descriptor-reg) (,sc)))))
   (frob move-single-float-arg single-reg single-stack nil)
   (frob move-double-float-arg double-reg double-stack t))
-
+
 ;;;; Complex float move functions
 
 
@@ -133,7 +133,7 @@
   ((complex-double-reg) (complex-double-stack))
   (storew x (current-nfp-tn vop) (tn-offset y)))
 
-
+
 ;;;
 ;;; Complex float register to register moves.
 ;;;
@@ -248,7 +248,7 @@
        (storew x nfp (tn-offset y))))))
 (define-move-vop move-complex-double-float-arg :move-arg
   (complex-double-reg descriptor-reg) (complex-double-reg))
-
+
 ;;;; Unboxed-to-boxed MOVE-ARG handling:
 
 ;; This little gem here says to use the VOP MOVE-ARG to move any float
@@ -258,7 +258,7 @@
 (define-move-vop move-arg :move-arg
   (single-reg double-reg complex-single-reg complex-double-reg)
   (descriptor-reg))
-
+
 ;;;; Arithmetic VOPs:
 
 (define-vop (float-op)
@@ -336,7 +336,7 @@
   (:save-p :compute-only)
   (:generator 1
     (inst fsqrt y x)))
-
+
 ;;;; Comparison:
 
 (define-vop (float-compare)
@@ -421,7 +421,7 @@
   (frob <= :le <=/single-float-zero <=/double-float-zero nil)
   (frob >= :ge >=/single-float-zero >=/double-float-zero nil)
   (frob = :eq eql/single-float-zero eql/double-float-zero t))
-
+
 ;;;; Conversion:
 
 (macrolet ((frob (name translate from-sc from-type to-sc to-type)
@@ -648,7 +648,7 @@
                           4
                           0))
                    other-pointer-lowtag)))))))
-
+
 ;;;; Float mode hackery:
 
 (sb-xc:deftype float-modes () '(unsigned-byte 32))
@@ -674,7 +674,7 @@
   (:generator 3
     (inst msr :fpsr new)
     (move res new)))
-
+
 ;;;; Complex float VOPs
 
 (define-vop (make-complex-single-float)

--- a/src/compiler/arm64/insts.lisp
+++ b/src/compiler/arm64/insts.lisp
@@ -27,7 +27,7 @@
             sb-vm::complex-single-reg sb-vm::complex-double-reg
             sb-vm::tmp-tn sb-vm::zr-tn sb-vm::nsp-offset)))
 
-
+
 
 (defconstant-eqx +conditions+
   '((:eq . 0)
@@ -60,7 +60,7 @@
 (defun invert-condition (condition)
   (aref sb-vm::+condition-name-vec+
         (logxor 1 (conditional-opcode condition))))
-
+
 ;;;; disassembler field definitions
 
 (progn
@@ -116,7 +116,7 @@
   (define-arg-type ldr-str-reg-annotation :printer #'annotate-ldr-str-reg)
 
   (define-arg-type label :sign-extend t :use-label #'use-label))
-
+
 ;;;; primitive emitters
 
 (define-bitfield-emitter emit-word 32
@@ -186,7 +186,7 @@
 (define-instruction lra-header-word (segment)
   (:emitter
    (emit-header-data segment return-pc-widetag)))
-
+
 ;;;; Addressing mode 1 support
 
 ;;; Addressing mode 1 has some 11 formats.  These are immediate,
@@ -259,7 +259,7 @@
              (shifter-operand-operand operand)
              (shifter-operand-register operand)))))
 
-
+
 ;;;; Addressing mode 2 support
 
 ;;; Addressing mode 2 ostensibly has 9 formats.  These are formed from
@@ -293,7 +293,7 @@
   (make-memory-operand :base base :offset offset
                        :mode mode))
 
-
+
 ;;;; Data-processing instructions
 
 
@@ -2231,7 +2231,7 @@
                                     #b01111
                                     #b111)
                                 (tn-offset rn) (tn-offset rd)))))))
-
+
 ;;;; Boxed-object computation instructions (for LRA and CODE)
 
 ;;; Compute the address of a CODE object by parsing the header of a

--- a/src/compiler/arm64/macros.lisp
+++ b/src/compiler/arm64/macros.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Instruction-like macros.
 
 (defmacro move (dst src)
@@ -119,7 +119,7 @@
      (emit-label ,label)
      (inst lra-header-word)))
 
-
+
 ;;;; Stack TN's
 
 ;;; Move a stack TN to a register and vice-versa.
@@ -155,7 +155,7 @@
            (move ,n-reg ,n-stack))
           ((control-stack)
            (load-stack-offset ,n-reg cfp-tn ,n-stack)))))))
-
+
 ;;;; Storage allocation:
 
 
@@ -280,7 +280,7 @@
          (load-immediate-word ,flag-tn (compute-object-header ,size ,type-code))
          (storew ,flag-tn ,result-tn 0 ,lowtag))
        ,@body)))
-
+
 ;;;; Error Code
 (defun emit-error-break (vop kind code values)
   (assemble ()
@@ -305,7 +305,7 @@
                             error-trap)
                         (error-number-or-lose error-code) values)
       start-lab)))
-
+
 ;;;; PSEUDO-ATOMIC
 
 #+sb-safepoint
@@ -349,7 +349,7 @@
          (emit-label not-interrputed))
        #+sb-safepoint
        (emit-safepoint))))
-
+
 ;;;; memory accessor vop generators
 
 (defmacro define-full-reffer (name type offset lowtag scs el-type

--- a/src/compiler/arm64/memory.lisp
+++ b/src/compiler/arm64/memory.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Cell-Ref and Cell-Set are used to define VOPs like CAR, where the
 ;;; offset to be read or written is a property of the VOP used.
 

--- a/src/compiler/arm64/move.lisp
+++ b/src/compiler/arm64/move.lisp
@@ -120,7 +120,7 @@
    (unsigned-reg) (unsigned-stack))
   (store-stack-offset x (current-nfp-tn vop) y))
 
-
+
 ;;;; The Move VOP:
 (define-vop (move)
   (:args (x :target y
@@ -300,7 +300,7 @@
                    cfp-tn)
                (tn-ref-load-tn (tn-ref-across (sb-c::vop-args vop1)))))))))))
 
-
+
 ;;;; ILLEGAL-MOVE
 
 ;;; This VOP exists just to begin the lifetime of a TN that couldn't
@@ -315,7 +315,7 @@
   (:save-p :compute-only)
   (:generator 666
     (error-call vop 'object-not-type-error x type)))
-
+
 ;;;; Moves and coercions:
 
 ;;; These MOVE-TO-WORD VOPs move a tagged integer to a raw full-word

--- a/src/compiler/arm64/nlx.lisp
+++ b/src/compiler/arm64/nlx.lisp
@@ -16,7 +16,7 @@
 ;;; non-local entry.
 (defun make-nlx-entry-arg-start-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn r8-offset))
-
+
 ;;; Save and restore dynamic environment.
 ;;;
 ;;; These VOPs are used in the reentered function to restore the appropriate
@@ -69,7 +69,7 @@
   (:args (nsp :scs (any-reg descriptor-reg)))
   (:generator 1
      (inst mov-sp nsp-tn nsp)))
-
+
 ;;;; Unwind block hackery:
 
 ;;; Compute the address of the catch block from its TN, then store into the
@@ -144,7 +144,7 @@
     (load-tl-symbol-value block *current-unwind-protect-block*)
     (loadw block block unwind-block-uwp-slot)
     (store-tl-symbol-value block *current-unwind-protect-block*)))
-
+
 ;;;; NLX entry VOPs:
 
 (define-vop (nlx-entry)

--- a/src/compiler/arm64/parms.lisp
+++ b/src/compiler/arm64/parms.lisp
@@ -90,7 +90,7 @@
   (defconstant-eqx float-exceptions-byte (byte 8 0) #'equalp)
 
   (defconstant float-fast-bit (ash 1 24))) ;; Flush-to-zero mode
-
+
 ;;;; Where to put the different spaces.
 
 ;;; On non-gencgc we need large dynamic and static spaces for PURIFY
@@ -112,7 +112,7 @@
 (!gencgc-space-setup #xF0000000 :dynamic-space-start #x1000000000)
 
 (defconstant linkage-table-entry-size 16)
-
+
 ;;;; other miscellaneous constants
 
 (defenum (:start 8)
@@ -125,7 +125,7 @@
   single-step-before-trap
   invalid-arg-count-trap
   error-trap)
-
+
 ;;;; Static symbols.
 
 ;;; These symbols are loaded into static space directly after NIL so
@@ -156,7 +156,7 @@
     sb-kernel:%negate)
   #'equalp)
 
-
+
 ;;;; Assembler parameters:
 
 ;;; The number of bits per element in the assemblers code vector.

--- a/src/compiler/arm64/pred.lisp
+++ b/src/compiler/arm64/pred.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; The Branch VOP.
 
 ;;; The unconditional branch, emitted when we can't drop through to the desired
@@ -22,7 +22,7 @@
   (:generator 5
     (inst b dest)))
 
-
+
 ;;;; Generic conditional VOPs
 
 ;;; The generic conditional branch, emitted immediately after test
@@ -44,7 +44,7 @@
   (declare (ignore node dst-tn x-tn y-tn))
   nil)
 
-
+
 ;;;; Conditional VOPs:
 
 (define-vop (if-eq)

--- a/src/compiler/arm64/sap.lisp
+++ b/src/compiler/arm64/sap.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged SAP to an untagged representation.
@@ -77,7 +77,7 @@
 ;;; descriptor passing location.
 (define-move-vop move-arg :move-arg
   (sap-reg) (descriptor-reg))
-
+
 ;;;; SAP-INT and INT-SAP
 (define-vop (sap-int)
   (:args (sap :scs (sap-reg) :target int))
@@ -98,7 +98,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move sap int)))
-
+
 ;;;; POINTER+ and POINTER-
 (define-vop (pointer+)
   (:translate sap+)
@@ -143,7 +143,7 @@
   (:result-types signed-num)
   (:generator 1
     (inst sub res ptr1 ptr2)))
-
+
 ;;;; mumble-SYSTEM-REF and mumble-SYSTEM-SET
 (macrolet ((def-system-ref-and-set
                (ref-name set-name sc type size &key signed)
@@ -214,7 +214,7 @@
     single-reg single-float :single)
   (def-system-ref-and-set sap-ref-double %set-sap-ref-double
     double-reg double-float :double))
-
+
 ;;; Noise to convert normal lisp data objects into SAPs.
 (define-vop (vector-sap)
   (:translate vector-sap)

--- a/src/compiler/arm64/system.lisp
+++ b/src/compiler/arm64/system.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Type frobbing VOPs
 
 (define-vop (widetag-of)
@@ -138,7 +138,7 @@
   (:generator 1
     (inst and res ptr (dpb -1 (byte (- n-word-bits n-fixnum-tag-bits 1)
                                     n-fixnum-tag-bits) 0))))
-
+
 ;;;; Allocation
 
 (define-vop (dynamic-space-free-pointer)
@@ -164,7 +164,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move int csp-tn)))
-
+
 ;;;; Code object frobbing.
 
 (define-vop (code-instructions)
@@ -233,7 +233,7 @@
     (loadw res res cons-car-slot list-pointer-lowtag)
     (inst tst res fixnum-tag-mask)
     (inst csel res null-tn res :eq)))
-
+
 ;;;; other miscellaneous VOPs
 
 (defknown sb-unix::receive-pending-interrupt () (values))

--- a/src/compiler/arm64/type-vops.lisp
+++ b/src/compiler/arm64/type-vops.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (defun %test-fixnum (value temp target not-p)
   (declare (ignore temp))
   (assemble ()
@@ -128,7 +128,7 @@
                           (inst b (if not-p :gt :le) target)
                           (inst b :le when-true))))))))))
         (emit-label drop-through)))))
-
+
 ;;;; Other integer ranges.
 
 ;;; A (signed-byte 64) can be represented with either fixnum or a bignum with
@@ -214,7 +214,7 @@
   (:translate fixnump)
   (:generator 3
     (inst adds temp value value)))
-
+
 ;;; MOD type checks
 (defun power-of-two-limit-p (x)
   (and (fixnump x)

--- a/src/compiler/arm64/vm.lisp
+++ b/src/compiler/arm64/vm.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; register specs
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -92,7 +92,7 @@
   (defregset *register-arg-offsets*  r0 r1 r2 r3)
   (defparameter *register-arg-names* '(r0 r1 r2 r3)))
 
-
+
 ;;;; SB and SC definition:
 
 (!define-storage-bases
@@ -217,7 +217,7 @@
 
   (catch-block control-stack :element-size catch-block-size)
   (unwind-block control-stack :element-size unwind-block-size))
-
+
 ;;;; Make some random tns for important registers.
 
 (macrolet ((defregtn (name sc)
@@ -242,7 +242,7 @@
   (defregtn lr interior-reg)
   #+sb-thread
   (defregtn thread interior-reg))
-
+
 ;;; If VALUE can be represented as an immediate constant, then return the
 ;;; appropriate SC number, otherwise return NIL.
 (defun immediate-constant-sc (value)
@@ -259,7 +259,7 @@
 
 (defun boxed-immediate-sc-p (sc)
   (eql sc immediate-sc-number))
-
+
 ;;;; function call parameters
 
 ;;; the SC numbers for register and stack arguments/return values
@@ -284,7 +284,7 @@
                               :sc (sc-or-lose 'descriptor-reg)
                               :offset n))
           *register-arg-offsets*))
-
+
 ;;; This function is called by debug output routines that want a pretty name
 ;;; for a TN's location.  It returns a thing that can be printed with PRINC.
 (defun location-print-name (tn)

--- a/src/compiler/array-tran.lisp
+++ b/src/compiler/array-tran.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; utilities for optimizing array operations
 
 ;;; Return UPGRADED-ARRAY-ELEMENT-TYPE for LVAR, or do
@@ -140,7 +140,7 @@
        (constant-lvar-p arg)
        (lvar-value arg)
        t))
-
+
 ;;;; DERIVE-TYPE optimizers
 
 (defun derive-aref-type (array)
@@ -372,7 +372,7 @@
                             adjustable fill-pointer displaced-to
                             node)))
 
-
+
 ;;;; constructors
 
 ;;; Convert VECTOR into a MAKE-ARRAY.
@@ -1116,7 +1116,7 @@
                                call
                                :adjustable adjustable
                                :fill-pointer fill-pointer))
-
+
 ;;;; ADJUST-ARRAY
 (deftransform adjust-array ((array dims &key displaced-to displaced-index-offset)
                             (array integer &key
@@ -1146,7 +1146,7 @@
                             :displaced-to displaced-to
                             ,@(and displaced-index-offset
                                    '(:displaced-index-offset displacement)))))))
-
+
 ;;;; miscellaneous properties of arrays
 
 ;;; Transforms for various array properties. If the property is know
@@ -1443,7 +1443,7 @@
                           (lvar-value dimension)
                           'dimension)
                index))
-
+
 ;;;; WITH-ARRAY-DATA
 
 ;;; This checks to see whether the array is simple and the start and
@@ -1592,7 +1592,7 @@
                                 :policy (> speed space))
   "inline non-SIMPLE-vector-handling logic"
   (transform-%with-array-data/mumble array node t))
-
+
 ;;;; array accessors
 
 ;;; We convert all typed array accessors into AREF and (SETF AREF) with type
@@ -1803,7 +1803,7 @@
   `(hairy-data-vector-set array
                           (check-bound array (array-total-size array) index)
                           new-value))
-
+
 ;;;; bit-vector array operation canonicalization
 ;;;;
 ;;;; We convert all bit-vector operations to have the result array
@@ -1843,7 +1843,7 @@
 (deftransform bit-not ((bit-array-1 result-bit-array)
                        (bit-vector (eql t)))
   '(bit-not bit-array-1 bit-array-1))
-
+
 ;;; Pick off some constant cases.
 (defoptimizer (array-header-p derive-type) ((array))
   (let ((type (lvar-type array))

--- a/src/compiler/assem.lisp
+++ b/src/compiler/assem.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-ASSEM")
-
+
 ;;;; assembly control parameters
 
 ;;; Only the scheduling assembler cares about this constant,
@@ -21,7 +21,7 @@
   (if (boundp '+assem-max-locations+)
       (symbol-value '+assem-max-locations+)
       0))
-
+
 ;;;; the SEGMENT structure
 
 ;;; This structure holds the state of the assembler.
@@ -190,7 +190,7 @@
              ,@body)
          (setf (segment-current-index ,n-segment) ,old-index
                (segment-current-posn ,n-segment) ,old-posn)))))
-
+
 ;;;; structures/types used by the scheduler
 
 (!def-boolean-attribute instruction
@@ -373,7 +373,7 @@
 
 (defun assembling-to-elsewhere-p ()
   (eq *current-destination* (asmstream-elsewhere-section *asmstream*)))
-
+
 ;;;; the scheduler itself
 
 (defmacro without-scheduling (() &body body)
@@ -802,7 +802,7 @@
                    (cons inst remaining))))))
   (values))
 )) ; end PROGN
-
+
 ;;;; structure used during output emission
 
 ;;; a constraint on how the output stream must be aligned
@@ -859,7 +859,7 @@
                     (:copier nil))
   ;; the number of bytes of filler here
   (bytes 0 :type index))
-
+
 ;;;; output functions
 
 ;;; interface: Emit the supplied BYTE to SEGMENT, growing SEGMENT if
@@ -1065,7 +1065,7 @@
 (defun %emit-postit (segment function)
   (push function (segment-postits segment))
   (values))
-
+
 ;;;; output compression/position assignment stuff
 
 ;;; Grovel though all the annotations looking for choosers. When we
@@ -1265,7 +1265,7 @@
     (setf (segment-final-index segment) (segment-final-posn segment))
     new-buffer))
 
-
+
 ;;;; interface to the rest of the compiler
 (defun op-encoder-name (string-designator &optional create)
   (cond ((string= string-designator '.skip)
@@ -1610,7 +1610,7 @@
     (declare (type (simple-array assembly-unit 1) v))
     (length (write-sequence v stream))))
 
-
+
 ;;;; interface to the instruction set definition
 
 ;;; Define a function named NAME that merges its arguments into a

--- a/src/compiler/backend.lisp
+++ b/src/compiler/backend.lisp
@@ -20,7 +20,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; miscellaneous backend properties
 
 ;;; the number of references that a TN must have to offset the
@@ -91,7 +91,7 @@
 (defglobal *backend-type-predicates* nil)
 (declaim (type hash-table *backend-predicate-types*))
 (declaim (type list *backend-type-predicates*))
-
+
 ;;;; VM support routines which backends need to implement
 
 ;;; from vm.lisp
@@ -125,7 +125,7 @@
 ;;; emit-nop
 ;;; location-number
 
-
+
 ;;;; This is a prototype interface to support Christophe Rhodes' new
 ;;;; (sbcl-0.pre7.57) VOP :GUARD clauses for implementations which
 ;;;; depend on CPU variants, e.g. the differences between I486,

--- a/src/compiler/checkgen.lisp
+++ b/src/compiler/checkgen.lisp
@@ -13,7 +13,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; cost estimation
 
 ;;; Return some sort of guess about the cost of a call to a function.
@@ -183,7 +183,7 @@
                                              (values-type-optional type))
                            :rest (acond ((values-type-rest type)
                                          (weaken-type it)))))))
-
+
 ;;;; checking strategy determination
 
 ;;; Return the type we should test for when we really want to check

--- a/src/compiler/codegen.lisp
+++ b/src/compiler/codegen.lisp
@@ -13,7 +13,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; utilities used during code generation
 
 ;;; the number of bytes used by the code object header
@@ -51,7 +51,7 @@
 ;;; designated by 2ENV
 (defun callee-return-pc-tn (2env)
   (ir2-physenv-return-pc-pass 2env))
-
+
 ;;;; noise to emit an instruction trace
 
 (defun trace-instruction (section vop inst args state
@@ -77,7 +77,7 @@
       (t
        (format t "~0,8T~A~@[~0,8T~{~A~^, ~}~]~%" inst args))))
   (values))
-
+
 ;;;; GENERATE-CODE and support routines
 
 ;;; standard defaults for slots of SEGMENT objects

--- a/src/compiler/constraint.lisp
+++ b/src/compiler/constraint.lisp
@@ -86,7 +86,7 @@
   ;; If true, negates the sense of the constraint, so the relation
   ;; does *not* hold.
   (not-p nil :type boolean))
-
+
 ;;; Historically, CMUCL and SBCL have used a sparse set implementation
 ;;; for which most operations are O(n) (see sset.lisp), but at the
 ;;; cost of at least a full word of pointer for each constraint set
@@ -290,7 +290,7 @@
     (defconsetop conset-union bit-ior)
     (defconsetop conset-intersection bit-and)
     (defconsetop conset-difference bit-andc2)))
-
+
 ;;; Constraints are hash-consed. Unfortunately, types aren't, so we have
 ;;; to over-approximate and then linear search through the potential hits.
 ;;; LVARs can only be found in EQL (not-p = NIL) constraints, while constant
@@ -383,7 +383,7 @@
         (when (lambda-var-p y)
           (register-constraint y new x))
         new)))
-
+
 ;;; Actual conset interface
 ;;;
 ;;; Constraint propagation needs to iterate over the set of lambda-vars known to
@@ -542,7 +542,7 @@
         (inherit-constraints (eql1) var2 constraints target)
         (inherit-constraints (eql2) var1 constraints target))
       t)))
-
+
 ;;; If REF is to a LAMBDA-VAR with CONSTRAINTs (i.e. we can do flow
 ;;; analysis on it), then return the LAMBDA-VAR, otherwise NIL.
 #-sb-fluid (declaim (inline ok-ref-lambda-var))

--- a/src/compiler/ctype.lisp
+++ b/src/compiler/ctype.lisp
@@ -67,7 +67,7 @@
     (apply *unwinnage-fun* format-string format-args))
   (values))
 
-
+
 ;;;; stuff for checking a call against a function type
 ;;;;
 ;;;; FIXME: This is stuff to look at when I get around to fixing
@@ -382,7 +382,7 @@ and no value was provided for it." name))))))))))
            :returns (tail-set-type
                      (lambda-tail-set
                       (optional-dispatch-main-entry functional))))))))
-
+
 ;;;; approximate function types
 ;;;;
 ;;;; FIXME: This is stuff to look at when I get around to fixing function
@@ -616,7 +616,7 @@ and no value was provided for it." name))))))))))
           (unless (find name keys :key #'key-info-name)
             (note-lossage "Function previously called with unknown argument keyword ~S."
                   name)))))))
-
+
 ;;;; ASSERT-DEFINITION-TYPE
 
 ;;; Intersect LAMBDA's var types with TYPES, giving a warning if there
@@ -921,7 +921,7 @@ and no value was provided for it." name))))))))))
                      :allowp (fun-type-allowp type)
                      :returns (fun-type-returns type))
       type))
-
+
 ;;; Call FUN with (arg-lvar arg-type lvars &optional annotation)
 (defun map-combination-args-and-types (fun call &optional info
                                                           unknown-keys-fun
@@ -1062,7 +1062,7 @@ and no value was provided for it." name))))))))))
            nil
            t))))
   (values))
-
+
 ;;;; FIXME: Move to some other file.
 (defun check-catch-tag-type (tag)
   (declare (type lvar tag))

--- a/src/compiler/dce.lisp
+++ b/src/compiler/dce.lisp
@@ -5,7 +5,7 @@
 ;;;; blocks.
 
 (in-package "SB-C")
-
+
 ;;; A CLAMBDA is deemed to be "externally referenced" if:
 ;;;   - It is of KIND :TOPLEVEL (a toplevel CLAMBDA).
 ;;;   - It is LAMBDA-HAS-EXTERNAL-REFERENCES-P true (from COMPILE
@@ -26,7 +26,7 @@
                 (not (eq (node-component ref)
                          home-component)))
               (lambda-refs clambda)))))
-
+
 (defun dce-analyze-ref (ref)
   (let ((leaf (ref-leaf ref)))
     (typecase leaf
@@ -70,7 +70,7 @@
   (dce-analyze-block
    (node-block
     (lambda-bind clambda))))
-
+
 (defun eliminate-dead-code (component)
   (clear-flags component)
 

--- a/src/compiler/debug-dump.lisp
+++ b/src/compiler/debug-dump.lisp
@@ -18,7 +18,7 @@
 (defvar *contexts*)
 (declaim (type (vector t) *contexts*))
 
-
+
 ;;;; debug blocks
 
 (deftype location-kind ()
@@ -298,7 +298,7 @@
         (dump-location-from-info loc var-locs)))
     ;; lz-compress accept any array of octets and returns a simple-array
     (logically-readonlyize (lz-compress byte-buffer))))
-
+
 ;;; Return DEBUG-SOURCE structure containing information derived from
 ;;; INFO.
 (defun debug-source-for-info (info &key function)
@@ -379,7 +379,7 @@
          (elt sequence 0))
         (t
          (coerce-to-smallest-eltype sequence))))
-
+
 ;;;; variables
 
 ;;; Return a SC+OFFSET describing TN's location.
@@ -566,7 +566,7 @@
            (aver (or (null (leaf-refs var))
                      (not (tn-offset (leaf-info var)))))
            debug-info-var-deleted))))
-
+
 ;;;; arguments/returns
 
 ;;; Return a vector to be used as the COMPILED-DEBUG-FUN-ARGS for FUN.
@@ -624,7 +624,7 @@
   (coerce-to-smallest-eltype
    (mapcar #'tn-sc+offset
            (return-info-locations (tail-set-info (lambda-tail-set fun))))))
-
+
 ;;;; debug functions
 
 ;;; Return a C-D-F structure with all the mandatory slots filled in.
@@ -712,7 +712,7 @@
                    (setf (compiled-debug-fun-returns dfun)
                          (compute-debug-returns fun)))))))
     dfun))
-
+
 ;;;; full component dumping
 
 ;;; Compute the full form function map.
@@ -764,7 +764,7 @@
                                     (source-info-file-info *source-info*))
                                    component-tlf-num)))
        :contexts (compact-vector *contexts*)))))
-
+
 ;;; Write BITS out to BYTE-BUFFER in backend byte order. The length of
 ;;; BITS must be evenly divisible by eight.
 (defun write-packed-bit-vector (bits byte-buffer)

--- a/src/compiler/debug.lisp
+++ b/src/compiler/debug.lisp
@@ -122,7 +122,7 @@
       (clrhash *seen-blocks*)
       (clrhash *seen-funs*))
     (values)))
-
+
 ;;;; function consistency checking
 
 (defun observe-functional (x)
@@ -241,7 +241,7 @@
       (check-fun-stuff fun)
       (dolist (let (lambda-lets fun))
         (check-fun-stuff let)))))
-
+
 ;;;; loop consistency checking
 
 #|
@@ -408,7 +408,7 @@
          (barf "~S ends in normal node, but doesn't have one successor."
                block)))))
   (values))
-
+
 ;;;; node consistency checking
 
 ;;; Check that the DEST for LVAR is the specified NODE. We also mark
@@ -516,7 +516,7 @@
                 (barf "~S has VALUE but no ENTRY." node)))))))
 
   (values))
-
+
 ;;;; IR2 consistency checking
 
 ;;; Check for some kind of consistency in some REFs linked together by
@@ -632,7 +632,7 @@
   (do-ir2-blocks (block component)
     (check-ir2-block-consistency block))
   (values))
-
+
 ;;;; lifetime analysis checking
 
 ;;; Dump some info about how many TNs there, and what the conflicts data
@@ -817,7 +817,7 @@
   (check-tn-conflicts component)
   (check-block-conflicts component)
   (check-environment-lifetimes component))
-
+
 ;;;; pack consistency checking
 
 (defun check-pack-consistency (component)
@@ -841,7 +841,7 @@
           (check (vop-info-result-load-scs info) (vop-results vop))
           (check (vop-info-arg-load-scs info) (vop-args vop))))))
   (values))
-
+
 ;;;; data structure dumping routines
 
 ;;; When we print CONTINUATIONs and TNs, we assign them small numeric

--- a/src/compiler/dfo.lisp
+++ b/src/compiler/dfo.lisp
@@ -414,7 +414,7 @@
 
     ;; Pull out top-level-ish code.
     (separate-toplevelish-components (components))))
-
+
 ;;; Insert the code in LAMBDA at the end of RESULT-LAMBDA.
 (defun merge-1-toplevel-lambda (result-lambda lambda)
   (declare (type clambda result-lambda lambda))

--- a/src/compiler/disassem.lisp
+++ b/src/compiler/disassem.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-DISASSEM")
-
+
 ;;; types and defaults
 
 (defconstant label-column-width 7)
@@ -27,7 +27,7 @@
   `(integer 0 (,max-filtered-value-index)))
 (deftype filtered-value-vector ()
   `(simple-array t (,max-filtered-value-index)))
-
+
 ;;;; disassembly parameters
 
 ;; With a few tweaks, you can use a running SBCL as a cross-assembler
@@ -57,7 +57,7 @@
 
 (defvar *disassem-note-column* (+ 45 *disassem-inst-column-width*)
   "The column in which end-of-line comments for notes are started.")
-
+
 ;;;; A DCHUNK contains the bits we look at to decode an
 ;;;; instruction.
 ;;;; I tried to keep this abstract so that if using integers > the machine
@@ -152,7 +152,7 @@
 (defun dchunk-count-bits (x)
   (declare (type dchunk x))
   (logcount x))
-
+
 (defstruct (arg (:constructor %make-arg (name))
                 (:copier nil)
                 (:predicate nil))
@@ -177,7 +177,7 @@
   (length 0 :type disassem-length)               ; in bytes
 
   (default-printer nil :type list))
-
+
 ;;; A FUNSTATE holds the state of any arguments used in a disassembly
 ;;; function. It is a 2-level alist. The outer list maps each ARG to
 ;;; a list of styles in which that arg can be rendered.
@@ -192,7 +192,7 @@
 (defun arg-or-lose (name funstate)
   (or (car (assoc name funstate :key #'arg-name :test #'eq))
       (pd-error "unknown argument ~S" name)))
-
+
 ;;; machinery to provide more meaningful error messages during compilation
 (defvar *current-instruction-flavor*)
 (defun pd-error (fmt &rest args)
@@ -474,7 +474,7 @@
          `(list ,@forms))
         (t
          (car forms))))
-
+
 ;;; DEFINE-ARG-TYPE Name {Key Value}*
 ;;;
 ;;; Define a disassembler argument type NAME (which can then be referenced in
@@ -520,7 +520,7 @@
   (setf (get name 'arg-type)
         (apply 'modify-arg (%make-arg name) nil
                (nconc (when inherit (list :type inherit)) properties))))
-
+
 (defun %gen-arg-forms (arg rendering funstate)
   (declare (type arg arg) (type list funstate))
   (ecase rendering
@@ -557,7 +557,7 @@
        (if (arg-use-label arg)
            `((lookup-label ,(maybe-listify numeric-forms)))
            numeric-forms)))))
-
+
 (defun find-printer-fun (printer-source args cache *current-instruction-flavor*)
   (let* ((source (preprocess-printer printer-source args))
          (funstate (make-funstate args))
@@ -698,7 +698,7 @@
 ;;; reference refers to a valid arg.
 (defun preprocess-printer (printer args)
   (preprocess-conditionals (preprocess-chooses printer args) args))
-
+
 ;;; Return the first non-keyword symbol in a depth-first search of TREE.
 (defun find-first-field-name (tree)
   (cond ((null tree)
@@ -721,7 +721,7 @@
         (t
          (sharing-mapcar (lambda (sub) (preprocess-chooses sub args))
                          printer))))
-
+
 ;;;; some simple functions that help avoid consing when we're just
 ;;;; recursively filtering things that usually don't change
 
@@ -734,7 +734,7 @@
        (recons list
                      (funcall fun (car list))
                      (sharing-mapcar fun (cdr list)))))
-
+
 (defun all-arg-refs-relevant-p (printer args)
   (cond ((or (null printer) (keywordp printer) (eq printer t))
          t)
@@ -880,7 +880,7 @@
            (compile-test subj key funstate))
           (t
            (pd-error "bogus test-form: ~S" test)))))
-
+
 #-sb-fluid (declaim (inline bytes-to-bits))
 (declaim (maybe-inline sign-extend tab tab0))
 

--- a/src/compiler/dump.lisp
+++ b/src/compiler/dump.lisp
@@ -14,7 +14,7 @@
 ;;; here is awfully chummy with the SB-C package. CMU CL didn't have
 ;;; any separation between the two packages, and a lot of tight
 ;;; coupling remains. -- WHN 2001-06-04
-
+
 ;;;; fasl dumper state
 
 ;;; The FASL-OUTPUT structure represents everything we need to
@@ -240,7 +240,7 @@
     (aver (not (gethash x circ)))
     (setf (gethash x circ) x))
   (values))
-
+
 ;;;; opening and closing fasl files
 
 ;;; Open a fasl file, write its header, and return a FASL-OUTPUT
@@ -317,7 +317,7 @@
   ;; That's all, folks.
   (close (fasl-output-stream fasl-output) :abort abort-p)
   (values))
-
+
 ;;;; main entries to object dumping
 
 ;;; This function deals with dumping objects that are complex enough
@@ -463,7 +463,7 @@
           (dump-circularities *circularities-detected* file)
           (clrhash circ)))
       (sub-dump-object x file)))
-
+
 ;;;; LOAD-TIME-VALUE and MAKE-LOAD-FORM support
 
 ;;; Emit a funcall of the function and return the handle for the
@@ -504,7 +504,7 @@
 (defun fasl-note-dumpable-instance (structure file)
   (setf (gethash structure (fasl-output-valid-structures file)) t)
   (values))
-
+
 ;;;; number dumping
 
 (defun dump-ratio (x file)
@@ -570,7 +570,7 @@
       (sub-dump-object re file)
       (sub-dump-object im file)
       (dump-fop 'fop-complex file)))))
-
+
 ;;;; symbol dumping
 
 ;;; Return the table index of PKG, adding the package to the table if
@@ -595,7 +595,7 @@
            (incf (fasl-output-table-free file))
            (push (cons pkg entry) (fasl-output-packages file))
            entry))))
-
+
 ;;; dumper for lists
 
 ;;; Dump a list, setting up patching information when there are
@@ -689,7 +689,7 @@
         (t
          (dump-byte (logior fop-list-base-opcode) file)
          (dump-varint (- n 16) file))))
-
+
 ;;;; array dumping
 
 ;;; Dump the array thing.
@@ -780,7 +780,7 @@
                             0
                             (ceiling (* length bits-per-length) sb-vm:n-byte-bits)
                             #+sb-xc-host bits-per-length))))
-
+
 ;;; Dump characters and string-ish things.
 
 (defun dump-character (char file)
@@ -840,7 +840,7 @@
     (incf (fasl-output-table-free file)))
 
   (values))
-
+
 ;;;; component (function) dumping
 
 (defun dump-segment (segment code-length fasl-output)
@@ -1093,7 +1093,7 @@
   (dump-push-previously-dumped-fun fun fasl-output)
   (dump-fop 'fop-funcall-for-effect fasl-output 0)
   (values))
-
+
 ;;;; dumping structures
 
 ;;; Even as late as calling DUMP-STRUCTURE we might have to deduce that a

--- a/src/compiler/early-c.lisp
+++ b/src/compiler/early-c.lisp
@@ -36,7 +36,7 @@
 (defconstant sb-xc:multiple-values-limit sb-xc:most-positive-fixnum
   "The exclusive upper bound on the number of multiple VALUES that you can
   return.")
-
+
 ;;;; cross-compiler-only versions of CL special variables, so that we
 ;;;; don't have weird interactions with the host compiler
 
@@ -44,7 +44,7 @@
 (defvar sb-xc:*compile-file-truename*)
 (defvar sb-xc:*compile-print*)
 (defvar sb-xc:*compile-verbose*)
-
+
 ;;;; miscellaneous types used both in the cross-compiler and on the target
 
 ;;;; FIXME: The INDEX and LAYOUT-DEPTHOID definitions probably belong
@@ -60,7 +60,7 @@
   ;; FIXME: Probably should exclude negative bignum
   #+compact-instance-header 'integer
   #-compact-instance-header '(and integer (not (eql 0))))
-
+
 ;;; An INLINEP value describes how a function is called. The values
 ;;; have these meanings:
 ;;;     NIL     No declaration seen: do whatever you feel like, but don't
@@ -166,7 +166,7 @@ the stack without triggering overflow protection.")
     (prog1
         *object-id-counter*
       (incf *object-id-counter*))))
-
+
 ;;;; miscellaneous utilities
 
 ;;; This is for "observers" who want to know if type names have been added.

--- a/src/compiler/float-tran.lisp
+++ b/src/compiler/float-tran.lisp
@@ -12,7 +12,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; coercions
 
 (deftransform float ((n f) (* single-float) *)
@@ -114,7 +114,7 @@
                              (when (< bits ,(* num d))
                                (return (values (truncate bits ,d)))))))))))))))
 
-
+
 ;;;; float accessors
 
 ;;; NaNs can not be constructed from constant bits mainly due to compiler problems
@@ -169,7 +169,7 @@
           `(let ((,temp (abs float2)))
             (if (minusp ,bits) (- ,temp) ,temp)))
         `(if (minusp ,bits) $-1d0 $1d0))))
-
+
 ;;;; DECODE-FLOAT, INTEGER-DECODE-FLOAT, and SCALE-FLOAT
 
 (defknown decode-single-float (single-float)
@@ -346,7 +346,7 @@
   (frob %double-float double-float
         sb-xc:most-negative-double-float sb-xc:most-positive-double-float))
 ) ; PROGN
-
+
 ;;;; float contagion
 
 (defun safe-ctype-for-single-coercion-p (x)
@@ -486,7 +486,7 @@
   (frob >=)
   (frob =)
   (frob = t))
-
+
 ;;;; irrational derive-type methods
 
 ;;; Derive the result to be float for argument types in the
@@ -515,7 +515,7 @@
                  (csubtypep (lvar-type y)
                             (specifier-type '(real $0.0)))))
     (specifier-type 'float)))
-
+
 ;;;; irrational transforms
 
 (macrolet ((def (name prim rtype)
@@ -594,7 +594,7 @@
 ;;; ANSI says log with base zero returns zero.
 (deftransform log ((x y) (float float) float)
   '(if (zerop y) y (/ (log x) (log y))))
-
+
 ;;; Handle some simple transformations.
 
 (deftransform abs ((x) ((complex double-float)) double-float)
@@ -1530,7 +1530,7 @@
     #'cis))
 
 ) ; PROGN
-
+
 ;;;; TRUNCATE, FLOOR, CEILING, and ROUND
 
 (macrolet ((define-frobs (fun ufun)

--- a/src/compiler/fndb.lisp
+++ b/src/compiler/fndb.lisp
@@ -12,7 +12,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; information for known functions:
 
 (defknown coerce (t type-specifier) t
@@ -40,7 +40,7 @@
 (defknown (sb-xc:upgraded-complex-part-type sb-xc:upgraded-array-element-type)
     (type-specifier &optional lexenv-designator) (or list symbol)
     (unsafely-flushable))
-
+
 ;;;; from the "Predicates" chapter:
 
 ;;; FIXME: Is it right to have TYPEP (and TYPE-OF, elsewhere; and
@@ -91,7 +91,7 @@
 (defknown fixnum-mod-p (t fixnum) boolean
   (movable foldable flushable always-translatable))
 
-
+
 ;;;; classes
 
 (sb-xc:deftype name-for-class () t) ; FIXME: disagrees w/ LEGAL-CLASS-NAME-P
@@ -104,7 +104,7 @@
 (defknown copy-structure (structure-object) structure-object
   (flushable)
   :derive-type #'result-type-first-arg)
-
+
 ;;;; from the "Control Structure" chapter:
 
 ;;; This is not FLUSHABLE, since it's required to signal an error if
@@ -154,7 +154,7 @@
 ;;; represented by a call to VALUES.
 (defknown values (&rest t) * (movable flushable))
 (defknown values-list (list) * (movable foldable unsafely-flushable))
-
+
 ;;;; from the "Macros" chapter:
 
 (defknown macro-function (symbol &optional lexenv-designator)
@@ -167,7 +167,7 @@
 (defknown compiler-macro-function (t &optional lexenv-designator)
   (or function null)
   (flushable))
-
+
 ;;;; from the "Declarations" chapter:
 
 (defknown proclaim (list) (values) (recursive))
@@ -191,7 +191,7 @@
 (defknown gensym (&optional (or string unsigned-byte)) symbol ())
 (defknown symbol-package (symbol) (or package null) (flushable))
 (defknown keywordp (t) boolean (flushable))       ; If someone uninterns it...
-
+
 ;;;; from the "Packages" chapter:
 
 (defknown gentemp (&optional string package-designator) symbol)
@@ -236,7 +236,7 @@
 ;; private
 (defknown package-iter-step (fixnum index simple-vector list)
   (values fixnum index simple-vector list symbol symbol))
-
+
 ;;;; from the "Numbers" chapter:
 
 (defknown zerop (number) boolean (movable foldable flushable))
@@ -451,7 +451,7 @@
   random-state (flushable))
 
 (defknown random-state-p (t) boolean (movable foldable flushable))
-
+
 ;;;; from the "Characters" chapter:
 (defknown (standard-char-p graphic-char-p alpha-char-p
                            upper-case-p lower-case-p both-case-p alphanumericp)
@@ -506,7 +506,7 @@
   ;; Common Lisp being able to handle any characters other than those
   ;; guaranteed by the ANSI spec.
   (movable #-sb-xc-host foldable flushable))
-
+
 ;;;; from the "Sequences" chapter:
 
 (defknown elt (proper-sequence index) t (foldable unsafely-flushable))
@@ -857,7 +857,7 @@
   sequence
   (recursive)
   :derive-type #'result-type-first-arg)
-
+
 ;;;; from the "Manipulating List Structure" chapter:
 (defknown (car cdr first rest)
   (list)
@@ -1033,7 +1033,7 @@
 
 (defknown (memq assq) (t proper-list) list (foldable flushable))
 (defknown (delq delq1) (t (modifying list)) list (flushable))
-
+
 ;;;; from the "Hash Tables" chapter:
 
 (defknown make-hash-table
@@ -1069,7 +1069,7 @@
 (defknown (sb-impl::signal-corrupt-hash-table
            sb-impl::signal-corrupt-hash-table-bucket)
  (t) nil ())
-
+
 ;;;; from the "Arrays" chapter
 
 (defknown make-array ((or index list)
@@ -1185,7 +1185,7 @@
          (:displaced-index-offset index))
   array ())
 ;  :derive-type 'result-type-arg1) Not even close...
-
+
 ;;;; from the "Strings" chapter:
 
 (defknown char (string index) character (foldable flushable))
@@ -1238,7 +1238,7 @@
   :derive-type #'result-type-first-arg)
 
 (defknown string (string-designator) string (flushable))
-
+
 ;;;; internal non-keyword versions of string predicates:
 
 (defknown (string<* string>* string<=* string>=* string/=*)
@@ -1254,13 +1254,13 @@
                      (inhibit-flushing index 0) (inhibit-flushing sequence-end nil))
   boolean
   (foldable flushable))
-
+
 ;;;; from the "Eval" chapter:
 
 (defknown eval (t) * (recursive))
 (defknown constantp (t &optional lexenv-designator) boolean
   (foldable flushable))
-
+
 ;;;; from the "Streams" chapter:
 
 (defknown make-synonym-stream (symbol) stream (flushable))
@@ -1286,7 +1286,7 @@
 (defknown file-string-length (ansi-stream (or string character))
   (or unsigned-byte null)
   (flushable))
-
+
 ;;;; from the "Input/Output" chapter:
 
 ;;; (The I/O functions are given effects ANY under the theory that
@@ -1478,7 +1478,7 @@
 
 (defknown (y-or-n-p yes-or-no-p) (&optional (or string null function) &rest t) boolean
   ())
-
+
 ;;;; from the "File System Interface" chapter:
 
 ;;; (No pathname functions are FOLDABLE because they all potentially
@@ -1609,7 +1609,7 @@
 
 (defknown directory (pathname-designator &key (:resolve-symlinks t))
   list ())
-
+
 ;;;; from the "Conditions" chapter:
 
 (defknown (signal warn) (condition-designator-head &rest t) null)
@@ -1639,7 +1639,7 @@
 (defknown simple-reader-error (stream string &rest t) nil)
 (defknown sb-kernel:reader-eof-error (stream string) nil)
 
-
+
 ;;;; from the "Miscellaneous" Chapter:
 
 (defknown compile ((or symbol cons) &optional (or list function))
@@ -1736,7 +1736,7 @@
 
 (defknown constantly (t) function (movable flushable))
 (defknown complement (function) function (movable flushable))
-
+
 ;;;; miscellaneous extensions
 
 (defknown (symbol-global-value sym-global-val) (symbol) t ()
@@ -1750,7 +1750,7 @@
 
 (defknown array-storage-vector (array) (simple-array * (*))
     (any))
-
+
 ;;;; magical compiler frobs
 
 (defknown %rest-values (t t t) * (always-translatable))
@@ -1926,7 +1926,7 @@
 (defknown %check-vector-sequence-bounds (vector index sequence-end)
   index
   (unwind))
-
+
 ;;;; SETF inverses
 
 (defknown (setf aref) (t (modifying array) &rest index) t ()
@@ -1953,7 +1953,7 @@
   :derive-type #'result-type-last-arg)
 (defknown %set-fill-pointer ((modifying complex-vector) index) index ()
   :derive-type #'result-type-last-arg)
-
+
 ;;;; ALIEN and call-out-to-C stuff
 
 (defknown %alien-funcall ((or string system-area-pointer) alien-type &rest *) *)

--- a/src/compiler/generic/early-type-vops.lisp
+++ b/src/compiler/generic/early-type-vops.lisp
@@ -9,7 +9,7 @@
 ;;;; provided with absolutely no warranty. See the COPYING and CREDITS
 ;;;; files for more information.
 (in-package "SB-VM")
-
+
 (defconstant-eqx +immediate-types+
   `(,unbound-marker-widetag ,character-widetag #+64-bit ,single-float-widetag)
   #'equal)

--- a/src/compiler/generic/genesis.lisp
+++ b/src/compiler/generic/genesis.lisp
@@ -40,7 +40,7 @@
 (defun round-up (number size)
   "Round NUMBER up to be an integral multiple of SIZE."
   (* size (ceiling number size)))
-
+
 ;;;; implementing the concept of "vector" in (almost) portable
 ;;;; Common Lisp
 ;;;;
@@ -142,7 +142,7 @@
             do (setf (svref new-outer-vector i) (make-smallvec)))
       (setf (bigvec-outer-vector bigvec)
             new-outer-vector))))
-
+
 ;;;; looking up bytes and multi-byte values in a BIGVEC (considering
 ;;;; it as an image of machine memory on the cross-compilation target)
 
@@ -179,7 +179,7 @@
 (macrolet ((acc (bv index) `(#+64-bit bvref-64 #-64-bit bvref-32 ,bv ,index)))
   (defun (setf bvref-word) (new-val bytes index) (setf (acc bytes index) new-val))
   (defun bvref-word (bytes index) (acc bytes index)))
-
+
 ;;;; representation of spaces in the core
 
 ;;; If there is more than one dynamic space in memory (i.e., if a
@@ -256,7 +256,7 @@
                                         (/ sb-vm:immobile-card-bytes sb-vm:n-word-bytes))
                                        (t
                                         0))))
-
+
 ;;;; representation of descriptors
 
 (declaim (inline is-fixnum-lowtag))
@@ -542,7 +542,7 @@
 (defun make-character-descriptor (data)
   (make-other-immediate-descriptor data sb-vm:character-widetag))
 
-
+
 ;;;; miscellaneous variables and other noise
 
 ;;; a handle on the trap object
@@ -561,7 +561,7 @@
 (declaim (special *!cold-toplevels* *!cold-defsymbols*
                   *!cold-defuns* *cold-methods*))
 
-
+
 ;;;; miscellaneous stuff to read and write the core memory
 
 ;; Like above, but the list is held in the target's image of the host symbol,
@@ -611,7 +611,7 @@
     (declare (type descriptor address) (type sb-vm:word index)
              (type (or sb-vm:word sb-vm:signed-word) bits))
     (write-bits (logand bits sb-ext:most-positive-word))))
-
+
 ;;;; allocating images of primitive objects in the cold core
 
 (defun write-header-word (des header-word)
@@ -731,7 +731,7 @@
     #-compact-instance-header
     (write-wordindexed des sb-vm:instance-slots-offset layout)
     des))
-
+
 ;;;; copying simple objects into the cold core
 
 (defun base-string-to-core (string &optional (gspace *dynamic*))
@@ -939,7 +939,7 @@ core and return a descriptor to it."
          (vector (make-array len)))
     (dotimes (i len vector)
       (setf (aref vector i) (funcall transform (cold-svref descriptor i))))))
-
+
 ;;;; symbol magic
 
 #+sb-thread
@@ -1024,7 +1024,7 @@ core and return a descriptor to it."
           ;; way we build other primordial stuff such as layout-of-layout.
           (cold-set symbol target-val)
           target-val)))))
-
+
 ;;;; layouts and type system pre-initialization
 
 ;;; Since we want to be able to dump structure constants and
@@ -1333,7 +1333,7 @@ core and return a descriptor to it."
              (list     (chill-layout 'list t-layout sequence))
              (symbol   (chill-layout 'symbol t-layout)))
         (chill-layout 'null t-layout sequence list symbol)))))
-
+
 ;;;; interning symbols in the cold image
 
 ;;; a map from package name as a host string to
@@ -1800,7 +1800,7 @@ core and return a descriptor to it."
     (cold-set 'sb-vm::*fp-constant-1d0* (number-to-core $1d0))
     (cold-set 'sb-vm::*fp-constant-0f0* (number-to-core $0f0))
     (cold-set 'sb-vm::*fp-constant-1f0* (number-to-core $1f0))))
-
+
 ;;;; functions and fdefinition objects
 
 ;;; a hash table mapping from fdefinition names to descriptors of cold
@@ -2004,7 +2004,7 @@ core and return a descriptor to it."
                                     (descriptor elt)))
                           info)))))
 
-
+
 ;;;; fixups and related stuff
 
 ;;; an EQUAL hash table
@@ -2260,7 +2260,7 @@ core and return a descriptor to it."
                (cold-cons (cold-intern (first rtn)) (make-fixnum-descriptor (cdr rtn))))
              '*!initial-assembler-routines*)))
 
-
+
 ;;;; general machinery for cold-loading FASL files
 
 (defun pop-fop-stack (stack)
@@ -2311,7 +2311,7 @@ core and return a descriptor to it."
     (write-line (namestring filename)))
   (with-open-file (s filename :element-type '(unsigned-byte 8))
     (load-as-fasl s nil nil)))
-
+
 ;;;; miscellaneous cold fops
 
 (define-cold-fop (fop-misc-trap) *unbound-marker*)
@@ -2379,7 +2379,7 @@ core and return a descriptor to it."
                  (bug "can't alter layout of ~s" name))))
         ;; Make a new definition from scratch.
         (make-cold-layout name depthoid flags length bitmap inherits))))
-
+
 ;;;; cold fops for loading symbols
 
 ;;; Given STRING naming a symbol exported from COMMON-LISP, return either "SB-XC"
@@ -2428,14 +2428,14 @@ core and return a descriptor to it."
                (read-wordindexed symbol sb-vm:symbol-name-slot)))))
     ;; Genesis performs additional coalescing of uninterned symbols
     (push-fop-table (get-uninterned-symbol name) (fasl-input))))
-
+
 ;;;; cold fops for loading packages
 
 (define-cold-fop (fop-named-package-save (namelen))
   (let ((name (make-string namelen)))
     (read-string-as-bytes (fasl-input-stream) name)
     (push-fop-table (find-package name) (fasl-input))))
-
+
 ;;;; cold fops for loading vectors
 
 (define-cold-fop (fop-base-string (len))
@@ -2490,7 +2490,7 @@ core and return a descriptor to it."
                          (make-fixnum-descriptor total-elements)))
     result))
 
-
+
 ;;;; cold fops for calling (or not calling)
 
 (not-cold-fop fop-eval)
@@ -2564,7 +2564,7 @@ core and return a descriptor to it."
                              *load-time-value-counter*
                              *load-time-value-counter*)))
 
-
+
 ;;;; cold fops for fixing up circularities
 
 (define-cold-fop (fop-rplaca (tbl-slot idx))
@@ -2590,7 +2590,7 @@ core and return a descriptor to it."
   (dotimes (i index)
     (setq obj (read-wordindexed obj sb-vm:cons-cdr-slot)))
   obj)
-
+
 ;;;; cold fops for loading code objects and functions
 
 (define-cold-fop (fop-fdefn)
@@ -2762,7 +2762,7 @@ core and return a descriptor to it."
                  (member flavor '(:assembly-routine :assembly-routine*)))
         (push (cold-cons code-obj (make-fixnum-descriptor offset))
               *allocation-point-fixup-notes*)))))
-
+
 ;;;; sanity checking space layouts
 
 (defun check-spaces ()
@@ -2791,7 +2791,7 @@ core and return a descriptor to it."
       (check sb-vm:dynamic-0-space-start sb-vm:dynamic-0-space-end :dynamic-0)
       #+linkage-table
       (check sb-vm:linkage-table-space-start sb-vm:linkage-table-space-end :linkage-table))))
-
+
 ;;;; emitting C header file
 
 (defun tailwise-equal (string tail)
@@ -3230,7 +3230,7 @@ core and return a descriptor to it."
 };~2%")
     (write-array "sc_and_offset_sc_number_bytes" sb-c::+sc+offset-scn-bytes+)
     (write-array "sc_and_offset_offset_bytes"    sb-c::+sc+offset-offset-bytes+)))
-
+
 ;;;; writing map file
 
 ;;; Write a map file describing the cold load. Some of this
@@ -3316,7 +3316,7 @@ III. initially undefined function references (alphabetically):
           (sort (%hash-table-alist *cold-symbols*) #'< :key #'car))
 
   (values))
-
+
 ;;;; writing core file
 
 (defun output-gspace (gspace data-page core-file write-word verbose)
@@ -3464,7 +3464,7 @@ III. initially undefined function references (alphabetically):
     (format t "done]~%")
     (force-output))
   (values))
-
+
 ;;;; the actual GENESIS function
 
 ;;; Read the FASL files in OBJECT-FILE-NAMES and produce a Lisp core,

--- a/src/compiler/generic/late-nlx.lisp
+++ b/src/compiler/generic/late-nlx.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Return a list of TNs that can be used to snapshot the dynamic
 ;;; state for use with the SAVE- and RESTORE-DYNAMIC-ENVIRONMENT VOPs.
 (defun make-dynamic-state-tns ()

--- a/src/compiler/generic/late-type-vops.lisp
+++ b/src/compiler/generic/late-type-vops.lisp
@@ -9,7 +9,7 @@
 ;;;; provided with absolutely no warranty. See the COPYING and CREDITS
 ;;;; files for more information.
 (in-package "SB-VM")
-
+
 
 ;;; FIXME: backend-specific junk doesn't belong in compiler/generic.
 

--- a/src/compiler/generic/objdef.lisp
+++ b/src/compiler/generic/objdef.lisp
@@ -29,7 +29,7 @@
 ;;;;     the beginning of an arbitrary-length sequence of bytes following
 ;;;;     the fixed-layout slots).
 ;;;; -- WHN 2001-12-29
-
+
 ;;;; the primitive objects themselves
 
 (define-primitive-object (cons :type cons
@@ -337,7 +337,7 @@ during backtrace.
   #+x86-64 bsp
   (previous-catch :c-type #-alpha "struct catch_block *" #+alpha "u32")
   tag)
-
+
 ;;;; symbols
 
 (define-primitive-object (symbol :lowtag other-pointer-lowtag

--- a/src/compiler/generic/pinned-objects.lisp
+++ b/src/compiler/generic/pinned-objects.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (defmacro with-pinned-objects ((&rest objects) &body body)
   #.(concatenate 'string
   "Arrange with the garbage collector that the pages occupied by

--- a/src/compiler/generic/primtype.lisp
+++ b/src/compiler/generic/primtype.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; primitive type definitions
 
 (/show0 "primtype.lisp 17")
@@ -135,7 +135,7 @@
 ;;; miscellaneous primitive types that don't exist at the LISP level
 (!def-primitive-type catch-block (catch-block) :type nil)
 (!def-primitive-type unwind-block (unwind-block) :type nil)
-
+
 ;;;; PRIMITIVE-TYPE-OF and friends
 
 ;;; Return the most restrictive primitive type that contains OBJECT.

--- a/src/compiler/generic/sanctify.lisp
+++ b/src/compiler/generic/sanctify.lisp
@@ -13,7 +13,7 @@
 ;;;; more information.
 
 (in-package "SB-VM")
-
+
 ;;; Do whatever is necessary to make the given code component
 ;;; executable.  This isn't always strictly necessary (some ARM
 ;;; systems have coherent caches, for example), but it covers the

--- a/src/compiler/generic/type-error.lisp
+++ b/src/compiler/generic/type-error.lisp
@@ -9,7 +9,7 @@
 ;;;; provided with absolutely no warranty. See the COPYING and CREDITS
 ;;;; files for more information.
 (in-package "SB-VM")
-
+
 ;;; (ARRAY NIL) stuff looks the same on all platforms
 ;;;
 ;;; This is separate from DATA-VECTOR-REF, because it's declared as
@@ -84,7 +84,7 @@
     ;; a jump, it's in the regular segment which pollutes the
     ;; instruction pipe with undecodable junk (the sc-numbers).
     (error-call vop errcode object)))
-
+
 #+immobile-space
 (defun type-err-type-tn-loadp (thing)
   (cond ((sc-is thing immediate)
@@ -137,7 +137,7 @@
   (def failed-aver sb-kernel::failed-aver-error
     sb-impl::%failed-aver
     nil form))
-
+
 
 (defun emit-internal-error (kind code values &key trap-emitter
                                                   (compact-error-trap t))

--- a/src/compiler/generic/utils.lisp
+++ b/src/compiler/generic/utils.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Make a fixnum out of NUM. (I.e. shift by two bits if it will fit.)
 (defun fixnumize (num)
   (if (fixnump num)
@@ -31,7 +31,7 @@
           (displacement-bounds lowtag element-size data-offset)
         (<= min offset max))))
 
-
+
 ;;;; routines for dealing with static symbols
 
 (defun static-symbol-p (symbol)
@@ -76,7 +76,7 @@
   (+ (static-fdefn-offset name)
      (- other-pointer-lowtag)
      (* fdefn-raw-addr-slot n-word-bytes)))
-
+
 ;;;; interfaces to IR2 conversion
 
 ;;; Return a wired TN describing the N'th full call argument passing

--- a/src/compiler/generic/vm-fndb.lisp
+++ b/src/compiler/generic/vm-fndb.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; internal type predicates
 
 ;;; Simple TYPEP uses that don't have any standard predicate are
@@ -92,7 +92,7 @@
 ;;; Predicates that don't accept T for the first argument type
 (defknown (float-infinity-p float-nan-p float-infinity-or-nan-p)
   (float) boolean (movable foldable flushable))
-
+
 ;;;; miscellaneous "sub-primitives"
 
 (defknown pointer-hash (t) hash (flushable))
@@ -375,7 +375,7 @@
          (and fixnum unsigned-byte)) ; not flushable
        (defknown symbol-tls-index (symbol)
          (and fixnum unsigned-byte) (flushable)))
-
+
 ;;;; debugger support
 
 (defknown sb-vm::current-thread-offset-sap (fixnum)
@@ -388,7 +388,7 @@
 (defknown fun-code-header (t) t (movable flushable))
 (defknown %make-lisp-obj (sb-vm:word) t (movable flushable))
 (defknown get-lisp-obj-address (t) sb-vm:word (flushable))
-
+
 ;;;; 32-bit logical operations
 
 (defknown word-logical-not (sb-vm:word) sb-vm:word
@@ -405,7 +405,7 @@
 (defknown (shift-towards-start shift-towards-end) (sb-vm:word fixnum)
   sb-vm:word
   (foldable flushable movable))
-
+
 ;;;; bignum operations
 
 (defknown %allocate-bignum (bignum-length) bignum
@@ -465,7 +465,7 @@
 (defknown (%ashl %ashr %digit-logical-shift-right)
           (bignum-element-type (mod #.sb-vm:n-word-bits)) bignum-element-type
   (foldable flushable movable))
-
+
 ;;;; bit-bashing routines
 
 ;;; FIXME: there's some ugly duplication between the (INTERN (FORMAT ...))
@@ -500,7 +500,7 @@
    (or (simple-unboxed-array (*)) system-area-pointer) index index)
   (values)
   ())
-
+
 ;;;; code/function/fdefn object manipulation routines
 
 ;;; Return a SAP pointing to the instructions part of CODE-OBJ.
@@ -548,7 +548,7 @@
 #+sb-fasteval
 (defknown sb-interpreter:fun-proto-fn (interpreted-function)
   sb-interpreter::interpreted-fun-prototype (flushable))
-
+
 
 (defknown %data-vector-and-index (array index)
                                  (values (simple-array * (*)) index)

--- a/src/compiler/generic/vm-macs.lisp
+++ b/src/compiler/generic/vm-macs.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; other miscellaneous stuff
 
 ;;; This returns a form that returns a dual-word aligned number of bytes when
@@ -21,7 +21,7 @@
 ;;; FIXME: should be called PAD-DATA-BLOCK-SIZE
 (defmacro pad-data-block (words)
   `(logandc2 (+ (ash ,words word-shift) lowtag-mask) lowtag-mask))
-
+
 ;;;; primitive object definition stuff
 
 (defun remove-keywords (options keywords)
@@ -180,7 +180,7 @@
                      ,sb-name ,@args)
                    (defconstant ,constant-name ,sc-number))))))
       `(progn ,@(mapcan #'process-class classes)))))
-
+
 ;;;; some general constant definitions
 
 ;;; The maximum number of storage classes and offsets within a given
@@ -200,7 +200,7 @@
   (integer-length (1- finite-sc-offset-limit)))
 (deftype finite-sc-offset () `(integer 0 (,finite-sc-offset-limit)))
 (deftype finite-sc-offset-map () `(unsigned-byte ,finite-sc-offset-limit))
-
+
 ;;;; stuff for defining reffers and setters
 
 (in-package "SB-C")

--- a/src/compiler/generic/vm-tran.lisp
+++ b/src/compiler/generic/vm-tran.lisp
@@ -97,7 +97,7 @@
     `(truly-the layout (%funcallable-instance-info ,x 0)))
   (define-source-transform %set-funcallable-instance-layout (x val)
     `(setf (%funcallable-instance-info ,x 0) (the layout ,val))))
-
+
 ;;;; simplifying HAIRY-DATA-VECTOR-REF and HAIRY-DATA-VECTOR-SET
 
 (deftransform hairy-data-vector-ref ((string index) (simple-string t))
@@ -348,7 +348,7 @@
   '(if (array-header-p %array)
        (values (%array-data %array) %index)
        (values %array %index)))
-
+
 ;;;; BIT-VECTOR hackery
 
 ;;; SIMPLE-BIT-VECTOR bit-array operations are transformed to a word
@@ -576,7 +576,7 @@
           (declare (optimize (speed 3) (safety 0))
                    (type index index))
           (setf (%vector-raw-bits sequence index) value))))))
-
+
 ;;;; %BYTE-BLT
 
 ;;; FIXME: The old CMU CL code used various COPY-TO/FROM-SYSTEM-AREA
@@ -622,7 +622,7 @@
                (sap+ (sapify src) src-start)
                (- dst-end dst-start)))
      (values)))
-
+
 ;;;; transforms for EQL of floating point values
 #-(vop-named sb-vm::eql/single-float)
 (deftransform eql ((x y) (single-float single-float))
@@ -634,7 +634,7 @@
                   (= (double-float-high-bits x) (double-float-high-bits y)))
   #+64-bit '(= (double-float-bits x) (double-float-bits y)))
 
-
+
 ;;;; modular functions
 ;;;
 ;;; FIXME: I think that the :GOODness of a modular function boils down
@@ -658,7 +658,7 @@
   (define-good-signed-modular-funs
       logand logandc1 logandc2 logeqv logior lognand lognor lognot
       logorc1 logorc2 logxor))
-
+
 ;;;; word-wise logical operations
 
 ;;; These transforms assume the presence of modular arithmetic to
@@ -697,7 +697,7 @@
 (deftransform word-logical-andc2 ((x y))
   `(logand (logandc2 x y) ,most-positive-word))
 
-
+
 ;;; There are two different ways the multiplier can be recoded. The
 ;;; more obvious is to shift X by the correct amount for each bit set
 ;;; in Y and to sum the results. But if there is a string of bits that
@@ -747,7 +747,7 @@
             adds
             shifts)))
 
-
+
 ;;; Transform GET-LISP-OBJ-ADDRESS for constant immediates, since the normal
 ;;; VOP can't handle them.
 

--- a/src/compiler/generic/vm-type.lisp
+++ b/src/compiler/generic/vm-type.lisp
@@ -68,7 +68,7 @@
   `(integer 0 ,(* (1- (ash 1 (- sb-vm:n-word-bits sb-vm:n-widetag-bits)))
                   sb-vm:n-word-bits)))
 
-
+
 ;;;; hooks into the type system
 
 (sb-xc:deftype unboxed-array (&optional dims)

--- a/src/compiler/generic/vm-typetran.lisp
+++ b/src/compiler/generic/vm-typetran.lisp
@@ -12,7 +12,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; internal predicates
 
 ;;; These type predicates are used to implement simple cases of TYPEP.
@@ -123,7 +123,7 @@
 ;;; accepting any type object.
 (define-type-predicate %standard-char-p standard-char)
 (define-type-predicate non-null-symbol-p (and symbol (not null)))
-
+
 (defglobal *backend-type-predicates-grouped*
     (let (plist)
       (loop for (type . pred) in *backend-type-predicates*

--- a/src/compiler/globaldb.lisp
+++ b/src/compiler/globaldb.lisp
@@ -40,7 +40,7 @@
     (format stream "~S ~S, ~D" (meta-info-category x) (meta-info-kind x)
             (meta-info-number x))))
 
-
+
 ;;; Why do we suppress the :COMPILE-TOPLEVEL situation here when we're
 ;;; running the cross-compiler? The cross-compiler (which was built
 ;;; from these sources) has its version of these data and functions
@@ -90,7 +90,7 @@
             :category category :kind kind :type-spec type-spec
             :type-checker checker :validate-function validator
             :default default :number id)))))
-
+
 ;;;; info types, and type numbers, part II: what's
 ;;;; needed only at compile time, not at run time
 
@@ -130,7 +130,7 @@
                 #+sb-xc (meta-info-number (meta-info category kind)))))
 ;; It's an external symbol of SB-INT so wouldn't be removed automatically
 (push '("SB-INT" define-info-type) *!removable-symbols*)
-
+
 
 (macrolet ((meta-info-or-lose (category kind)
              ;; don't need to type-check META-INFO's result, since it
@@ -249,7 +249,7 @@
       (when hookp
         (funcall (truly-the function (cdr hook)) name info-number answer nil))
       (values answer nil))))
-
+
 ;;;; ":FUNCTION" subsection - Data pertaining to globally known functions.
 (define-info-type (:function :definition) :type-spec #-sb-xc-host (or fdefn null) #+sb-xc-host t)
 
@@ -369,7 +369,7 @@
 ;;;   (AND (SATISFIES UNINTERESTING-METHOD-REDEFINITION-P) RATIONAL)
 ;;; is *empty-type*, which in turn avoids type cache pollution.
 (define-info-type (:function :predicate-truth-constraint) :type-spec t)
-
+
 ;;;; ":VARIABLE" subsection - Data pertaining to globally known variables.
 
 ;;; the kind of variable-like thing described

--- a/src/compiler/hppa/alloc.lisp
+++ b/src/compiler/hppa/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; LIST and LIST*
 (define-vop (list-or-list*)
   (:args (things :more t))
@@ -75,7 +75,7 @@
 (define-vop (list* list-or-list*)
   (:variant t))
 
-
+
 ;;;; Special purpose inline allocators.
 ;;; ALLOCATE-VECTOR
 (define-vop (allocate-vector-on-heap)
@@ -163,7 +163,7 @@
     (with-fixed-allocation
         (result nil temp value-cell-widetag value-cell-size stack-allocate-p)
       (storew value result value-cell-value-slot other-pointer-lowtag))))
-
+
 ;;;; Automatic allocators for primitive objects.
 
 (define-vop (make-unbound-marker)

--- a/src/compiler/hppa/arith.lisp
+++ b/src/compiler/hppa/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Unary operations.
 
 (define-vop (fast-safe-arith-op)
@@ -52,7 +52,7 @@
   (:translate lognot)
   (:generator 2
     (inst uaddcm zero-tn x res)))
-
+
 ;;;; Binary fixnum operations.
 
 ;;; Assume that any constant operand is the second arg...
@@ -529,7 +529,7 @@
     (move q-pass q)
     (move r-pass r)))
 
-
+
 ;;;; Binary conditional VOPs:
 
 (define-vop (fast-conditional)
@@ -640,7 +640,7 @@
   (:arg-types * (:constant (signed-byte 9)))
   (:variant-cost 6))
 
-
+
 ;;;; modular functions
 (define-modular-fun +-mod32 (x y) + :untagged nil 32)
 (define-vop (fast-+-mod32/unsigned=>unsigned fast-+/unsigned=>unsigned)
@@ -720,7 +720,7 @@
     (inst shd zero-tn num :variable r)))
 
 
-
+
 ;;;; Bignum stuff.
 
 (define-vop (bignum-length get-header-data)

--- a/src/compiler/hppa/array.lisp
+++ b/src/compiler/hppa/array.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Allocator for the array header.
 (define-vop (make-array-header)
   (:translate make-array-header)
@@ -37,7 +37,7 @@
       (storew header result 0 other-pointer-lowtag)
       (inst add bytes alloc-tn alloc-tn))))
 
-
+
 ;;;; Additional accessors and setters for the array header.
 (define-full-reffer %array-dimension *
   array-dimensions-offset other-pointer-lowtag
@@ -57,7 +57,7 @@
     (inst sra res n-widetag-bits res)
     (inst addi (- (1- array-dimensions-offset)) res res)
     (inst sll res n-fixnum-tag-bits res)))
-
+
 ;;;; Bounds checking routine.
 (define-vop (check-bound)
   (:translate %check-bound)
@@ -73,7 +73,7 @@
       (%test-fixnum index nil error t)
       (inst bc :>>= nil index bound error))))
 
-
+
 ;;;; Accessors/Setters
 
 ;;; Variants built on top of word-index-ref, etc.  I.e. those vectors whos
@@ -373,7 +373,7 @@
       (unless (location= result-imag value-imag)
         (inst funop :copy value-imag result-imag)))))
 
-
+
 ;;; These vops are useful for accessing the bits of a vector irrespective of
 ;;; what type of vector it is.
 (define-full-reffer vector-raw-bits * vector-data-offset other-pointer-lowtag

--- a/src/compiler/hppa/call.lisp
+++ b/src/compiler/hppa/call.lisp
@@ -55,7 +55,7 @@
 ;;; are using non-standard conventions.
 (defun make-arg-count-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn nargs-offset))
-
+
 ;;; bytes-needed-for-non-descriptor-stack-frame is the amount
 ;;; we grow or shrink the NSP/NFP stack. This stack is used
 ;;; by C-code so the convention (grow direction, grow size)
@@ -164,7 +164,7 @@
       (move csp-tn res)
       (inst ldo (* nargs n-word-bytes) csp-tn csp-tn))))
 
-
+
 ;;; Fix: boil down below notes into something nicer
 ;;; Emit code needed at the return-point from an unknown-values call for a
 ;;; fixed number of values.  VALUES is the head of the TN-REF list for the
@@ -309,7 +309,7 @@ default-value-8
           (inst compute-code-from-lra code-tn lra-label temp code-tn)))))
   (values))
 
-
+
 ;;;; Unknown values receiving:
 
 ;;;    Emit code needed at the return point for an unknown-values call for an
@@ -372,7 +372,7 @@ default-value-8
               nvals)
   (:temporary (:scs (non-descriptor-reg)) temp))
 
-
+
 ;;; This hook in the codegen pass lets us insert code before fall-thru entry
 ;;; points, local-call entry points, and tail-call entry points.  The default
 ;;; does nothing.
@@ -382,7 +382,7 @@ default-value-8
     (emit-label trampoline-label))
   (emit-label start-label))
 
-
+
 ;;;; Local call with unknown values convention return:
 
 ;;; Non-TR local call for a fixed number of values passed according to the
@@ -473,7 +473,7 @@ default-value-8
       (when cur-nfp
         (load-stack-tn cur-nfp nfp-save)))))
 
-
+
 ;;;; Local call with known values return:
 
 ;;; Non-TR local call with known return locations.  Known-value return works
@@ -543,7 +543,7 @@ default-value-8
     (inst bv lip)
     (move ocfp-temp cfp-tn t)))
 
-
+
 ;;;; Full call:
 ;;;
 ;;;    There is something of a cross-product effect with full calls.  Different
@@ -883,7 +883,7 @@ default-value-8
         (move cur-nfp nsp-tn)
         (inst nop)))))
 
-
+
 ;;;; Unknown values return:
 
 ;;; Return a single value using the unknown-values convention.
@@ -1007,7 +1007,7 @@ default-value-8
         (inst ldil fixup tmp)
         (inst be fixup lisp-heap-space tmp :nullify t)))))
 
-
+
 ;;;; XEP hackery:
 
 ;;; Get the lexical environment from its passing location.

--- a/src/compiler/hppa/cell.lisp
+++ b/src/compiler/hppa/cell.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Data object ref/set stuff.
 
 (define-vop (slot)
@@ -34,7 +34,7 @@
 (define-vop (init-slot set-slot)
   (:info name dx-p offset lowtag)
   (:ignore name dx-p))
-
+
 ;;;; Symbol hacking VOPs:
 
 ;;; The compiler likes to be able to directly SET symbols.
@@ -102,7 +102,7 @@
   (:translate sym-global-val))
 (define-vop (fast-symbol-global-value fast-symbol-value)
   (:translate sym-global-val))
-
+
 ;;;; Fdefinition (fdefn) objects.
 
 (define-vop (fdefn-fun cell-ref)
@@ -155,7 +155,7 @@
     (storew temp fdefn fdefn-raw-addr-slot other-pointer-lowtag)
     (move fdefn result)))
 
-
+
 ;;;; Binding and Unbinding.
 
 ;;; BIND -- Establish VAL as a binding for SYMBOL.  Save the old value and
@@ -210,7 +210,7 @@
       (inst nop)
       (emit-label done))))
 
-
+
 ;;;; Closure indexing.
 
 (define-full-reffer closure-index-ref *
@@ -244,7 +244,7 @@
   (:info offset)
   (:generator 4
     (storew cfp-tn object (+ closure-info-offset offset) fun-pointer-lowtag)))
-
+
 ;;;; Value Cell hackery.
 
 (define-vop (value-cell-ref cell-ref)
@@ -254,7 +254,7 @@
   (:variant value-cell-value-slot other-pointer-lowtag))
 
 
-
+
 ;;;; Instance hackery:
 
 (define-vop (instance-length)
@@ -274,7 +274,7 @@
   instance-pointer-lowtag (descriptor-reg any-reg null zero) * %instance-set)
 
 
-
+
 ;;;; Code object frobbing.
 
 (define-full-reffer code-header-ref * 0 other-pointer-lowtag
@@ -283,7 +283,7 @@
 (define-full-setter code-header-set * 0 other-pointer-lowtag
   (descriptor-reg any-reg null zero) * code-header-set)
 
-
+
 ;;;; raw instance slot accessors
 (macrolet ((lfloat (imm base dst &key side)
              `(cond

--- a/src/compiler/hppa/char.lisp
+++ b/src/compiler/hppa/char.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged char to an untagged representation.
@@ -68,7 +68,7 @@
 ;;; a descriptor passing location.
 (define-move-vop move-arg :move-arg
   (character-reg) (any-reg descriptor-reg))
-
+
 ;;;; Other operations:
 (define-vop (char-code)
   (:translate char-code)
@@ -89,7 +89,7 @@
   (:result-types character)
   (:generator 1
     (inst srl code 2 res)))
-
+
 ;;; Comparison of characters.
 (define-vop (character-compare)
   (:args (x :scs (character-reg))

--- a/src/compiler/hppa/float.lisp
+++ b/src/compiler/hppa/float.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Move functions.
 (define-move-fun (load-fp-zero 1) (vop x y)
   ((fp-single-zero) (single-reg)
@@ -51,7 +51,7 @@
    (double-reg) (double-stack))
   (let ((offset (tn-byte-offset y)))
     (str-float x offset (current-nfp-tn vop))))
-
+
 ;;;; Move VOPs
 (define-vop (move-float)
   (:args (x :scs (single-reg double-reg)
@@ -123,7 +123,7 @@
   (single-reg descriptor-reg) (single-reg))
 (define-move-vop move-float-arg :move-arg
   (double-reg descriptor-reg) (double-reg))
-
+
 ;;;; Complex float move functions
 (defun complex-single-reg-real-tn (x)
   (make-random-tn :kind :normal :sc (sc-or-lose 'single-reg)
@@ -321,7 +321,7 @@
 (define-move-vop move-arg :move-arg
   (single-reg double-reg complex-single-reg complex-double-reg)
   (descriptor-reg))
-
+
 ;;;; stuff for c-call float-in-int-register arguments
 (define-vop (move-to-single-int-reg)
   (:note "pointer to float-in-int coercion")
@@ -517,7 +517,7 @@
                   DONE))))
   (frob %negate/single-float %negate single-reg single-float fp-single-zero-tn)
   (frob %negate/double-float %negate double-reg double-float fp-double-zero-tn))
-
+
 ;;;; Comparison:
 
 (define-vop (float-compare)
@@ -557,7 +557,7 @@
   (frob > #b10001 #b01101 >/single-float >/double-float)
   (frob = #b00101 #b11001 =/single-float =/double-float))
 
-
+
 ;;;; Conversion:
 
 (macrolet ((frob (name translate from-sc from-type to-sc to-type)
@@ -876,7 +876,7 @@
                       (t
                        (error "set-floating-point-modes error, ldo offset too large")))
                 (move new res))))
-
+
 ;;;; Complex float VOPs
 
 (define-vop (make-complex-single-float)

--- a/src/compiler/hppa/insts.lisp
+++ b/src/compiler/hppa/insts.lisp
@@ -22,7 +22,7 @@
             sb-vm::zero-tn
             sb-vm::null-offset sb-vm::code-offset sb-vm::zero-offset)))
 
-
+
 ;;;; Utility functions.
 
 (defun reg-tn-encoding (tn)
@@ -129,7 +129,7 @@
        (byte 2 1)
        (ldb (byte 1 2) space)))
 
-
+
 ;;;; Initial disassembler setup.
 
 (defvar *disassem-use-lisp-reg-names* t)
@@ -304,7 +304,7 @@
                    ((= reg null-offset)
                     (maybe-note-nil-indexed-object offset dstate)))))))
 
-
+
 ;;;; Define-instruction-formats for disassembler.
 
 (define-instruction-format (load/store 32)
@@ -468,7 +468,7 @@
   (t   :field (byte 5 0) :type 'fp-reg))
 
 
-
+
 ;;;; Load and Store stuff.
 
 (define-bitfield-emitter emit-load/store 32
@@ -669,7 +669,7 @@
                              4 #xC (if modify 1 0)
                              (short-disp-encoding segment disp))))
 
-
+
 ;;;; Immediate 21-bit Instructions.
 ;;; Note the heavy scrambling of the immediate value to instruction memory
 
@@ -699,7 +699,7 @@
    (emit-imm21 segment #x0A (reg-tn-encoding reg)
                (encode-imm21 segment value))))
 
-
+
 ;;;; Branch instructions.
 
 (define-bitfield-emitter emit-branch 32
@@ -918,7 +918,7 @@
                               (reg-tn-encoding reg)
                               (if cond 2 6) target nullify))))
 
-
+
 ;;;; Computation Instructions
 
 (define-bitfield-emitter emit-r3-inst 32
@@ -1108,7 +1108,7 @@
   (define-deposit-inst zdep 0))
 
 
-
+
 ;;;; System Control Instructions.
 
 (define-bitfield-emitter emit-break 32
@@ -1187,7 +1187,7 @@
                      (reg-tn-encoding reg))))
 
 
-
+
 ;;;; Floating point instructions.
 
 (define-bitfield-emitter emit-fp-load/store 32
@@ -1411,7 +1411,7 @@
                                result-encoding))))))
 
 
-
+
 ;;;; Instructions built out of other insts.
 
 (define-instruction-macro move (src dst &optional cond)
@@ -1522,7 +1522,7 @@
                         (maybe-negate-cond cond (not not-p)))
                   (inst b target :nullify t)))))))))
 
-
+
 ;;;; Instructions to convert between code ptrs, functions, and lras.
 
 (defun emit-header-data (segment type)
@@ -1605,7 +1605,7 @@
      (lambda (label posn delta-if-after)
        (+ (label-position label posn delta-if-after)
           (component-header-length)))))
-
+
 ;;;; Data instructions.
 (define-bitfield-emitter emit-word 32
   (byte 32 0))

--- a/src/compiler/hppa/macros.lisp
+++ b/src/compiler/hppa/macros.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 (in-package "SB-VM")
 
-
+
 
 (defmacro expand (expr)
   (let ((gensym (gensym)))
@@ -108,7 +108,7 @@ byte-ordering issues."
      (emit-label ,label)
      (inst lra-header-word)))
 
-
+
 ;;;; Stack TN's
 
 ;;; Move a stack TN to a register and vice-versa.
@@ -140,7 +140,7 @@ byte-ordering issues."
           ((control-stack)
            (loadw ,n-reg cfp-tn (tn-offset ,n-stack))))))))
 
-
+
 ;;;; Storage allocation:
 
 (defmacro with-fixed-allocation ((result-tn flag-tn temp-tn type-code
@@ -186,7 +186,7 @@ initializes the object."
     (storew zero-tn csp-tn -1)
     (emit-label aligned)))
 
-
+
 ;;;; Error Code
 (defun emit-error-break (vop kind code values)
   (assemble ()
@@ -206,7 +206,7 @@ initializes the object."
       (emit-label start-lab)
       (apply #'error-call vop error-code values)
       start-lab)))
-
+
 ;;;; PSEUDO-ATOMIC
 
 ;;; handy macro for making sequences look atomic
@@ -224,7 +224,7 @@ initializes the object."
          (t
           ;; FIXME: Make this case work, somehow
           (error "EXTRA out-of-range in PSEUDO-ATOMIC"))))))
-
+
 ;;;; indexed references
 
 (sb-xc:deftype load/store-index (scale lowtag min-offset

--- a/src/compiler/hppa/move.lisp
+++ b/src/compiler/hppa/move.lisp
@@ -73,7 +73,7 @@
   (let ((nfp (current-nfp-tn vop)))
     (storew x nfp (tn-offset y))))
 
-
+
 ;;;; The Move VOP:
 (define-vop (move)
   (:args (x :target y
@@ -110,7 +110,7 @@
 (define-move-vop move-arg :move-arg
   (any-reg descriptor-reg null zero)
   (any-reg descriptor-reg))
-
+
 ;;;; Moves and coercions:
 
 ;;; These MOVE-TO-WORD VOPs move a tagged integer to a raw full-word

--- a/src/compiler/hppa/nlx.lisp
+++ b/src/compiler/hppa/nlx.lisp
@@ -4,7 +4,7 @@
 ;;; non-local entry.
 (defun make-nlx-entry-arg-start-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn ocfp-offset))
-
+
 ;;; Save and restore dynamic environment.
 ;;;
 ;;; These VOPs are used in the reentered function to restore the appropriate
@@ -57,7 +57,7 @@
   (:args (nsp :scs (any-reg descriptor-reg)))
   (:generator 1
     (move nsp-tn nsp)))
-
+
 ;;;; Unwind block hackery:
 
 ;;; Compute the address of the catch block from its TN, then store into the
@@ -131,7 +131,7 @@
     (loadw block block unwind-block-uwp-slot)
     (store-symbol-value block *current-unwind-protect-block*)))
 
-
+
 ;;;; NLX entry VOPs:
 
 

--- a/src/compiler/hppa/parms.lisp
+++ b/src/compiler/hppa/parms.lisp
@@ -8,7 +8,7 @@
 
 (defconstant +backend-fasl-file-implementation+ :hppa)
 (defconstant +backend-page-bytes+ 4096)
-
+
 ;;;; Machine Architecture parameters:
 (eval-when (:compile-toplevel :load-toplevel :execute)
 
@@ -60,7 +60,7 @@
 (defconstant float-fast-bit 0)                   ; No fast mode on HPPA.
 
 
-
+
 ;;;; Description of the target address space.
 
 ;;; Where to put the different spaces.
@@ -85,7 +85,7 @@
 ;; The space-register holding the C text heap.
 (defconstant c-text-space 4)
 
-
+
 ;;;; Other random constants.
 
 (defenum ()
@@ -103,7 +103,7 @@
   single-step-before-trap
   single-step-after-trap
   error-trap)
-
+
 ;;;; Static symbols.
 
 ;;; These symbols are loaded into static space directly after NIL so

--- a/src/compiler/hppa/pred.lisp
+++ b/src/compiler/hppa/pred.lisp
@@ -1,6 +1,6 @@
 (in-package "SB-VM")
 
-
+
 ;;;; The Branch VOP.
 
 ;;; The unconditional branch, emitted when we can't drop through to the desired
@@ -11,7 +11,7 @@
   (:generator 5
     (inst b dest :nullify t)))
 
-
+
 ;;;; Generic conditional VOPs
 
 ;;; The generic conditional branch, emitted immediately after test
@@ -27,7 +27,7 @@
   (declare (ignore node dst-tn x-tn y-tn))
   nil)
 
-
+
 ;;;; Conditional VOPs:
 
 (define-vop (if-eq)

--- a/src/compiler/hppa/sap.lisp
+++ b/src/compiler/hppa/sap.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged SAP to an untagged representation.
@@ -73,7 +73,7 @@
 ;;; descriptor passing location.
 (define-move-vop move-arg :move-arg
   (sap-reg) (descriptor-reg))
-
+
 ;;;; SAP-INT and INT-SAP
 (define-vop (sap-int)
   (:args (sap :scs (sap-reg) :target int))
@@ -94,7 +94,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move int sap)))
-
+
 ;;;; POINTER+ and POINTER-
 (define-vop (pointer+)
   (:translate sap+)
@@ -127,7 +127,7 @@
   (:result-types signed-num)
   (:generator 1
     (inst sub ptr1 ptr2 res)))
-
+
 ;;;; mumble-SYSTEM-REF and mumble-SYSTEM-SET
 (macrolet ((def-system-ref-and-set
           (ref-name set-name sc type size &optional signed)
@@ -239,7 +239,7 @@
     single-reg single-float :float)
   (def-system-ref-and-set sap-ref-double %set-sap-ref-double
     double-reg double-float :float))
-
+
 ;;; Noise to convert normal lisp data objects into SAPs.
 (define-vop (vector-sap)
   (:translate vector-sap)

--- a/src/compiler/hppa/subprim.lisp
+++ b/src/compiler/hppa/subprim.lisp
@@ -1,7 +1,7 @@
 (in-package "SB-VM")
 
 
-
+
 ;;;; Length
 
 (define-vop (length/list)

--- a/src/compiler/hppa/system.lisp
+++ b/src/compiler/hppa/system.lisp
@@ -1,6 +1,6 @@
 (in-package "SB-VM")
 
-
+
 ;;;; Type frobbing VOPs
 
 ;FIX this vop got instruction-exploded after mips convert, look at old hppa
@@ -119,7 +119,7 @@
   (:policy :fast-safe)
   (:generator 1
     (inst zdep ptr n-positive-fixnum-bits n-positive-fixnum-bits res)))
-
+
 ;;;; Allocation
 
 (define-vop (dynamic-space-free-pointer)
@@ -146,7 +146,7 @@
   (:generator 1
     (move csp-tn int)))
 
-
+
 ;;;; Code object frobbing.
 
 (define-vop (code-instructions)
@@ -178,7 +178,7 @@
     (inst addi (- fun-pointer-lowtag other-pointer-lowtag) ndescr ndescr)
     (inst add ndescr code func)))
 
-
+
 ;;;; Other random VOPs.
 
 
@@ -217,7 +217,7 @@
       (inst addi -64 nsp-tn nsp-tn)
       (when cur-nfp
         (load-stack-tn cur-nfp nfp-save)))))
-
+
 ;;;; Dynamic vop count collection support
 
 (define-vop (count-me)

--- a/src/compiler/hppa/type-vops.lisp
+++ b/src/compiler/hppa/type-vops.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Test generation utilities.
 (defun %test-fixnum (value temp target not-p)
   (declare (ignore temp))
@@ -73,7 +73,7 @@
                     (inst bci greater-or-equal nil end temp target)
                     (inst bci :>= nil end temp when-true)))))))
         (emit-label drop-through)))))
-
+
 ;;;; Other integer ranges.
 
 ;;; A (signed-byte 32) can be represented with either fixnum or a bignum with
@@ -141,7 +141,7 @@
   (:generator 45
     (unsigned-byte-32-test value temp not-p target not-target)
     NOT-TARGET))
-
+
 ;;;; List/symbol types:
 ;;;
 ;;; symbolp (or symbol (eq nil))

--- a/src/compiler/hppa/vm.lisp
+++ b/src/compiler/hppa/vm.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Registers
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -242,7 +242,7 @@
 ;                       :element-size 2
                        ))
 
-
+
 ;;;; Make some random tns for important registers.
 
 ;;; how can we address reg L0 through L0-offset when it is not
@@ -290,7 +290,7 @@
                   :sc (sc-or-lose 'double-reg)
                   :offset 0))
 
-
+
 ;;; If VALUE can be represented as an immediate constant, then return
 ;;; the appropriate SC number, otherwise return NIL.
 (defun immediate-constant-sc (value)
@@ -320,7 +320,7 @@
   (or (eql sc zero-sc-number)
       (eql sc null-sc-number)
       (eql sc immediate-sc-number)))
-
+
 ;;;; Function Call Parameters
 
 ;;; The SC numbers for register and stack arguments/return values.
@@ -357,7 +357,7 @@
 
 ;;; This is used by the debugger.
 (defconstant single-value-return-byte-offset 4)
-
+
 ;;; This function is called by debug output routines that want a pretty name
 ;;; for a TN's location.  It returns a thing that can be printed with PRINC.
 (defun location-print-name (tn)

--- a/src/compiler/info-functions.lisp
+++ b/src/compiler/info-functions.lisp
@@ -16,7 +16,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; internal utilities defined in terms of INFO
 
 (defun check-variable-name (name &key
@@ -167,7 +167,7 @@
   (let ((answer (info :function :inlining-data fun-name)))
     (when (typep answer 'dxable-args)
       (dxable-args-list answer))))
-
+
 ;;;; ANSI Common Lisp functions which are defined in terms of the info
 ;;;; database
 
@@ -240,7 +240,7 @@ return NIL. Can be set with SETF when ENV is NIL."
       (:symbol name "setting the compiler-macro-function of ~A")
     (setf (info :function :compiler-macro-function name) function)
     function))
-
+
 ;;;; a subset of DOCUMENTATION functionality for bootstrapping
 
 ;; Return the number of calls to NAME that IR2 emitted as full calls,

--- a/src/compiler/integer-tran.lisp
+++ b/src/compiler/integer-tran.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; RANDOM in various integer cases
 
 (deftransform random ((limit &optional state)

--- a/src/compiler/ir1-translators.lisp
+++ b/src/compiler/ir1-translators.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; special forms for control
 
 (def-ir1-translator progn ((&rest forms) start next result)
@@ -84,7 +84,7 @@ otherwise evaluate ELSE and return its values. ELSE defaults to NIL."
                    (or (sub (car forms))
                        (somesub (cdr forms))))))
         (sub form))))
-
+
 ;;;; BLOCK and TAGBODY
 
 ;;;; We make an ENTRY node to mark the start and a :ENTRY cleanup to
@@ -251,7 +251,7 @@ constrained to be used only within the dynamic extent of the TAGBODY."
       (when home-lambda
         (sset-adjoin entry (lambda-calls-or-closes home-lambda))))
     (use-ctran exit (second found))))
-
+
 ;;;; translators for compiler-magic special forms
 
 ;;; This handles EVAL-WHEN in non-top-level forms. (EVAL-WHENs in top
@@ -406,7 +406,7 @@ body, references to a NAME will effectively be replaced with the EXPANSION."
    (lambda (&optional vars)
      (ir1-translate-locally body start next result :vars vars))
    :compile))
-
+
 ;;;; %PRIMITIVE
 ;;;;
 ;;;; Uses of %PRIMITIVE are either expanded into Lisp code or turned
@@ -469,7 +469,7 @@ body, references to a NAME will effectively be replaced with the EXPANSION."
                                   (subseq args required min))
                                ,@(subseq args 0 required)
                                ,@(subseq args min)))))
-
+
 ;;;; QUOTE
 
 (def-ir1-translator quote ((thing) start next result)
@@ -477,7 +477,7 @@ body, references to a NAME will effectively be replaced with the EXPANSION."
 
 Return VALUE without evaluating it."
   (reference-constant start next result thing))
-
+
 ;;; We now have a switch to decide whether relative pathnames
 ;;; can be stored in fasl files as their source name.
 ;;; Regardless of what ANSI says must be bound to *fooNAME* specials,
@@ -663,7 +663,7 @@ be a lambda expression."
                 (source-variable-or-else lvar "callable expression")))
               (t
                `(,coercer ,lvar-name))))))
-
+
 ;;;; FUNCALL
 (def-ir1-translator %funcall ((function &rest args) start next result)
   ;; MACROEXPAND so that (LAMBDA ...) forms arriving here don't get an
@@ -702,7 +702,7 @@ be a lambda expression."
 (define-source-transform %coerce-callable-to-fun (thing)
   (ensure-source-fun-form thing :give-up t))
 
-
+
 ;;;; LET and LET*
 ;;;;
 ;;;; (LET and LET* can't be implemented as macros due to the fact that
@@ -813,7 +813,7 @@ Sequentially evaluate the FORMS in a lexical environment where the
 DECLARATIONS have effect. If LOCALLY is a top level form, then the FORMS are
 also processed as top level forms."
   (ir1-translate-locally body start next result))
-
+
 ;;;; FLET and LABELS
 
 ;;; Given a list of local function specifications in the style of
@@ -948,7 +948,7 @@ other."
                        :funs (pairlis names real-funs))))
         (ir1-convert-fbindings start next result real-funs forms)))))
 
-
+
 ;;;; the THE special operator, and friends
 
 ;;; A logic shared among THE and TRULY-THE.
@@ -1105,7 +1105,7 @@ care."
       (lambda (whole env)
         (declare (ignore env))
         `(the ,(caadr whole) ,@(cddr whole))))
-
+
 ;;;; SETQ
 
 (defun explode-setq (form err-fun)
@@ -1172,7 +1172,7 @@ care."
       (push res (basic-var-sets var))
       (link-node-to-previous-ctran res dest-ctran)
       (use-continuation res next result))))
-
+
 ;;;; CATCH, THROW and UNWIND-PROTECT
 
 ;;; We turn THROW into a MULTIPLE-VALUE-CALL of a magical function,
@@ -1351,7 +1351,7 @@ due to normal completion or a non-local exit such as THROW)."
           (declare (optimize (insert-debug-catch 0)))
           ,@cleanup
           (%continue-unwind ,next ,start ,count))))))
-
+
 ;;;; multiple-value stuff
 
 (def-ir1-translator multiple-value-call ((fun &rest args) start next result)
@@ -1407,7 +1407,7 @@ VALUES-FORM."
     (setf (lvar-dest value-lvar) cast)
     (use-continuation cast next result)))
 
-
+
 ;;;; interface to defining macros
 
 ;;; Old CMUCL comment:

--- a/src/compiler/ir1opt.lisp
+++ b/src/compiler/ir1opt.lisp
@@ -15,7 +15,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; interface for obtaining results of constant folding
 
 ;;; Return true for an LVAR whose sole use is a reference to a
@@ -78,7 +78,7 @@
     (loop for use in uses
           for leaf = (ref-leaf use)
           collect (constant-value leaf))))
-
+
 ;;;; interface for obtaining results of type inference
 
 ;;; Our best guess for the type of this lvar's value. Note that this
@@ -251,7 +251,7 @@
                  (coerce-to-values type))))
            dest))))
     *wild-type*))
-
+
 ;;;; interface routines used by optimizers
 
 ;;; This function is called by optimizers to indicate that something
@@ -366,7 +366,7 @@
         (use-lvar cast internal-lvar)
         t))))
 
-
+
 ;;;; IR1-OPTIMIZE
 
 ;;; Do one forward pass over COMPONENT, deleting unreachable blocks
@@ -538,7 +538,7 @@
                             (bound-cast-check node)))
              (flush-dest (cast-value node))
              (unlink-node node)))))))
-
+
 ;;;; local call return type propagation
 
 ;;; This function is called on RETURN nodes that have their REOPTIMIZE
@@ -620,7 +620,7 @@
                  (reoptimize-lvar (node-lvar ref)))))))))
 
   (values))
-
+
 ;;;; IF optimization
 
 ;;; Check whether the predicate is known to be true or false,
@@ -763,7 +763,7 @@
       (reoptimize-lvar new-lvar)
       (setf (component-reanalyze *current-component*) t)))
   (values))
-
+
 ;;;; exit IR1 optimization
 
 ;;; This function attempts to delete an exit node, returning true if
@@ -793,7 +793,7 @@
           (delete-filter node (node-lvar node) value)
           (unlink-node node)))))
 
-
+
 ;;;; combination IR1 optimization
 
 (defun check-important-result (node info)
@@ -1269,7 +1269,7 @@
                                   (leaf-source-name leaf)
                                   nil))))))))
   (values))
-
+
 ;;;; known function optimization
 
 ;;; Add a failed optimization note to FAILED-OPTIMZATIONS for NODE,
@@ -1624,7 +1624,7 @@
                                         values)))
                    fun-name)))))))
   (values))
-
+
 ;;;; local call optimization
 
 ;;; Propagate TYPE to LEAF and its REFS, marking things changed.
@@ -2082,7 +2082,7 @@
                 when type do (propagate-to-refs var type)))))
 
   (values))
-
+
 ;;;; multiple values optimization
 
 ;;; Do stuff to notice a change to a MV combination node. There are

--- a/src/compiler/ir1report.lisp
+++ b/src/compiler/ir1report.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; compiler error context determination
 
 (declaim (special *current-path*))
@@ -272,7 +272,7 @@
                                     ((boundp '*lexenv*)
                                      *lexenv*)))
                      nil)))))))))
-
+
 ;;;; printing error messages
 
 ;;; We save the context information that we printed out most recently
@@ -519,7 +519,7 @@ has written, having proved that it is unreachable."))
                 "~{~{~A~^ ~}~^ => ~}"
                 #+sb-xc-host (list (list (caar context)))
                 #-sb-xc-host context)))))
-
+
 ;;;; condition system interface
 
 ;;; Keep track of how many times each kind of condition happens.
@@ -556,7 +556,7 @@ has written, having proved that it is unreachable."))
   (setf *warnings-p* t)
   (print-compiler-condition condition)
   (muffle-warning condition))
-
+
 ;;;; undefined warnings
 
 (defvar *undefined-warning-limit* 3

--- a/src/compiler/ir1tran-lambda.lisp
+++ b/src/compiler/ir1tran-lambda.lisp
@@ -1066,7 +1066,7 @@
      (ir1-convert-inline-lambda thing
                                 :source-name source-name
                                 :debug-name debug-name))))
-
+
 ;;; Convert the forms produced by RECONSTRUCT-LEXENV to LEXENV
 (defun process-inline-lexenv (inline-lexenv)
   (labels ((recurse (inline-lexenv lexenv)
@@ -1397,7 +1397,7 @@ is potentially harmful to any already-compiled callers using (SAFETY 0)."
           (compiler-style-warn 'same-file-redefinition-warning :name name)
           (push name-key (fun-names-in-this-file *compilation*))))))
 
-
+
 ;;; Entry point utilities
 
 ;;; Return a function for the Nth entry point.

--- a/src/compiler/ir1tran.lisp
+++ b/src/compiler/ir1tran.lisp
@@ -89,7 +89,7 @@
   to optimize code which uses those definitions? Setting this true
   gives non-ANSI, early-CMU-CL behavior. It can be useful for improving
   the efficiency of stable code.")
-
+
 ;;;; namespace management utilities
 
 ;; As with LEXENV-FIND, we assume use of *LEXENV*, but macroexpanders
@@ -308,7 +308,7 @@
                                   :%source-name name
                                   :type type
                                   :where-from where-from)))))))
-
+
 ;;; Grovel over CONSTANT checking for any sub-parts that need to be
 ;;; processed with MAKE-LOAD-FORM. We have to be careful, because
 ;;; CONSTANT might be circular. We also check that the constant (and
@@ -370,7 +370,7 @@
           (emit-make-load-form constant name)
           (grovel constant))))
   (values))
-
+
 ;;;; some flow-graph hacking utilities
 
 ;;; This function sets up the back link between the node and the
@@ -442,7 +442,7 @@
 (defun use-continuation (node ctran lvar)
   (use-ctran node ctran)
   (use-lvar node lvar))
-
+
 ;;;; exported functions
 
 ;;; This function takes a form and the top level form number for that
@@ -532,7 +532,7 @@
          (frob)
          (frob)
          (setq trail (cdr trail)))))))
-
+
 ;;;; IR1-CONVERT, macroexpansion and special form dispatching
 
 (declaim (ftype (sfunction (ctran ctran (or lvar null) t)
@@ -893,7 +893,7 @@
                           (compiler-error "~@<~A~@:_ ~A~:>"
                                           (wherestring) c))))))
       (funcall (valid-macroexpand-hook) fun form *lexenv*))))
-
+
 ;;;; conversion utilities
 
 ;;; Convert a bunch of forms, discarding all the values except the
@@ -918,7 +918,7 @@
                     forms (cdr forms)))))))
   (values))
 
-
+
 ;;;; code coverage
 
 ;;; Check the policy for whether we should generate code coverage
@@ -982,7 +982,7 @@
           (when *current-path*
             (instrument-coverage start nil form))))
       start))
-
+
 ;;;; converting combinations
 
 ;;; Does this form look like something that we should add single-stepping
@@ -1159,7 +1159,7 @@
   (ir1-convert-combination start next result
                            form
                            (maybe-reanalyze-functional functional)))
-
+
 ;;;; PROCESS-DECLS
 
 ;;; Given a list of LAMBDA-VARs and a variable name, return the

--- a/src/compiler/ir1util.lisp
+++ b/src/compiler/ir1util.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; cleanup hackery
 
 (defun lexenv-enclosing-cleanup (lexenv)
@@ -63,7 +63,7 @@
         (setf (block-last block) (ctran-use next))
         (setf (node-next (block-last block)) nil)
         block))))
-
+
 ;;;; lvar use hacking
 
 ;;; Return a list of all the nodes which use LVAR.
@@ -266,7 +266,7 @@
                  (or (not (cast-p use))
                      (lvar-almost-immediately-used-p (cast-value use))))
       (return))))
-
+
 ;;;; BLOCK UTILS
 
 (declaim (inline block-to-be-deleted-p))
@@ -300,7 +300,7 @@
 ;;; Return the lexenv of the last node in BLOCK.
 (defun block-end-lexenv (block)
   (node-lexenv (block-last block)))
-
+
 ;;;; lvar substitution
 
 (defun update-lvar-dependencies (new old)
@@ -396,7 +396,7 @@
         (when new-lvar
           (propagate-lvar-dx new-lvar old-lvar t)
           t)))))
-
+
 ;;;; block starting/creation
 
 ;;; Return the block that CTRAN is the start of, making a block if
@@ -460,7 +460,7 @@
        (setf (ctran-block ctran) nil)
        (link-blocks block (ctran-starts-block ctran))))
     (:block-start)))
-
+
 ;;;;
 
 ;;; Filter values of LVAR through FORM, which must be an ordinary/mv
@@ -579,7 +579,7 @@
     (use-lvar ref lvar)
     (link-node-to-previous-ctran node ctran)
     lvar))
-
+
 ;;;; miscellaneous shorthand functions
 
 ;;; Return the home (i.e. enclosing non-LET) CLAMBDA for NODE. Since
@@ -1125,7 +1125,7 @@
                  (make-short-values-type (list (single-value-type
                                                 (node-derived-type dest)))))
         (reoptimize-lvar prev)))
-
+
 ;;; Return a new LEXENV just like DEFAULT except for the specified
 ;;; slot values. Values for the alist slots are APPENDed to the
 ;;; beginning of the current value, rather than replacing it entirely.
@@ -1194,7 +1194,7 @@
      (lexenv-policy lexenv)
      (lexenv-user-data lexenv)
      lexenv)))
-
+
 ;;;; flow/DFO/component hackery
 
 ;;; Join BLOCK1 and BLOCK2.
@@ -1535,7 +1535,7 @@
             ((not ctran))
           (setf (ctran-block ctran) new-block))
         new-block))))
-
+
 ;;;; deleting stuff
 
 ;;; Deal with deleting the last (read) reference to a LAMBDA-VAR.
@@ -2323,7 +2323,7 @@ is :ANY, the function name is not checked."
   (unlink-node combination)
   (values))
 
-
+
 ;;;; leaf hackery
 
 ;;; Change the LEAF that a REF refers to.
@@ -2493,7 +2493,7 @@ is :ANY, the function name is not checked."
                     (go :next))
                    (cast
                     (go :next))))))))))
-
+
 ;;; Return true if VAR would have to be closed over if environment
 ;;; analysis ran now (i.e. if there are any uses that have a different
 ;;; home lambda than VAR's home.)
@@ -2525,7 +2525,7 @@ is :ANY, the function name is not checked."
 (defun nlx-info-lvar (nlx)
   (declare (type nlx-info nlx))
   (node-lvar (block-last (nlx-info-target nlx))))
-
+
 ;;;; functional hackery
 
 (declaim (ftype (sfunction (functional) clambda) main-entry))
@@ -2724,7 +2724,7 @@ is :ANY, the function name is not checked."
                     (multiple-value-bind (val win)
                        (valid-fun-use call (template-type template))
                       (when (or val (not win)) (return nil)))))))))))
-
+
 ;;;; careful call
 
 ;;; Apply a function to some arguments, returning a list of the values
@@ -2777,7 +2777,7 @@ is :ANY, the function name is not checked."
   (deffrob specifier-type careful-specifier-type compiler-specifier-type ir1-transform-specifier-type)
   (deffrob values-specifier-type careful-values-specifier-type compiler-values-specifier-type ir1-transform-values-specifier-type))
 
-
+
 ;;;; utilities used at run-time for parsing &KEY args in IR1
 
 ;;; This function is used by the result of PARSE-DEFTRANSFORM to find
@@ -2814,7 +2814,7 @@ is :ANY, the function name is not checked."
            ((null arg) t)
          (unless (member (lvar-value (first arg)) keys)
            (return nil)))))
-
+
 ;;;; miscellaneous
 
 ;;; Called by the expansion of the EVENT macro.
@@ -3010,7 +3010,7 @@ is :ANY, the function name is not checked."
          (or (eq fun lvar)
              (lvar-fun-is fun '(%coerce-callable-for-call))))))
 
-
+
 (defun proper-or-circular-list-p (x)
   (if (consp x)
       (let ((rabbit (cdr x))

--- a/src/compiler/ir2tran.lisp
+++ b/src/compiler/ir2tran.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; moves and type checks
 
 ;;; Move X to Y unless they are EQ.
@@ -36,7 +36,7 @@
 (defun emit-make-value-cell (node block value res)
   (event make-value-cell-event node)
   (vop make-value-cell node block value nil res))
-
+
 ;;;; leaf reference
 
 ;;; Return the TN that holds the value of THING in the environment ENV.
@@ -367,7 +367,7 @@
       (emit-move node block val (first locs))
       (move-lvar-result node block locs lvar)))
   (values))
-
+
 ;;;; utilities for receiving fixed values
 
 ;;; Return a TN that can be referenced to get the value of LVAR. LVAR
@@ -425,7 +425,7 @@
                     temp)))
             locs
             ptypes)))
-
+
 ;;;; utilities for delivering values to lvars
 
 ;;; Return a list of TNs with the specifier TYPES that can be used as
@@ -592,7 +592,7 @@
         (compiler-warn "Derived type ~s is not a suitable index for ~s."
                        (type-specifier index-type)
                        (type-specifier (lvar-type array)))))))
-
+
 ;;;; template conversion
 
 ;;; Build a TN-REFS list that represents access to the values of the
@@ -768,7 +768,7 @@
     (if (fun-type-p type)
         (fun-type-returns type)
         *wild-type*)))
-
+
 ;;;; local call
 
 ;;; Convert a LET by moving the argument values into the variables.
@@ -989,7 +989,7 @@
                 (ir2-convert-local-known-call node block fun returns
                                               lvar start)))))))
   (values))
-
+
 ;;;; full call
 
 ;;; Given a function lvar FUN, return (VALUES TN-TO-CALL NAMED-P),
@@ -1307,7 +1307,7 @@
         (t
          (ir2-convert-fixed-full-call node block)))
   (values))
-
+
 ;;;; entering functions
 (defun xep-verify-arg-count (node block fun arg-count-location)
   (when (policy fun (plusp verify-arg-count))
@@ -1483,7 +1483,7 @@
         (vop sb-vm::insert-safepoint node block))))
 
   (values))
-
+
 ;;;; function return
 
 ;;; Do stuff to return from a function with the specified values and
@@ -1535,7 +1535,7 @@
             (nil)))))
 
   (values))
-
+
 ;;;; debugger hooks
 ;;;;
 ;;;; These are used by the debugger to find the top function on the
@@ -1553,7 +1553,7 @@
     (move-lvar-result node block
                       (list (ir2-physenv-return-pc ir2-physenv))
                       (node-lvar node))))
-
+
 ;;;; multiple values
 
 ;;; This is almost identical to IR2-CONVERT-LET. Since LTN annotates
@@ -1777,7 +1777,7 @@ not stack-allocated LVAR ~S." source-lvar)))))
                    (eq (lvar-uses dest-fun) node))))
         (setf (basic-combination-fun dest) fun)
         (ir2-convert-full-call node block))))
-
+
 ;;;; special binding
 
 ;;; This is trivial, given our assumption of a shallow-binding
@@ -1854,7 +1854,7 @@ not stack-allocated LVAR ~S." source-lvar)))))
           ;; cleanup function). -- JES, 2007-06-16
           (declare (optimize (insert-debug-catch 0)))
           (%primitive unbind-to-here ,n-save-bs))))))
-
+
 ;;;; non-local exit
 
 ;;; Convert a non-local lexical exit. First find the NLX-INFO in our
@@ -2043,7 +2043,7 @@ not stack-allocated LVAR ~S." source-lvar)))))
     (vop* restore-dynamic-state node block
           ((reference-tn-list (cdr (ir2-nlx-info-dynamic-state 2info)) nil))
           (nil))))
-
+
 ;;;; n-argument functions
 
 (macrolet ((def (name)
@@ -2094,7 +2094,7 @@ not stack-allocated LVAR ~S." source-lvar)))))
   (def list)
   (def list*))
 
-
+
 (defoptimizer (mask-signed-field ir2-convert) ((width x) node block)
   (block nil
     (when (constant-lvar-p width)
@@ -2158,7 +2158,7 @@ not stack-allocated LVAR ~S." source-lvar)))))
 (defoptimizer (restart-point ir2-convert) ((location) node block)
   (setf (restart-location-label (lvar-value location))
         (block-label (ir2-block-block block))))
-
+
 ;;; Convert the code in a component into VOPs.
 (defun ir2-convert (component)
   (declare (type component component))

--- a/src/compiler/knownfun.lisp
+++ b/src/compiler/knownfun.lisp
@@ -113,7 +113,7 @@
           (remf (info :source-location :declaration name) 'defknown))))
   names)
 
-
+
 ;;; This macro should be the way that all implementation independent
 ;;; information about functions is made known to the compiler.
 ;;;
@@ -244,7 +244,7 @@
 (declaim (ftype (sfunction (t) fun-info) fun-info-or-lose))
 (defun fun-info-or-lose (name)
   (or (info :function :info name) (error "~S is not a known function." name)))
-
+
 ;;;; generic type inference methods
 
 (defun symeval-derive-type (node &aux (args (basic-combination-args node))

--- a/src/compiler/life.lisp
+++ b/src/compiler/life.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; utilities
 
 ;;; Link in a GLOBAL-CONFLICTS structure for TN in BLOCK with NUMBER
@@ -72,7 +72,7 @@
         (setf (block-physenv-cache block)
               (block-physenv block))
         physenv)))
-
+
 ;;;; pre-pass
 
 ;;; Convert TN (currently local) to be a global TN, since we
@@ -393,7 +393,7 @@
               (init-global-conflict-kind new))))))))
 
   (values))
-
+
 ;;;; environment TN stuff
 
 ;;; Add a :LIVE global conflict for TN in 2BLOCK if there is none
@@ -520,7 +520,7 @@
   (setf (tn-physenv tn) tn-physenv)
   (push tn (ir2-physenv-live-tns (physenv-info tn-physenv)))
   (values))
-
+
 ;;;; flow analysis
 
 ;;; For each GLOBAL-TN in BLOCK2 that is :LIVE, :READ or :READ-ONLY,
@@ -639,7 +639,7 @@
       (unless did-something (return))))
 
   (values))
-
+
 ;;;; post-pass
 
 ;;; Note that TN conflicts with all current live TNs. NUM is TN's LTN
@@ -866,7 +866,7 @@
   (declare (type component component))
   (do-ir2-blocks (block component)
     (conflict-analyze-1-block block)))
-
+
 ;;;; alias TN stuff
 
 ;;; Destructively modify OCONF to include the conflict information in CONF.
@@ -1035,7 +1035,7 @@
             (when (member (tn-kind tn) '(:normal :debug-environment))
               (convert-to-environment-tn tn physenv))))))))
 
-
+
 (defun lifetime-analyze (component)
   (lifetime-pre-pass component)
   (maybe-environmentalize-closure-tns component)
@@ -1043,7 +1043,7 @@
   (lifetime-flow-analysis component)
   (lifetime-post-pass component)
   (merge-alias-conflicts component))
-
+
 ;;;; conflict testing
 
 ;;; Test for a conflict between the local TN X and the global TN Y. We

--- a/src/compiler/locall.lisp
+++ b/src/compiler/locall.lisp
@@ -123,7 +123,7 @@
   (merge-tail-sets call fun)
   (change-ref-leaf ref fun)
   (values))
-
+
 ;;;; external entry point creation
 
 ;;; Return a LAMBDA form that can be used as the definition of the XEP
@@ -303,7 +303,7 @@
                                                 :zombie :deleted)))
       (change-ref-leaf ref (or (functional-entry-fun fun)
                                (make-xep fun))))))
-
+
 ;;; Attempt to convert all references to FUN to local calls. The
 ;;; reference must be the function for a call, and the function lvar
 ;;; must be used only once, since otherwise we cannot be sure what
@@ -608,7 +608,7 @@
             :format-control
             "function called with ~R argument~:P, but wants exactly ~R"
             :format-arguments (list n-call-args nargs))))))
-
+
 ;;;; &OPTIONAL, &MORE and &KEYWORD calls
 
 ;;; This is similar to CONVERT-LAMBDA-CALL, but deals with
@@ -832,7 +832,7 @@
                                    more-temps)))))
 
   (values))
-
+
 ;;;; LET conversion
 ;;;;
 ;;;; Converting to a LET has differing significance to various parts
@@ -1295,7 +1295,7 @@
                                         ;  for me to handle - PK 2012-05-30
               (substitute-let-funargs dest clambda component))))
         t))))
-
+
 ;;;; tail local calls and assignments
 
 ;;; Return T if there are no cleanups between BLOCK1 and BLOCK2, or if

--- a/src/compiler/ltn.lisp
+++ b/src/compiler/ltn.lisp
@@ -12,7 +12,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; utilities
 
 ;;; Return the LTN-POLICY indicated by the node policy.
@@ -265,7 +265,7 @@
             (make-stack-pointer-tn))))
   (ltn-annotate-casts lvar)
   (values))
-
+
 ;;;; node-specific analysis functions
 
 ;;; Annotate the result lvar for a function. We use the RETURN-INFO
@@ -477,7 +477,7 @@
                                               node ltn-policy)
   (declare (ignore target source node ltn-policy)))
 
-
+
 ;;;; known call annotation
 
 ;;; Return true if RESTR is satisfied by TYPE. If T-OK is true, then a
@@ -919,7 +919,7 @@
               types)))))))
   (values))
 
-
+
 ;;;; interfaces
 
 ;;; most of the guts of the two interface functions: Compute the

--- a/src/compiler/macros.lisp
+++ b/src/compiler/macros.lisp
@@ -138,7 +138,7 @@
   (when (info :function :source-transform fun-name)
     (warn "Redefining source-transform for ~S" fun-name))
   (setf (info :function :source-transform fun-name) lambda))
-
+
 ;;;; lambda-list parsing utilities
 ;;;;
 ;;;; IR1 transforms, optimizers and type inferencers need to be able
@@ -215,7 +215,7 @@
                 (sort (intersection (mapcar #'car (binds)) (cdr all-dummies))
                       #'string<))))))
 ) ; EVAL-WHEN
-
+
 ;;;; DEFTRANSFORM
 
 ;;; Define an IR1 transformation for NAME. An IR1 transformation
@@ -352,7 +352,7 @@
                                  ,doc
                                  ,important
                                  policy))))))
-
+
 ;;; Create a function which parses combination args according to WHAT
 ;;; and LAMBDA-LIST, where WHAT is either a function name or a list
 ;;; (FUN-NAME KIND) and does some KIND of optimization.
@@ -413,7 +413,7 @@
                           (symbolicate "FUN-INFO-" (second what)))
                        (fun-info-or-lose ',(first what)))
                       #',name))))))
-
+
 ;;;; IR groveling macros
 
 ;;; Iterate over the blocks in a component, binding BLOCK-VAR to each
@@ -627,7 +627,7 @@
            (setf (component-last-block ,component)
                  ,old-last-block))))))
 
-
+
 ;;;; the EVENT statistics/trace utility
 
 ;;; FIXME: This seems to be useful for troubleshooting and
@@ -744,7 +744,7 @@
              (setf (event-info-count v) 0))
            *event-info*)
   (values))
-
+
 ;;;; functions on directly-linked lists (linked through specialized
 ;;;; NEXT operations)
 

--- a/src/compiler/main.lisp
+++ b/src/compiler/main.lisp
@@ -86,7 +86,7 @@
 ;; Used during compilation to keep track of with source paths have been
 ;; instrumented in which blocks.
 (defun code-coverage-blocks (x) (cdr x))
-
+
 ;;;; WITH-COMPILATION-UNIT and WITH-COMPILATION-VALUES
 
 (defmacro sb-xc:with-compilation-unit (options &body body)
@@ -382,7 +382,7 @@ Examples:
           (push (list* thing fmt-or-condition args)
                 (file-info-style-warning-tracker file-info)))
         (apply 'style-warn fmt-or-condition args)))))
-
+
 ;;;; component compilation
 
 (defparameter *max-optimize-iterations* 3 ; ARB
@@ -742,7 +742,7 @@ necessary, since type inference may take arbitrarily long to converge.")
 
   (clear-constant-info)
   (values))
-
+
 ;;;; clearing global data structures
 ;;;;
 ;;;; FIXME: Is it possible to get rid of this stuff, getting rid of
@@ -787,7 +787,7 @@ necessary, since type inference may take arbitrarily long to converge.")
     (blast *free-funs*)
     (blast *constants*))
   (values))
-
+
 ;;;; trace output
 
 ;;; Print out some useful info about COMPONENT to STREAM.
@@ -811,7 +811,7 @@ necessary, since type inference may take arbitrarily long to converge.")
   (print-ir2-blocks component)
   (terpri)
   (values))
-
+
 ;;; Given a pathname, return a SOURCE-INFO structure.
 (defun make-file-source-info (file external-format &optional form-tracking-p)
   (make-source-info
@@ -1074,7 +1074,7 @@ necessary, since type inference may take arbitrarily long to converge.")
   (let ((file-info (source-info-file-info info)))
     (values (aref (file-info-forms file-info) index)
             (aref (file-info-positions file-info) index))))
-
+
 ;;;; processing of top level forms
 
 ;;; This is called by top level form processing when we are ready to
@@ -1451,7 +1451,7 @@ necessary, since type inference may take arbitrarily long to converge.")
                            (convert-and-maybe-compile form path)))))))))))
 
   (values))
-
+
 ;;;; load time value support
 ;;;;
 ;;;; (See EMIT-MAKE-LOAD-FORM.)
@@ -1522,7 +1522,7 @@ necessary, since type inference may take arbitrarily long to converge.")
       (setf (component-name component) (leaf-debug-name lambda))
       (compile-component component)
       (clear-ir1-info component))))
-
+
 ;;;; COMPILE-FILE
 
 (defun object-call-toplevel-lambda (tll)
@@ -1944,7 +1944,7 @@ SPEED and COMPILATION-SPEED optimization values, and the
               (or (probe-file output-file-name) output-file-name))
             warnings-p
             failure-p)))
-
+
 ;;; a helper function for COMPILE-FILE-PATHNAME: the default for
 ;;; the OUTPUT-FILE argument
 ;;;
@@ -1976,7 +1976,7 @@ SPEED and COMPILATION-SPEED optimization values, and the
   (if output-file-p
       (merge-pathnames output-file (cfp-output-file-default input-file))
       (cfp-output-file-default input-file)))
-
+
 ;;;; MAKE-LOAD-FORM stuff
 
 ;;; The entry point for MAKE-LOAD-FORM support. When IR1 conversion

--- a/src/compiler/meta-vmdef.lisp
+++ b/src/compiler/meta-vmdef.lisp
@@ -17,7 +17,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; storage class and storage base definition
 
 ;;; Define a storage base having the specified NAME. KIND may be :FINITE,
@@ -163,7 +163,7 @@
        (setf (gethash ',name *backend-sc-names*) (sc-or-lose ',name))
        (setf (sc-sb (sc-or-lose ',name)) (sb-or-lose ',sb-name))
        ',name)))
-
+
 ;;;; move/coerce definition
 
 ;;; Given a list of pairs of lists of SCs (as given to DEFINE-MOVE-VOP,
@@ -205,7 +205,7 @@
 (defglobal *sc-vop-slots*
     '((:move . sc-move-vops)
       (:move-arg . sc-move-arg-vops)))
-
+
 ;;;; primitive type definition
 
 ;;; Define a primitive type NAME. Each SCS entry specifies a storage
@@ -232,7 +232,7 @@
      (push (cons ',name ,result) *backend-primitive-type-aliases*)
      ',name))
 
-
+
 ;;;; VOP definition structures
 ;;;;
 ;;;; DEFINE-VOP uses some fairly complex data structures at
@@ -385,7 +385,7 @@
   (scs :test scs)
   (load :test load)
   (offset :test offset))
-
+
 ;;; Make NAME be the VOP used to move values in the specified FROM-SCs
 ;;; to the representation of the TO-SCs of each SC pair in SCS.
 ;;;
@@ -419,7 +419,7 @@
                  (let ((scn (sc-number sc)))
                    (setf (svref vec scn)
                          (adjoin-template vop (svref vec scn))))))))))))
-
+
 ;;;; miscellaneous utilities
 
 ;;; Find the operand or temporary with the specifed Name in the VOP
@@ -482,7 +482,7 @@
       (unless (typep thing type)
         (error "~:R argument is not a ~S: ~S" n type spec))
       thing)))
-
+
 ;;;; time specs
 
 ;;; Return a time spec describing a time during the evaluation of a
@@ -505,7 +505,7 @@
           (sub-phase (second dspec)))
       (+ (ash phase 16)
          sub-phase))))
-
+
 ;;;; generation of emit functions
 
 (defun compute-temporaries-description (parse)
@@ -608,7 +608,7 @@
 (defun make-emit-function-and-friends (parse)
   `(:temps ,(compute-temporaries-description parse)
     ,@(compute-ref-ordering parse)))
-
+
 ;;;; generator functions
 
 ;;; Return an alist that translates from lists of SCs we can load OP
@@ -773,7 +773,7 @@
            (assemble ()
              ,@(vop-parse-body parse))
            ,@(saves))))))
-
+
 (defvar *parse-vop-operand-count*)
 (defun make-operand-parse-temp ()
   (without-package-locks
@@ -868,7 +868,7 @@
                 ((operand-parse-load more)
                  (error "cannot specify :LOAD-IF in a :MORE operand")))))
       (values (the list (operands)) more))))
-
+
 ;;; Parse a temporary specification, putting the OPERAND-PARSE
 ;;; structures in the PARSE structure.
 (defun parse-temporary (spec parse)
@@ -929,7 +929,7 @@
                     (remove name (vop-parse-temps parse)
                             :key #'operand-parse-name))))))
   (values))
-
+
 (defun compute-parse-vop-operand-count (parse)
   (declare (type vop-parse parse))
   (labels ((compute-count-aux (parse)
@@ -1028,7 +1028,7 @@
         (t
          (error "unknown option specifier: ~S" (first spec)))))
     (values)))
-
+
 ;;;; making costs and restrictions
 
 ;;; Given an operand, returns two values:
@@ -1128,7 +1128,7 @@
         ',(if (vop-parse-more-results parse)
               (compute-loading-costs-if-any (vop-parse-more-results parse) nil)
               nil)))))
-
+
 ;;;; operand checking and stuff
 
 ;;; Given a list of arg/result restrictions, check for valid syntax
@@ -1262,7 +1262,7 @@
                 (if (vop-parse-more-results parse)
                     (list (vop-parse-more-results parse)))
                 (vop-parse-temps parse))))
-
+
 ;;;; function translation stuff
 
 ;;; Return forms to establish this VOP as a IR2 translation template
@@ -1333,7 +1333,7 @@
                             `(list ,@(mapcar #'make-operand-type results))))
       :more-results-type ,(when more-results
                             (make-operand-type more-result)))))
-
+
 ;;;; setting up VOP-INFO
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -1388,7 +1388,7 @@
           (unless (eq (vop-parse-body parse) :unspecified)
             (make-generator-function parse)))
       :variant (list ,@variant))))
-
+
 ;;; Define the symbol NAME to be a Virtual OPeration in the compiler.
 ;;; If specified, INHERITS is the name of a VOP that we default
 ;;; unspecified information from. Each SPEC is a list beginning with a
@@ -1703,7 +1703,7 @@
       (try-coalescing vop-info-targets)))
   (setf (gethash (vop-info-name vop-info) *backend-template-names*)
         vop-info))
-
+
 ;;;; emission macros
 
 ;;; Return code to make a list of VOP arguments or results, linked by
@@ -1853,7 +1853,7 @@
                           ,@(when info
                               `((list ,@info))))
            (values))))))
-
+
 ;;;; miscellaneous macros
 
 ;;; SC-Case TN {({(SC-Name*) | SC-Name | T} Form*)}*

--- a/src/compiler/mips/alloc.lisp
+++ b/src/compiler/mips/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; LIST and LIST*
 (define-vop (list-or-list*)
   (:args (things :more t))
@@ -74,7 +74,7 @@
 
 (define-vop (list* list-or-list*)
   (:variant t))
-
+
 ;;;; Special purpose inline allocators.
 
 ;;; ALLOCATE-VECTOR
@@ -181,7 +181,7 @@
     (with-fixed-allocation (result pa-flag temp value-cell-widetag
                             value-cell-size stack-allocate-p)
       (storew value result value-cell-value-slot other-pointer-lowtag))))
-
+
 ;;;; Automatic allocators for primitive objects.
 
 (define-vop (make-unbound-marker)

--- a/src/compiler/mips/arith.lisp
+++ b/src/compiler/mips/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Unary operations.
 
 (define-vop (fast-safe-arith-op)
@@ -52,7 +52,7 @@
   (:translate lognot)
   (:generator 2
     (inst nor res x zero-tn)))
-
+
 ;;;; Binary fixnum operations.
 
 ;;; Assume that any constant operand is the second arg...
@@ -419,7 +419,7 @@
     (inst mfhi r)))
 
 
-
+
 ;;;; Binary conditional VOPs:
 
 (define-vop (fast-conditional)
@@ -578,7 +578,7 @@
   (:arg-types * (:constant (signed-byte 14)))
   (:variant-cost 6))
 
-
+
 ;;;; 32-bit logical operations
 
 (define-vop (shift-towards-someplace)
@@ -608,7 +608,7 @@
        (inst srl r num amount))
       (:little-endian
        (inst sll r num amount)))))
-
+
 ;;;; Modular arithmetic
 (define-modular-fun +-mod32 (x y) + :untagged nil 32)
 (define-vop (fast-+-mod32/unsigned=>unsigned fast-+/unsigned=>unsigned)

--- a/src/compiler/mips/array.lisp
+++ b/src/compiler/mips/array.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Allocator for the array header.
 (define-vop (make-array-header)
   (:policy :fast-safe)
@@ -36,7 +36,7 @@
       (inst or result alloc-tn other-pointer-lowtag)
       (storew header result 0 other-pointer-lowtag)
       (inst addu alloc-tn bytes))))
-
+
 ;;;; Additional accessors and setters for the array header.
 (define-full-reffer %array-dimension *
   array-dimensions-offset other-pointer-lowtag
@@ -57,7 +57,7 @@
     (inst sra temp n-widetag-bits)
     (inst subu temp (1- array-dimensions-offset))
     (inst sll res temp n-fixnum-tag-bits)))
-
+
 ;;;; Bounds checking routine.
 (define-vop (check-bound)
   (:translate %check-bound)
@@ -75,7 +75,7 @@
       (inst sltu temp index bound)
       (inst beq temp error)
       (inst nop))))
-
+
 ;;;; Accessors/Setters
 
 ;;; Variants built on top of word-index-ref, etc.  I.e. those vectors whos
@@ -407,7 +407,7 @@
                 n-word-bytes))))
     (unless (location= result value)
       (inst fmove :double result value))))
-
+
 ;;; Complex float arrays.
 (define-vop (data-vector-ref/simple-array-complex-single-float)
   (:note "inline array access")
@@ -509,7 +509,7 @@
       (unless (location= result-imag value-imag)
         (inst fmove :double result-imag value-imag)))))
 
-
+
 ;;; These vops are useful for accessing the bits of a vector irrespective of
 ;;; what type of vector it is.
 (define-full-reffer vector-raw-bits * vector-data-offset other-pointer-lowtag

--- a/src/compiler/mips/call.lisp
+++ b/src/compiler/mips/call.lisp
@@ -55,7 +55,7 @@
 ;;; are using non-standard conventions.
 (defun make-arg-count-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn nargs-offset))
-
+
 ;;;; Frame hackery:
 
 ;;; BYTES-NEEDED-FOR-NON-DESCRIPTOR-STACK-FRAME -- internal
@@ -167,7 +167,7 @@
 
 
 
-
+
 ;;; Emit code needed at the return-point from an unknown-values call for a
 ;;; fixed number of values.  Values is the head of the TN-Ref list for the
 ;;; locations that the values are to be received into.  Nvals is the number of
@@ -311,7 +311,7 @@ default-value-8
           (inst compute-code-from-lra code-tn code-tn lra-label temp))))
   (values))
 
-
+
 ;;;; Unknown values receiving:
 
 ;;;    Emit code needed at the return point for an unknown-values call for an
@@ -377,7 +377,7 @@ default-value-8
               nvals)
   (:temporary (:scs (non-descriptor-reg)) temp))
 
-
+
 ;;; This hook in the codegen pass lets us insert code before fall-thru entry
 ;;; points, local-call entry points, and tail-call entry points.  The default
 ;;; does nothing.
@@ -387,7 +387,7 @@ default-value-8
     (emit-label trampoline-label))
   (emit-label start-label))
 
-
+
 ;;;; Local call with unknown values convention return:
 
 ;;; Non-TR local call for a fixed number of values passed according to the
@@ -481,7 +481,7 @@ default-value-8
       (when cur-nfp
         (load-stack-tn cur-nfp nfp-save)))))
 
-
+
 ;;;; Local call with known values return:
 
 ;;; Non-TR local call with known return locations.  Known-value return works
@@ -554,7 +554,7 @@ default-value-8
     (inst j lip)
     (move cfp-tn ocfp-temp t)))
 
-
+
 ;;;; Full call:
 ;;;
 ;;;    There is something of a cross-product effect with full calls.  Different
@@ -892,7 +892,7 @@ default-value-8
               (bytes-needed-for-non-descriptor-stack-frame))
         (inst nop)))))
 
-
+
 ;;;; Unknown values return:
 
 ;;; Return a single value using the unknown-values convention.
@@ -1019,7 +1019,7 @@ default-value-8
 
       (inst j (make-fixup 'return-multiple :assembly-routine))
       (move nvals nvals-arg t))))
-
+
 ;;;; XEP hackery:
 
 ;;; Get the lexical environment from its passing location.

--- a/src/compiler/mips/cell.lisp
+++ b/src/compiler/mips/cell.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Data object ref/set stuff.
 
 (define-vop (slot)
@@ -34,7 +34,7 @@
 (define-vop (init-slot set-slot)
   (:info name dx-p offset lowtag)
   (:ignore name dx-p))
-
+
 ;;;; Symbol hacking VOPs:
 
 ;;; The compiler likes to be able to directly SET symbols.
@@ -112,7 +112,7 @@
   (:translate sym-global-val))
 (define-vop (fast-symbol-global-value fast-symbol-value)
   (:translate sym-global-val))
-
+
 ;;;; Fdefinition (fdefn) objects.
 
 (define-vop (fdefn-fun cell-ref)
@@ -169,7 +169,7 @@
     (move result fdefn)))
 
 
-
+
 ;;;; Binding and Unbinding.
 
 ;;; BIND -- Establish VAL as a binding for SYMBOL.  Save the old value and
@@ -228,7 +228,7 @@
       (emit-label done))))
 
 
-
+
 ;;;; Closure indexing.
 
 (define-full-reffer closure-index-ref *
@@ -262,7 +262,7 @@
   (:info offset)
   (:generator 4
     (storew cfp-tn object (+ closure-info-offset offset) fun-pointer-lowtag)))
-
+
 ;;;; Value Cell hackery.
 
 (define-vop (value-cell-ref cell-ref)
@@ -272,7 +272,7 @@
   (:variant value-cell-value-slot other-pointer-lowtag))
 
 
-
+
 ;;;; Instance hackery:
 
 (define-vop (instance-length)
@@ -293,7 +293,7 @@
   instance-pointer-lowtag (descriptor-reg any-reg null zero) * %instance-set)
 
 
-
+
 ;;;; Code object frobbing.
 
 (define-full-reffer code-header-ref * 0 other-pointer-lowtag
@@ -303,7 +303,7 @@
   (descriptor-reg any-reg null zero) * code-header-set)
 
 
-
+
 ;;;; raw instance slot accessors
 
 (macrolet ((def (suffix sc primtype)

--- a/src/compiler/mips/char.lisp
+++ b/src/compiler/mips/char.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged char to an untagged representation.
@@ -72,7 +72,7 @@
 ;;; a descriptor passing location.
 (define-move-vop move-arg :move-arg
   (character-reg) (any-reg descriptor-reg))
-
+
 ;;;; Other operations:
 (define-vop (char-code)
   (:translate char-code)
@@ -93,7 +93,7 @@
   (:result-types character)
   (:generator 1
     (inst srl res code n-fixnum-tag-bits)))
-
+
 ;;; Comparison of characters.
 (define-vop (character-compare)
   (:args (x :scs (character-reg))

--- a/src/compiler/mips/float.lisp
+++ b/src/compiler/mips/float.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Move functions:
 (define-move-fun (load-single 1) (vop x y)
   ((single-stack) (single-reg))
@@ -52,7 +52,7 @@
   (let ((nfp (current-nfp-tn vop))
         (offset (tn-byte-offset y)))
     (str-double x nfp offset)))
-
+
 ;;;; Move VOPs:
 (macrolet ((frob (vop sc format)
              `(progn
@@ -157,7 +157,7 @@
                   (,sc descriptor-reg) (,sc)))))
   (frob move-single-float-arg single-reg single-stack :single nil)
   (frob move-double-float-arg double-reg double-stack :double t))
-
+
 ;;;; Complex float move functions
 
 (defun complex-single-reg-real-tn (x)
@@ -375,7 +375,7 @@
   (single-reg double-reg complex-single-reg complex-double-reg)
   (descriptor-reg))
 
-
+
 ;;;; stuff for c-call float-in-int-register arguments
 (define-vop (move-to-single-int-reg)
   (:args (x :scs (single-reg descriptor-reg)))
@@ -437,7 +437,7 @@
 (define-move-vop move-double-int-reg :move-arg
   (double-int-carg-reg) (double-int-carg-reg))
 
-
+
 ;;;; Arithmetic VOPs:
 
 (define-vop (float-op)
@@ -496,7 +496,7 @@
   (frob %negate/single-float fneg %negate :single single-reg single-float)
   (frob %negate/double-float fneg %negate :double double-reg double-float))
 
-
+
 ;;;; Comparison:
 
 (define-vop (float-compare)
@@ -537,7 +537,7 @@
   (frob > :ngt t >/single-float >/double-float)
   (frob = :seq nil =/single-float =/double-float))
 
-
+
 ;;;; Conversion:
 
 (macrolet ((frob (name translate
@@ -694,7 +694,7 @@
     (inst mfc1 lo-bits float)
     (inst nop)))
 
-
+
 ;;;; Complex float VOPs
 
 (define-vop (make-complex-single-float)

--- a/src/compiler/mips/insts.lisp
+++ b/src/compiler/mips/insts.lisp
@@ -20,7 +20,7 @@
             sb-vm::registers sb-vm::float-registers
             sb-vm::zero
             sb-vm::lip-tn sb-vm::zero-tn)))
-
+
 ;;;; Constants, types, conversion functions, some disassembler stuff.
 
 (defun reg-tn-encoding (tn)
@@ -167,7 +167,7 @@
 (define-arg-type float-operation :printer float-operation-names)
 
 
-
+
 ;;;; Constants used by instruction emitters.
 
 (defconstant special-op #b000000)
@@ -178,7 +178,7 @@
 (defconstant cop3-op #b010011)
 
 
-
+
 ;;;; dissassem:define-instruction-formats
 
 (defconstant-eqx immed-printer
@@ -296,7 +296,7 @@
   (funct-filler :field (byte 4 2) :value 0)
   (ft           :value nil :type 'fp-reg))
 
-
+
 ;;;; Primitive emitters.
 
 (define-bitfield-emitter emit-word 32
@@ -319,7 +319,7 @@
   (byte 5 11) (byte 5 6) (byte 6 0))
 
 
-
+
 ;;;; Math instructions.
 
 (defun emit-math-inst (segment dst src1 src2 reg-opcode immed-opcode
@@ -544,7 +544,7 @@
   (:emitter
    (emit-shift-inst segment #b10 dst src1 src2)))
 
-
+
 ;;;; Floating point math.
 
 (define-instruction float-op (segment operation format dst src1 src2)
@@ -607,7 +607,7 @@
                     (fp-reg-tn-encoding ft) (fp-reg-tn-encoding fs) 0
                     (logior #b110000 (compare-kind operation)))))
 
-
+
 ;;;; Branch/Jump instructions.
 
 (defun emit-relative-branch (segment opcode r1 r2 target)
@@ -858,7 +858,7 @@
    (emit-relative-branch segment cop1-op #b01000 #b00001 target)))
 
 
-
+
 ;;;; Random movement instructions.
 
 (define-instruction lui (segment reg value)
@@ -1029,7 +1029,7 @@
                        cr 0 0)))
 
 
-
+
 ;;;; Random system hackery and other noise
 
 (define-instruction-macro entry-point ()
@@ -1205,7 +1205,7 @@
                           (+ (label-position label posn delta-if-after)
                              (component-header-length))))))
 
-
+
 ;;;; Loads and Stores
 
 (defun emit-load/store-inst (segment opcode reg base index

--- a/src/compiler/mips/macros.lisp
+++ b/src/compiler/mips/macros.lisp
@@ -20,7 +20,7 @@
             ,expr))
        (,gensym))))
 
-
+
 ;;; Instruction-like macros.
 
 (defmacro move (dst src &optional (always-emit-code-p nil))
@@ -103,7 +103,7 @@ byte-ordering issues."
      (inst lra-header-word)))
 
 
-
+
 ;;;; Stack TN's
 
 ;;; Move a stack TN to a register and vice-versa.
@@ -135,7 +135,7 @@ byte-ordering issues."
           ((control-stack)
            (loadw ,n-reg cfp-tn (tn-offset ,n-stack))))))))
 
-
+
 ;;;; Storage allocation:
 (defmacro with-fixed-allocation ((result-tn flag-tn temp-tn type-code
                                   size dynamic-extent-p
@@ -180,7 +180,7 @@ placed inside the PSEUDO-ATOMIC, and presumably initializes the object."
     (storew zero-tn csp-tn -1)
     (emit-label aligned)))
 
-
+
 ;;;; Three Way Comparison
 (defun three-way-comparison (x y condition flavor not-p target temp)
   (ecase condition
@@ -209,7 +209,7 @@ placed inside the PSEUDO-ATOMIC, and presumably initializes the object."
   (inst nop))
 
 
-
+
 ;;;; Error Code
 (defun emit-error-break (vop kind code values)
   (assemble ()
@@ -229,7 +229,7 @@ placed inside the PSEUDO-ATOMIC, and presumably initializes the object."
       (apply #'error-call vop error-code values)
       start-lab)))
 
-
+
 ;;;; PSEUDO-ATOMIC
 
 ;;; handy macro for making sequences look atomic
@@ -247,7 +247,7 @@ placed inside the PSEUDO-ATOMIC, and presumably initializes the object."
          (inst addu alloc-tn (1- ,extra))
          (inst break 0 pending-interrupt-trap)
          (emit-label label)))))
-
+
 ;;;; memory accessor vop generators
 
 (sb-xc:deftype load/store-index (scale lowtag min-offset

--- a/src/compiler/mips/move.lisp
+++ b/src/compiler/mips/move.lisp
@@ -57,7 +57,7 @@
   (let ((nfp (current-nfp-tn vop)))
     (storew x nfp (tn-offset y))))
 
-
+
 ;;;; The Move VOP:
 ;;;
 (define-vop (move)
@@ -97,7 +97,7 @@
 (define-move-vop move-arg :move-arg
   (any-reg descriptor-reg null zero)
   (any-reg descriptor-reg))
-
+
 ;;;; Moves and coercions:
 
 ;;; These MOVE-TO-WORD VOPs move a tagged integer to a raw full-word

--- a/src/compiler/mips/nlx.lisp
+++ b/src/compiler/mips/nlx.lisp
@@ -5,7 +5,7 @@
 ;;;
 (defun make-nlx-entry-arg-start-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn ocfp-offset))
-
+
 ;;; Save and restore dynamic environment.
 ;;;
 ;;; These VOPs are used in the reentered function to restore the appropriate
@@ -58,7 +58,7 @@
   (:args (nsp :scs (any-reg descriptor-reg)))
   (:generator 1
     (move nsp-tn nsp)))
-
+
 ;;;; Unwind block hackery:
 
 ;;; Compute the address of the catch block from its TN, then store into the
@@ -135,7 +135,7 @@
     (loadw block block unwind-block-uwp-slot)
     (store-symbol-value block *current-unwind-protect-block*)))
 
-
+
 ;;;; NLX entry VOPs:
 
 

--- a/src/compiler/mips/parms.lisp
+++ b/src/compiler/mips/parms.lisp
@@ -18,7 +18,7 @@
   ;; The o32 ABI specifies 4k-64k as page size. We have to pick the
   ;; maximum since mprotect() works only with page granularity.
 (defconstant +backend-page-bytes+ 65536)
-
+
 ;;;; Machine Architecture parameters:
 (eval-when (:compile-toplevel :load-toplevel :execute)
 
@@ -110,7 +110,7 @@
 
 ); eval-when
 
-
+
 ;;;; Other non-type constants.
 
 (defenum ()
@@ -127,7 +127,7 @@
   single-step-around-trap
   single-step-before-trap
   error-trap)
-
+
 ;;;; Static symbols.
 
 ;;; Static symbols are loaded into static space directly after NIL so

--- a/src/compiler/mips/pred.lisp
+++ b/src/compiler/mips/pred.lisp
@@ -1,6 +1,6 @@
 (in-package "SB-VM")
 
-
+
 ;;;; The Branch VOP.
 
 ;;; The unconditional branch, emitted when we can't drop through to the desired
@@ -12,7 +12,7 @@
     (inst b dest)
     (inst nop)))
 
-
+
 ;;;; Generic conditional VOPs
 
 ;;; The generic conditional branch, emitted immediately after test
@@ -28,7 +28,7 @@
   (declare (ignore node dst-tn x-tn y-tn))
   nil)
 
-
+
 ;;;; Conditional VOPs:
 
 (define-vop (if-eq)

--- a/src/compiler/mips/sap.lisp
+++ b/src/compiler/mips/sap.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged SAP to an untagged representation.
@@ -74,7 +74,7 @@
 ;;; descriptor passing location.
 (define-move-vop move-arg :move-arg
   (sap-reg) (descriptor-reg))
-
+
 ;;;; SAP-INT and INT-SAP
 
 ;;; The function SAP-INT is used to generate an integer corresponding
@@ -102,7 +102,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move sap int)))
-
+
 ;;;; POINTER+ and POINTER-
 (define-vop (pointer+)
   (:translate sap+)
@@ -129,7 +129,7 @@
   (:result-types signed-num)
   (:generator 1
     (inst subu res ptr1 ptr2)))
-
+
 ;;;; mumble-SYSTEM-REF and mumble-SYSTEM-SET
 (macrolet ((def-system-ref-and-set
           (ref-name set-name sc type size &optional signed)
@@ -305,7 +305,7 @@
     single-reg single-float :single)
   (def-system-ref-and-set sap-ref-double %set-sap-ref-double
     double-reg double-float :double))
-
+
 ;;; Noise to convert normal lisp data objects into SAPs.
 (define-vop (vector-sap)
   (:translate vector-sap)

--- a/src/compiler/mips/subprim.lisp
+++ b/src/compiler/mips/subprim.lisp
@@ -1,7 +1,7 @@
 (in-package "SB-VM")
 
 
-
+
 ;;;; Length
 
 (define-vop (length/list)

--- a/src/compiler/mips/system.lisp
+++ b/src/compiler/mips/system.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Type frobbing VOPs
 
 (define-vop (widetag-of)
@@ -133,7 +133,7 @@
     (inst sll res ptr 3)
     (inst srl res res 1)))
 
-
+
 ;;;; Allocation
 
 (define-vop (dynamic-space-free-pointer)
@@ -160,7 +160,7 @@
   (:generator 1
     (move int csp-tn)))
 
-
+
 ;;;; Code object frobbing.
 
 (define-vop (code-instructions)
@@ -215,7 +215,7 @@
     (inst addu ndescr (- fun-pointer-lowtag other-pointer-lowtag))
     (inst addu func code ndescr)))
 
-
+
 ;;;; Other random VOPs.
 
 
@@ -231,7 +231,7 @@
   (:generator 1
     (inst break 0 halt-trap)))
 
-
+
 ;;;; Dynamic vop count collection support
 
 (define-vop (count-me)

--- a/src/compiler/mips/type-vops.lisp
+++ b/src/compiler/mips/type-vops.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Test generation utilities.
 (defun %test-fixnum (value temp target not-p)
   (assemble ()
@@ -92,7 +92,7 @@
                       (inst blez temp when-true))))))))
         (inst nop)
         (emit-label drop-through)))))
-
+
 ;;;; TYPE-VOPs for types that are more complex to test for than simple
 ;;;; LOWTAG and WIDETAG tests, but that are nevertheless important:
 

--- a/src/compiler/mips/vm.lisp
+++ b/src/compiler/mips/vm.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Registers
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -90,7 +90,7 @@
   (defregset reserve-non-descriptor-regs
       nl4 cfunc))
 
-
+
 ;;;; SB and SC definition:
 
 (!define-storage-bases
@@ -249,7 +249,7 @@
 
 
 
-
+
 ;;;; Random TNs for interesting registers
 
 (macrolet ((defregtn (name sc)
@@ -278,7 +278,7 @@
 
   (defregtn code descriptor-reg)
   (defregtn lip interior-reg))
-
+
 ;;; If VALUE can be represented as an immediate constant, then return the
 ;;; appropriate SC number, otherwise return NIL.
 (defun immediate-constant-sc (value)
@@ -304,7 +304,7 @@
   (or (eql sc zero-sc-number)
       (eql sc null-sc-number)
       (eql sc immediate-sc-number)))
-
+
 ;;;; Function Call Parameters
 
 ;;; The SC numbers for register and stack arguments/return values.
@@ -345,7 +345,7 @@
 
 ;;; This is used by the debugger.
 (defconstant single-value-return-byte-offset 8)
-
+
 ;;; This function is called by debug output routines that want a pretty name
 ;;; for a TN's location.  It returns a thing that can be printed with PRINC.
 (defun location-print-name (tn)

--- a/src/compiler/node.lisp
+++ b/src/compiler/node.lisp
@@ -717,7 +717,7 @@
   block
   target
   info)
-
+
 ;;;; LEAF structures
 
 ;;; Variables, constants and functions are all represented by LEAF
@@ -858,7 +858,7 @@
   #+sb-show id
   inlinep
   (functionals :test functionals))
-
+
 ;;;; function stuff
 
 ;;; We default the WHERE-FROM and TYPE slots to :DEFINED and FUNCTION.
@@ -1356,7 +1356,7 @@
   `(lambda-var-attributep (lambda-var-flags ,var) deleted))
 (defmacro lambda-var-explicit-value-cell (var)
   `(lambda-var-attributep (lambda-var-flags ,var) explicit-value-cell))
-
+
 ;;;; basic node types
 
 ;;; A REF represents a reference to a LEAF. REF-REOPTIMIZE is
@@ -1565,7 +1565,7 @@
 
 ;;; Inserted by ARRAY-CALL-TYPE-DERIVER so that it can be later deleted
 (def!struct (array-index-cast (:include cast) (:copier nil)))
-
+
 ;;;; non-local exit support
 ;;;;
 ;;;; In IR1, we insert special nodes to mark potentially non-local
@@ -1605,7 +1605,7 @@
   #+sb-show id
   (entry :test entry)
   (value :test value))
-
+
 ;;; a helper for the POLICY macro, defined late here so that the
 ;;; various type tests can be inlined
 ;;; You might think that NIL as a policy becomes *POLICY*,
@@ -1630,7 +1630,7 @@
                         (lexenv thing)
                         (node (node-lexenv thing))
                         (functional (functional-lexenv thing)))))))
-
+
 ;;;; Freeze some structure types to speed type testing.
 
 ;; FIXME: the frozen-ness can't actually help optimize anything

--- a/src/compiler/pack-iterative.lisp
+++ b/src/compiler/pack-iterative.lisp
@@ -43,7 +43,7 @@
 ;;;; Compilers for Parallel Computing. Springer Berlin Heidelberg,
 ;;;; 2006. 1-16.
 ;;;; (http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.107.9598)
-
+
 ;;; Interference graph data structure
 
 ;; vertex in an interference graph
@@ -109,7 +109,7 @@
   (vertices nil :type list)
   ;; unsorted set of precolored vertices.
   (precolored-vertices nil :type list :read-only t))
-
+
 ;;; Interference graph construction
 ;;;
 ;;; First, compute conflict edges between vertices that aren't
@@ -231,7 +231,7 @@
   ;; Find the other edges by enumerating IR2 blocks
   (do-ir2-blocks (block component)
     (insert-block-local-conflicts block)))
-
+
 ;;; Interference graph construction, the rest: annotating vertex
 ;;; structures, and bundling up the conflict graph.
 ;;;
@@ -327,7 +327,7 @@
     (setf (ig-vertices graph) vertices)
     (do-sset-elements (neighbor (vertex-full-incidence vertex) graph)
       (sset-delete vertex (vertex-full-incidence neighbor)))))
-
+
 ;;; Support code
 
 ;; Return nil if COLOR conflicts with any of NEIGHBOR-COLORS.
@@ -448,7 +448,7 @@
      (vertices-best-color/single-color vertices (sc-locations-first colors)))
     (t
      (vertices-best-color/general vertices colors))))
-
+
 ;;; Coloring inner loop
 
 ;; Greedily choose the color for this vertex, also moving around any
@@ -540,7 +540,7 @@
       ;; These might benefit from further ordering... LexBFS?
       (color-vertices probably-spilled)))
   interference-graph)
-
+
 ;;; Iterative spilling logic.
 
 ;; maximum number of spill iterations
@@ -597,7 +597,7 @@
                (+ spilled (length colored)
                   (length (ig-precolored-vertices graph)))))
       colored)))
-
+
 ;;; Nice interface
 
 ;; Just pack vertices that have been assigned a color.

--- a/src/compiler/pack.lisp
+++ b/src/compiler/pack.lisp
@@ -21,7 +21,7 @@
 ;;; should be made conditional on SB-TWEAK.
 
 (declaim (ftype (function (component) index) ir2-block-count))
-
+
 ;;;; conflict determination
 
 ;;; Return true if TN has a conflict in SC at the specified offset.
@@ -262,7 +262,7 @@
     (setf (finite-sb-current-size sb) new-size))
   (values))
 
-
+
 ;;;; internal errors
 
 ;;; Give someone a hard time because there isn't any load function
@@ -417,7 +417,7 @@
              (primitive-type-name ptype)
              (mapcar #'sc-name (listify-restrictions load-scs))
              incon))))
-
+
 ;;;; register saving
 
 ;;; Do stuff to note that TN is spilled at VOP for the debugger's benefit.
@@ -575,7 +575,7 @@
           (basic-save-tn tn vop)))))
 
   (values))
-
+
 ;;;; optimized saving
 
 ;;; Save TN if it isn't a single-writer TN that has already been
@@ -741,7 +741,7 @@
                 (return t)))
         (setq block (optimized-emit-saves-block block saves restores)))
       (setq block (ir2-block-prev block)))))
-
+
 ;;; Iterate over the normal TNs, finding the cost of packing on the
 ;;; stack in units of the number of references. We count all read
 ;;; references as +1, write references as + *tn-write-cost*, and
@@ -825,7 +825,7 @@
               ;; race conditions in the debugger involving
               ;; backtraces from asynchronous interrupts.
               (setf (tn-sc tn) (tn-sc save-tn)))))))))
-
+
 ;;;; load TN packing
 
 ;;; These variables indicate the last location at which we computed
@@ -1240,7 +1240,7 @@
           (check-operand-restrictions (vop-info-arg-load-scs info)
                                       (vop-args vop))))))
   (values))
-
+
 ;;;; targeting
 
 ;;; Link the TN-REFS READ and WRITE together using the TN-REF-TARGET
@@ -1334,7 +1334,7 @@
                 (neq (tn-kind target) :arg-pass)
                 (check-ok-target target tn sc))
       (return-from find-ok-target-offset it))))
-
+
 ;;;; location selection
 
 ;;; Select some location for TN in SC, returning the offset if we
@@ -1382,7 +1382,7 @@
   (if (member (tn-kind tn) '(:save :save-once :specified-save))
       (tn-save-tn tn)
       tn))
-
+
 ;;;; pack interface
 
 ;; Misc. utilities

--- a/src/compiler/physenvanal.lisp
+++ b/src/compiler/physenvanal.lisp
@@ -211,7 +211,7 @@
             (when (and (lambda-var-p var)
                        (lambda-var-indirect var))
               (setf (lambda-var-explicit-value-cell var) t))))))))
-
+
 ;;;; non-local exit
 
 (defvar *functional-escape-info*)
@@ -384,7 +384,7 @@
             (aver (neq (node-physenv exit) target-physenv))
             (note-non-local-exit target-physenv exit))))))
   (values))
-
+
 ;;;; final decision on stack allocation of dynamic-extent structures
 (defun recheck-dynamic-extent-lvars (component)
   (declare (type component component))
@@ -435,7 +435,7 @@
                      (setf (component-dx-lvars component)
                            (append real-dx-lvars (component-dx-lvars component)))))))))
   (values))
-
+
 ;;;; cleanup emission
 
 ;;; Zoom up the cleanup nesting until we hit CLEANUP1, accumulating

--- a/src/compiler/ppc/alloc.lisp
+++ b/src/compiler/ppc/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; LIST and LIST*
 (define-vop (list-or-list*)
   (:args (things :more t))
@@ -75,7 +75,7 @@
 (define-vop (list* list-or-list*)
   (:variant t))
 
-
+
 ;;;; Special purpose inline allocators.
 
 (define-vop (make-fdefn)
@@ -131,7 +131,7 @@
       (storew value result value-cell-value-slot other-pointer-lowtag))))
 
 
-
+
 ;;;; Automatic allocators for primitive objects.
 
 (define-vop (make-unbound-marker)

--- a/src/compiler/ppc/arith.lisp
+++ b/src/compiler/ppc/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Unary operations.
 
 (define-vop (fast-safe-arith-op)
@@ -49,7 +49,7 @@
   (:translate lognot)
   (:generator 2
     (inst not res x)))
-
+
 ;;;; Binary fixnum operations.
 
 ;;; Assume that any constant operand is the second arg...
@@ -459,7 +459,7 @@
   (:translate *)
   (:generator 3
     (inst mulli r x y)))
-
+
 ;;; Shifting
 
 (macrolet ((def (name sc-type type result-type cost)
@@ -622,7 +622,7 @@
 
       (emit-label done))))
 
-
+
 ;;;; %LDB
 
 (defknown %%ldb (integer unsigned-byte unsigned-byte) unsigned-byte
@@ -685,7 +685,7 @@
           (mod (- (+ 32 n-fixnum-tag-bits) posn) 32)
           (- 32 size n-fixnum-tag-bits)
           (- 31 n-fixnum-tag-bits))))
-
+
 ;;;; Modular functions:
 (define-modular-fun lognot-mod32 (x) lognot :untagged nil 32)
 (define-vop (lognot-mod32/unsigned=>unsigned)
@@ -734,7 +734,7 @@
   (define-modular-backend logandc2)
   (define-modular-backend logorc1)
   (define-modular-backend logorc2))
-
+
 ;;;; Binary conditional VOPs:
 
 (define-vop (fast-conditional)
@@ -974,7 +974,7 @@
   (:arg-types * (:constant (signed-byte 11)))
   (:variant-cost 6))
 
-
+
 ;;;; 32-bit logical operations
 
 (define-vop (shift-towards-someplace)
@@ -998,7 +998,7 @@
   (:generator 1
     (inst rlwinm amount amount 0 27 31)
     (inst srw r num amount)))
-
+
 ;;;; Bignum stuff.
 
 (define-vop (bignum-length get-header-data)
@@ -1254,7 +1254,7 @@
   (:translate sb-bignum:%ashl)
   (:generator 1
     (inst slw result digit count)))
-
+
 (in-package "SB-C")
 
 (deftransform * ((x y)

--- a/src/compiler/ppc/array.lisp
+++ b/src/compiler/ppc/array.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Allocator for the array header.
 
 (define-vop (make-array-header)
@@ -40,7 +40,7 @@
       (storew ndescr header 0 other-pointer-lowtag))
     (move result header)))
 
-
+
 ;;;; Additional accessors and setters for the array header.
 (define-vop (%array-dimension word-index-ref)
   (:translate %array-dimension)
@@ -63,7 +63,7 @@
     (inst srawi temp temp n-widetag-bits)
     (inst subi temp temp (1- array-dimensions-offset))
     (inst slwi res temp n-fixnum-tag-bits)))
-
+
 ;;;; Bounds checking routine.
 
 
@@ -83,7 +83,7 @@
       (inst cmplw index bound)
       (inst bge error))))
 
-
+
 ;;;; Accessors/Setters
 
 ;;; Variants built on top of word-index-ref, etc.  I.e. those vectors whos
@@ -377,7 +377,7 @@
     (unless (location= result value)
       (inst fmr result value))))
 
-
+
 ;;; Complex float arrays.
 
 (define-vop (data-vector-ref/simple-array-complex-single-float)
@@ -477,7 +477,7 @@
       (unless (location= result-imag value-imag)
         (inst fmr result-imag value-imag)))))
 
-
+
 ;;; These vops are useful for accessing the bits of a vector irrespective of
 ;;; what type of vector it is.
 ;;;
@@ -499,7 +499,7 @@
   (:results (result :scs (unsigned-reg)))
   (:result-types unsigned-num)
   (:variant vector-data-offset other-pointer-lowtag))
-
+
 ;;;
 
 (define-vop (data-vector-ref/simple-array-signed-byte-8 signed-byte-index-ref)
@@ -540,7 +540,7 @@
          (value :scs (signed-reg)))
   (:results (result :scs (signed-reg)))
   (:result-types tagged-num))
-
+
 ;;;; ATOMIC-INCF for arrays
 
 (define-vop (array-atomic-incf/word)

--- a/src/compiler/ppc/call.lisp
+++ b/src/compiler/ppc/call.lisp
@@ -55,7 +55,7 @@
 ;;; passed when we are using non-standard conventions.
 (defun make-arg-count-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn nargs-offset))
-
+
 ;;;; Frame hackery:
 
 ;;; this is the first function in this file that differs materially from
@@ -295,7 +295,7 @@ default-value-8
         (inst compute-code-from-lra code-tn lra-tn lra-label temp)))
   (values))
 
-
+
 ;;;; Unknown values receiving:
 
 ;;;    Emit code needed at the return point for an unknown-values call for an
@@ -357,7 +357,7 @@ default-value-8
               nvals)
   (:temporary (:scs (non-descriptor-reg)) temp))
 
-
+
 ;;; This hook in the codegen pass lets us insert code before fall-thru entry
 ;;; points, local-call entry points, and tail-call entry points.  The default
 ;;; does nothing.
@@ -367,7 +367,7 @@ default-value-8
     (emit-label trampoline-label))
   (emit-label start-label))
 
-
+
 ;;;; Local call with unknown values convention return:
 
 ;;; Non-TR local call for a fixed number of values passed according to the
@@ -460,7 +460,7 @@ default-value-8
       (when cur-nfp
         (load-stack-tn cur-nfp nfp-save)))))
 
-
+
 ;;;; Local call with known values return:
 
 ;;; Non-TR local call with known return locations.  Known-value return works
@@ -528,7 +528,7 @@ default-value-8
     (move cfp-tn old-fp-temp)
     (inst j return-pc-temp (- n-word-bytes other-pointer-lowtag))))
 
-
+
 ;;;; Full call:
 ;;;
 ;;;    There is something of a cross-product effect with full calls.  Different
@@ -871,7 +871,7 @@ default-value-8
     (inst mtlr temp)
     (inst blr)))
 
-
+
 ;;;; Unknown values return:
 
 ;;; Return a single value using the unknown-values convention.
@@ -998,7 +998,7 @@ default-value-8
       (inst lr temp (make-fixup 'return-multiple :assembly-routine))
       (inst mtlr temp)
       (inst blr))))
-
+
 ;;;; XEP hackery:
 
 ;;; Get the lexical environment from its passing location.

--- a/src/compiler/ppc/cell.lisp
+++ b/src/compiler/ppc/cell.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Data object ref/set stuff.
 
 (define-vop (slot)
@@ -55,7 +55,7 @@
     EXIT
     (inst isync)))
 
-
+
 ;;;; Symbol hacking VOPs:
 
 (define-vop (%compare-and-swap-symbol-value)
@@ -229,7 +229,7 @@
     ;; ensure this is explained in the comment in objdef.lisp
     (loadw res symbol symbol-hash-slot other-pointer-lowtag)
     (inst clrrwi res res n-fixnum-tag-bits)))
-
+
 ;;;; Fdefinition (fdefn) objects.
 
 (define-vop (fdefn-fun cell-ref)
@@ -285,7 +285,7 @@
     (move result fdefn)))
 
 
-
+
 ;;;; Binding and Unbinding.
 
 ;;; BIND -- Establish VAL as a binding for SYMBOL.  Save the old value and
@@ -416,7 +416,7 @@
       (emit-label done))))
 
 
-
+
 ;;;; Closure indexing.
 
 (define-vop (closure-index-ref word-index-ref)
@@ -450,7 +450,7 @@
   (:info offset)
   (:generator 4
     (storew cfp-tn object (+ closure-info-offset offset) fun-pointer-lowtag)))
-
+
 ;;;; Value Cell hackery.
 
 (define-vop (value-cell-ref cell-ref)
@@ -460,7 +460,7 @@
   (:variant value-cell-value-slot other-pointer-lowtag))
 
 
-
+
 ;;;; Instance hackery:
 
 (define-vop (instance-length)
@@ -494,7 +494,7 @@
   (:variant instance-slots-offset instance-pointer-lowtag)
   (:arg-types instance tagged-num * *))
 
-
+
 ;;;; Code object frobbing.
 
 (define-vop (code-header-ref word-index-ref)
@@ -508,7 +508,7 @@
   (:variant 0 other-pointer-lowtag))
 
 
-
+
 ;;;; raw instance slot accessors
 
 (defun offset-for-raw-slot (index &optional (displacement 0))

--- a/src/compiler/ppc/char.lisp
+++ b/src/compiler/ppc/char.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged char to an untagged representation.
@@ -68,7 +68,7 @@
 ;;; to a descriptor passing location.
 (define-move-vop move-arg :move-arg
   (character-reg) (any-reg descriptor-reg))
-
+
 ;;;; Other operations:
 
 (define-vop (char-code)
@@ -90,7 +90,7 @@
   (:result-types character)
   (:generator 1
     (inst srwi res code n-fixnum-tag-bits)))
-
+
 ;;; Comparison of characters.
 (define-vop (character-compare)
   (:args (x :scs (character-reg))

--- a/src/compiler/ppc/float.lisp
+++ b/src/compiler/ppc/float.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Move functions:
 
 (define-move-fun (load-single 1) (vop x y)
@@ -35,7 +35,7 @@
     (inst stfd x nfp offset)))
 
 
-
+
 ;;;; Move VOPs:
 
 (macrolet ((frob (vop sc)
@@ -116,7 +116,7 @@
   (frob move-double-float-arg double-reg double-stack t))
 
 
-
+
 ;;;; Complex float move functions
 
 (defun complex-single-reg-real-tn (x)
@@ -349,7 +349,7 @@
   (single-reg double-reg complex-single-reg complex-double-reg)
   (descriptor-reg))
 
-
+
 ;;;; Arithmetic VOPs:
 
 (define-vop (float-op)
@@ -404,7 +404,7 @@
   (frob %negate/single-float fneg %negate single-reg single-float)
   (frob %negate/double-float fneg %negate double-reg double-float))
 
-
+
 ;;;; Comparison:
 
 (define-vop (float-compare)
@@ -443,7 +443,7 @@
   (frob > :gt :le >/single-float >/double-float)
   (frob = :eq :ne =/single-float =/double-float))
 
-
+
 ;;;; Conversion:
 
 (macrolet ((frob (name translate inst to-sc to-type)
@@ -687,7 +687,7 @@
       (descriptor-reg
         (loadw lo-bits float (1+ double-float-value-slot)
                other-pointer-lowtag)))))
-
+
 ;;;; Float mode hackery:
 
 (sb-xc:deftype float-modes () '(unsigned-byte 32))
@@ -726,7 +726,7 @@
       (inst mtfsf 255 fp-temp)
       (move res new))))
 
-
+
 ;;;; Complex float VOPs
 
 (define-vop (make-complex-single-float)

--- a/src/compiler/ppc/insts.lisp
+++ b/src/compiler/ppc/insts.lisp
@@ -21,7 +21,7 @@
             ;; TNs and offsets
             sb-vm::zero-tn sb-vm::lip-tn
             sb-vm::zero-offset sb-vm::null-offset)))
-
+
 ;;;; Constants, types, conversion functions, some disassembler stuff.
 
 (defun reg-tn-encoding (tn)
@@ -282,7 +282,7 @@
           (write addr :base 16 :radix t :stream stream))))
 
 
-
+
 ;;;; dissassem:define-instruction-formats
 
 (defmacro ppc-byte (startbit &optional (endbit startbit))
@@ -397,7 +397,7 @@
   frs ra d)
 
 
-
+
 ;;; There are around ... oh, 28 or so ... variants on the "X" format.
 ;;;  Some of them are only used by one instruction; some are used by dozens.
 ;;;  Some aren't used by instructions that we generate ...
@@ -462,7 +462,7 @@
 (def-ppc-iformat (x-27 '(:name))
   (xo xo21-30))
 
-
+
 ;;;;
 
 (def-ppc-iformat (xl '(:name :tab bt "," ba "," bb))
@@ -477,7 +477,7 @@
 (def-ppc-iformat (xl-xo '(:name))
   (xo xo21-30))
 
-
+
 ;;;;
 
 (def-ppc-iformat (xfx)
@@ -489,7 +489,7 @@
 (def-ppc-iformat (xfl '(:name :tab flm "," frb))
   flm frb (xo xo21-30) rc)
 
-
+
 ;;;
 
 (def-ppc-iformat (xo '(:name :tab rt "," ra "," rb))
@@ -501,7 +501,7 @@
 (def-ppc-iformat (xo-a '(:name :tab rt "," ra))
   rt ra oe (xo xo22-30) rc)
 
-
+
 ;;;
 
 (def-ppc-iformat (a '(:name :tab frt "," fra "," frb "," frc))
@@ -515,7 +515,7 @@
 
 (def-ppc-iformat (a-tbc '(:name :tab frt "," frb "," frc))
   frt frb frc (xo xo26-30) rc)
-
+
 
 (def-ppc-iformat (m '(:name :tab ra "," rs "," rb "," mb "," me))
   rs ra rb mb me rc)
@@ -529,7 +529,7 @@
   (data :field (byte 16 0) :reader xinstr-data))
 
 
-
+
 ;;;; Primitive emitters.
 
 
@@ -566,7 +566,7 @@
   (byte 6 26) (byte 5 21) (byte 5 16) (byte 5 11) (byte 5 6) (byte 5 1) (byte 1 0))
 
 
-
+
 
 (eval-when (:compile-toplevel :execute)
 (defun classify-dependencies (deplist)
@@ -1693,7 +1693,7 @@
 
 
 
-
+
 ;;; Here in the future, macros are our friends.
 
   (define-instruction-macro subis (rt ra simm)
@@ -1909,7 +1909,7 @@
 (define-instruction-macro blrl ()
   `(inst bclrl :bo-u 0))
 
-
+
 ;;; Some more macros
 
 (defun %lr (reg value)
@@ -1940,7 +1940,7 @@
   `(%lr ,reg ,value))
 
 
-
+
 ;;;; Instructions for dumping data and header objects.
 
 (define-instruction word (segment word)
@@ -1983,7 +1983,7 @@
   (:emitter
    (emit-header-data segment return-pc-widetag)))
 
-
+
 ;;;; Instructions for converting between code objects, functions, and lras.
 (defun emit-compute-inst (segment vop dst src label temp calc)
   (emit-chooser

--- a/src/compiler/ppc/macros.lisp
+++ b/src/compiler/ppc/macros.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Instruction-like macros.
 
 (defmacro move (dst src)
@@ -126,7 +126,7 @@
      (inst lra-header-word)))
 
 
-
+
 ;;;; Stack TN's
 
 ;;; Move a stack TN to a register and vice-versa.
@@ -157,7 +157,7 @@
           ((control-stack)
            (loadw ,n-reg cfp-tn (tn-offset ,n-stack))))))))
 
-
+
 ;;;; Storage allocation:
 
 ;;; This is the main mechanism for allocating memory in the lisp heap.
@@ -300,7 +300,7 @@
     (storew zero-tn csp-tn -1)
     (emit-label aligned)))
 
-
+
 ;;;; Error Code
 (defun emit-error-break (vop kind code values)
   (assemble ()
@@ -319,7 +319,7 @@
       (emit-label start-lab)
       (emit-error-break vop error-trap (error-number-or-lose error-code) values)
       start-lab)))
-
+
 ;;;; PSEUDO-ATOMIC
 
 ;;; handy macro for making sequences look atomic

--- a/src/compiler/ppc/memory.lisp
+++ b/src/compiler/ppc/memory.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Cell-Ref and Cell-Set are used to define VOPs like CAR, where the offset to
 ;;; be read or written is a property of the VOP used.
 ;;;
@@ -30,7 +30,7 @@
   (:policy :fast-safe)
   (:generator 4
     (storew value object offset lowtag)))
-
+
 ;;;; Indexed references:
 
 ;;; Define some VOPs for indexed memory reference.

--- a/src/compiler/ppc/move.lisp
+++ b/src/compiler/ppc/move.lisp
@@ -67,7 +67,7 @@
   (let ((nfp (current-nfp-tn vop)))
     (storew x nfp (tn-offset y))))
 
-
+
 ;;;; The Move VOP:
 (define-vop (move)
   (:args (x :target y
@@ -104,7 +104,7 @@
 (define-move-vop move-arg :move-arg
   (any-reg descriptor-reg)
   (any-reg descriptor-reg))
-
+
 ;;;; Moves and coercions:
 
 ;;; These MOVE-TO-WORD VOPs move a tagged integer to a raw full-word

--- a/src/compiler/ppc/nlx.lisp
+++ b/src/compiler/ppc/nlx.lisp
@@ -17,7 +17,7 @@
 (defun make-nlx-entry-arg-start-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn ocfp-offset))
 
-
+
 ;;; These VOPs are used in the reentered function to restore the
 ;;; appropriate dynamic environment. Currently we only save the
 ;;; CURRENT-CATCH and binding stack pointer. We don't need to
@@ -71,7 +71,7 @@
   (:generator 1
     (move nsp-tn nsp)))
 
-
+
 ;;;; Unwind block hackery:
 
 ;;; Compute the address of the catch block from its TN, then store into the
@@ -151,7 +151,7 @@
     (loadw block block unwind-block-uwp-slot)
     (store-tl-symbol-value block *current-unwind-protect-block* temp)))
 
-
+
 ;;;; NLX entry VOPs:
 
 

--- a/src/compiler/ppc/parms.lisp
+++ b/src/compiler/ppc/parms.lisp
@@ -109,7 +109,7 @@
 
 (defconstant float-fast-bit 2)         ; Non-IEEE mode
 
-
+
 ;;;; Where to put the different spaces.
 
 ;;; On non-gencgc we need large dynamic and static spaces for PURIFY
@@ -168,7 +168,7 @@
   (progn
     (defparameter dynamic-0-space-start #x10000000)
     (defparameter dynamic-0-space-end   #x3ffff000)))
-
+
 (defenum (:start 8)
   halt-trap
   pending-interrupt-trap
@@ -179,7 +179,7 @@
   single-step-around-trap
   single-step-before-trap
   error-trap)
-
+
 ;;;; Static symbols.
 
 

--- a/src/compiler/ppc/pred.lisp
+++ b/src/compiler/ppc/pred.lisp
@@ -4,7 +4,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; The Branch VOP.
 
 ;;; The unconditional branch, emitted when we can't drop through to the desired
@@ -15,7 +15,7 @@
   (:generator 5
     (inst b dest)))
 
-
+
 ;;;; Generic conditional VOPs
 
 ;;; The generic conditional branch, emitted immediately after test
@@ -31,7 +31,7 @@
   (declare (ignore node dst-tn x-tn y-tn))
   nil)
 
-
+
 ;;;; Conditional VOPs:
 
 (define-vop (if-eq)

--- a/src/compiler/ppc/sap.lisp
+++ b/src/compiler/ppc/sap.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged SAP to an untagged representation.
@@ -77,7 +77,7 @@
 ;;; descriptor passing location.
 (define-move-vop move-arg :move-arg
   (sap-reg) (descriptor-reg))
-
+
 ;;;; SAP-INT and INT-SAP
 (define-vop (sap-int)
   (:args (sap :scs (sap-reg) :target int))
@@ -98,7 +98,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move sap int)))
-
+
 ;;;; POINTER+ and POINTER-
 (define-vop (pointer+)
   (:translate sap+)
@@ -132,7 +132,7 @@
   (:result-types signed-num)
   (:generator 1
     (inst sub res ptr1 ptr2)))
-
+
 ;;;; mumble-SYSTEM-REF and mumble-SYSTEM-SET
 (macrolet ((def-system-ref-and-set
                (ref-name set-name sc type size &optional signed)
@@ -245,7 +245,7 @@
     single-reg single-float :single)
   (def-system-ref-and-set sap-ref-double %set-sap-ref-double
     double-reg double-float :double))
-
+
 ;;; Noise to convert normal lisp data objects into SAPs.
 (define-vop (vector-sap)
   (:translate vector-sap)

--- a/src/compiler/ppc/subprim.lisp
+++ b/src/compiler/ppc/subprim.lisp
@@ -4,7 +4,7 @@
 (in-package "SB-VM")
 
 
-
+
 ;;;; Length
 
 (define-vop (length/list)

--- a/src/compiler/ppc/system.lisp
+++ b/src/compiler/ppc/system.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Type frobbing VOPs
 
 (define-vop (widetag-of)
@@ -123,7 +123,7 @@
     ;; and shift the result into a positive fixnum like on x86.
     (inst rlwinm res ptr n-fixnum-tag-bits 1 n-positive-fixnum-bits)))
 
-
+
 ;;;; Allocation
 
 (define-vop (dynamic-space-free-pointer)
@@ -150,7 +150,7 @@
   (:generator 1
     (move int csp-tn)))
 
-
+
 ;;;; Code object frobbing.
 
 (define-vop (code-instructions)
@@ -195,7 +195,7 @@
     (inst add func code ndescr)))
 
 
-
+
 ;;;; Other random VOPs.
 
 
@@ -221,7 +221,7 @@
 (define-vop (halt)
   (:generator 1
     (inst unimp halt-trap)))
-
+
 ;;;; Dynamic vop count collection support
 
 (define-vop (count-me)
@@ -235,7 +235,7 @@
       (inst lwz count count-vector offset)
       (inst addi count count 1)
       (inst stw count count-vector offset))))
-
+
 ;;;; Memory barrier support
 
 (define-vop (%compiler-barrier)

--- a/src/compiler/ppc/type-vops.lisp
+++ b/src/compiler/ppc/type-vops.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (defun %test-fixnum (value temp target not-p)
   (assemble ()
     (inst andi. temp value fixnum-tag-mask)
@@ -101,7 +101,7 @@
                           (inst b? (if not-p :gt :le) target)
                           (inst ble when-true))))))))))
         (emit-label drop-through)))))
-
+
 ;;;; Other integer ranges.
 
 ;;; A (signed-byte 32) can be represented with either fixnum or a bignum with
@@ -173,7 +173,7 @@
         (inst b?  :cr1 (if not-p :lt :ge) target)
 
         (emit-label not-target)))))
-
+
 ;;;; List/symbol types:
 ;;;
 ;;; symbolp (or symbol (eq nil))

--- a/src/compiler/ppc/vm.lisp
+++ b/src/compiler/ppc/vm.lisp
@@ -21,7 +21,7 @@
   (* #-darwin 2
      #+darwin 8
      n-word-bytes))
-
+
 ;;;; Define the registers
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -94,7 +94,7 @@
  (defparameter register-arg-names '(a0 a1 a2 a3)))
 
 
-
+
 ;;;; SB and SC definition:
 
 (!define-storage-bases
@@ -230,7 +230,7 @@
 
   (catch-block control-stack :element-size catch-block-size)
   (unwind-block control-stack :element-size unwind-block-size))
-
+
 ;;;; Make some random tns for important registers.
 
 (macrolet ((defregtn (name sc)
@@ -255,7 +255,7 @@
   (defregtn cfp any-reg)
   (defregtn ocfp any-reg)
   (defregtn nsp any-reg))
-
+
 ;;; If VALUE can be represented as an immediate constant, then return the
 ;;; appropriate SC number, otherwise return NIL.
 (defun immediate-constant-sc (value)
@@ -276,7 +276,7 @@
   (or (eql sc zero-sc-number)
       (eql sc null-sc-number)
       (eql sc immediate-sc-number)))
-
+
 ;;;; function call parameters
 
 ;;; the SC numbers for register and stack arguments/return values
@@ -317,7 +317,7 @@
 
 ;;; This is used by the debugger.
 (defconstant single-value-return-byte-offset 8)
-
+
 ;;; This function is called by debug output routines that want a pretty name
 ;;; for a TN's location.  It returns a thing that can be printed with PRINC.
 (defun location-print-name (tn)

--- a/src/compiler/ppc64/alloc.lisp
+++ b/src/compiler/ppc64/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; LIST and LIST*
 (define-vop (list-or-list*)
   (:args (things :more t))
@@ -76,7 +76,7 @@
 (define-vop (list* list-or-list*)
   (:variant t))
 
-
+
 ;;;; Special purpose inline allocators.
 
 (define-vop (make-fdefn)
@@ -132,7 +132,7 @@
       (storew value result value-cell-value-slot other-pointer-lowtag))))
 
 
-
+
 ;;;; Automatic allocators for primitive objects.
 
 (define-vop (make-unbound-marker)

--- a/src/compiler/ppc64/arith.lisp
+++ b/src/compiler/ppc64/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Unary operations.
 
 (define-vop (fast-safe-arith-op)
@@ -49,7 +49,7 @@
   (:translate lognot)
   (:generator 2
     (inst not res x)))
-
+
 ;;;; Binary fixnum operations.
 
 ;;; Assume that any constant operand is the second arg...
@@ -459,7 +459,7 @@
   (:translate *)
   (:generator 3
     (inst mulli r x y)))
-
+
 ;;; Shifting
 
 (macrolet ((def (name sc-type type result-type cost)
@@ -608,7 +608,7 @@
   (:generator 2
     (inst popcntd temp arg)
     (inst slwi res arg n-fixnum-tag-bits)))
-
+
 ;;;; %LDB
 
 (defknown %%ldb (integer unsigned-byte unsigned-byte) unsigned-byte
@@ -675,7 +675,7 @@
           (mod (- (+ 32 n-fixnum-tag-bits) posn) 32)
           (- 32 size n-fixnum-tag-bits)
           (- 31 n-fixnum-tag-bits))))
-
+
 ;;;; Modular functions:
 
 ;;; FIXME: This should all be correctly ported to 64 bit
@@ -727,7 +727,7 @@
   (define-modular-backend logandc2)
   (define-modular-backend logorc1)
   (define-modular-backend logorc2))
-
+
 ;;;; Binary conditional VOPs:
 
 (define-vop (fast-conditional)
@@ -967,7 +967,7 @@
   (:arg-types * (:constant (signed-byte 11))) ; wtf is 11?
   (:variant-cost 6))
 
-
+
 ;;;; 64-bit logical operations
 
 (define-vop (shift-towards-someplace)
@@ -996,7 +996,7 @@
     (ecase *backend-byte-order*
       (:big-endian    (inst srd r num temp))
       (:little-endian (inst sld r num temp)))))
-
+
 ;;;; Bignum stuff.
 
 (define-vop (bignum-length get-header-data)
@@ -1254,7 +1254,7 @@
   (:translate sb-bignum:%ashl)
   (:generator 1
     (inst sld result digit count)))
-
+
 (in-package "SB-C")
 
 #+nil

--- a/src/compiler/ppc64/array.lisp
+++ b/src/compiler/ppc64/array.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Allocator for the array header.
 
 (define-vop (make-array-header)
@@ -41,7 +41,7 @@
       (storew ndescr header 0 other-pointer-lowtag))
     (move result header)))
 
-
+
 ;;;; Additional accessors and setters for the array header.
 (define-vop (%array-dimension word-index-ref)
   (:translate %array-dimension)
@@ -64,7 +64,7 @@
     (inst srawi temp temp n-widetag-bits)
     (inst subi temp temp (1- array-dimensions-offset))
     (inst slwi res temp n-fixnum-tag-bits)))
-
+
 ;;;; Bounds checking routine.
 
 
@@ -84,7 +84,7 @@
       (inst cmpld index bound)
       (inst bge error))))
 
-
+
 ;;;; Accessors/Setters
 
 ;;; Variants built on top of word-index-ref, etc.  I.e. those vectors whos
@@ -408,7 +408,7 @@
     (unless (location= result value)
       (inst fmr result value))))
 
-
+
 ;;; Complex float arrays.
 
 (define-vop (data-vector-ref/simple-array-complex-single-float)
@@ -495,7 +495,7 @@
       (unless (location= result-imag value-imag)
         (inst fmr result-imag value-imag))))))
 
-
+
 ;;; These vops are useful for accessing the bits of a vector irrespective of
 ;;; what type of vector it is.
 ;;;
@@ -517,7 +517,7 @@
   (:results (result :scs (unsigned-reg)))
   (:result-types unsigned-num)
   (:variant vector-data-offset other-pointer-lowtag))
-
+
 ;;;
 
 (define-vop (data-vector-ref/simple-array-signed-byte-8 signed-byte-index-ref)
@@ -558,7 +558,7 @@
          (value :scs (signed-reg)))
   (:results (result :scs (signed-reg)))
   (:result-types tagged-num))
-
+
 ;;;; ATOMIC-INCF for arrays
 
 (define-vop (array-atomic-incf/word)

--- a/src/compiler/ppc64/call.lisp
+++ b/src/compiler/ppc64/call.lisp
@@ -55,7 +55,7 @@
 ;;; passed when we are using non-standard conventions.
 (defun make-arg-count-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn nargs-offset))
-
+
 ;;;; Frame hackery:
 
 ;;; this is the first function in this file that differs materially from
@@ -295,7 +295,7 @@ default-value-8
         (inst compute-code-from-lra code-tn lra-tn lra-label temp)))
   (values))
 
-
+
 ;;;; Unknown values receiving:
 
 ;;;    Emit code needed at the return point for an unknown-values call for an
@@ -357,7 +357,7 @@ default-value-8
               nvals)
   (:temporary (:scs (non-descriptor-reg)) temp))
 
-
+
 ;;; This hook in the codegen pass lets us insert code before fall-thru entry
 ;;; points, local-call entry points, and tail-call entry points.  The default
 ;;; does nothing.
@@ -367,7 +367,7 @@ default-value-8
     (emit-label trampoline-label))
   (emit-label start-label))
 
-
+
 ;;;; Local call with unknown values convention return:
 
 ;;; Non-TR local call for a fixed number of values passed according to the
@@ -460,7 +460,7 @@ default-value-8
       (when cur-nfp
         (load-stack-tn cur-nfp nfp-save)))))
 
-
+
 ;;;; Local call with known values return:
 
 ;;; Non-TR local call with known return locations.  Known-value return works
@@ -529,7 +529,7 @@ default-value-8
     ;; return to the instruction immediately following the LRA header
     (inst j return-pc-temp (- n-word-bytes other-pointer-lowtag))))
 
-
+
 ;;;; Full call:
 ;;;
 ;;;    There is something of a cross-product effect with full calls.  Different
@@ -878,7 +878,7 @@ default-value-8
     (inst mtlr temp)
     (inst blr)))
 
-
+
 ;;;; Unknown values return:
 
 ;;; Return a single value using the unknown-values convention.
@@ -1005,7 +1005,7 @@ default-value-8
       (inst lr temp (make-fixup 'return-multiple :assembly-routine))
       (inst mtlr temp)
       (inst blr))))
-
+
 ;;;; XEP hackery:
 
 ;;; Get the lexical environment from its passing location.

--- a/src/compiler/ppc64/cell.lisp
+++ b/src/compiler/ppc64/cell.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Data object ref/set stuff.
 
 (define-vop (slot)
@@ -55,7 +55,7 @@
     EXIT
     (inst isync)))
 
-
+
 ;;;; Symbol hacking VOPs:
 
 (define-vop (%compare-and-swap-symbol-value)
@@ -229,7 +229,7 @@
     ;; ensure this is explained in the comment in objdef.lisp
     (loadw res symbol symbol-hash-slot other-pointer-lowtag)
     (inst clrrdi res res n-fixnum-tag-bits)))
-
+
 ;;;; Fdefinition (fdefn) objects.
 
 (define-vop (fdefn-fun cell-ref)
@@ -285,7 +285,7 @@
     (move result fdefn)))
 
 
-
+
 ;;;; Binding and Unbinding.
 
 ;;; BIND -- Establish VAL as a binding for SYMBOL.  Save the old value and
@@ -416,7 +416,7 @@
       (emit-label done))))
 
 
-
+
 ;;;; Closure indexing.
 
 (define-vop (closure-index-ref word-index-ref)
@@ -450,7 +450,7 @@
   (:info offset)
   (:generator 4
     (storew cfp-tn object (+ closure-info-offset offset) fun-pointer-lowtag)))
-
+
 ;;;; Value Cell hackery.
 
 (define-vop (value-cell-ref cell-ref)
@@ -460,7 +460,7 @@
   (:variant value-cell-value-slot other-pointer-lowtag))
 
 
-
+
 ;;;; Instance hackery:
 
 (define-vop (instance-length)
@@ -492,7 +492,7 @@
   (:variant instance-slots-offset instance-pointer-lowtag)
   (:arg-types instance tagged-num * *))
 
-
+
 ;;;; Code object frobbing.
 
 (define-vop (code-header-ref word-index-ref)
@@ -506,7 +506,7 @@
   (:variant 0 other-pointer-lowtag))
 
 
-
+
 ;;;; raw instance slot accessors
 
 (defun offset-for-raw-slot (index &optional (displacement 0))

--- a/src/compiler/ppc64/char.lisp
+++ b/src/compiler/ppc64/char.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged char to an untagged representation.
@@ -68,7 +68,7 @@
 ;;; to a descriptor passing location.
 (define-move-vop move-arg :move-arg
   (character-reg) (any-reg descriptor-reg))
-
+
 ;;;; Other operations:
 
 (define-vop (char-code)
@@ -90,7 +90,7 @@
   (:result-types character)
   (:generator 1
     (inst srwi res code n-fixnum-tag-bits)))
-
+
 ;;; Comparison of characters.
 (define-vop (character-compare)
   (:args (x :scs (character-reg))

--- a/src/compiler/ppc64/float.lisp
+++ b/src/compiler/ppc64/float.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Move functions:
 
 (define-move-fun (load-single 1) (vop x y)
@@ -35,7 +35,7 @@
     (inst stfd x nfp offset)))
 
 
-
+
 ;;;; Move VOPs:
 
 (macrolet ((frob (vop sc)
@@ -148,7 +148,7 @@
   (frob move-double-float-arg double-reg double-stack t))
 
 
-
+
 ;;;; Complex float move functions
 
 (defun complex-single-reg-real-tn (x)
@@ -378,7 +378,7 @@
   (single-reg double-reg complex-single-reg complex-double-reg)
   (descriptor-reg))
 
-
+
 ;;;; Arithmetic VOPs:
 
 (define-vop (float-op)
@@ -433,7 +433,7 @@
   (frob %negate/single-float fneg %negate single-reg single-float)
   (frob %negate/double-float fneg %negate double-reg double-float))
 
-
+
 ;;;; Comparison:
 
 (define-vop (float-compare)
@@ -472,7 +472,7 @@
   (frob > :gt :le >/single-float >/double-float)
   (frob = :eq :ne =/single-float =/double-float))
 
-
+
 ;;;; Conversion:
 
 (macrolet ((frob (name translate inst to-sc to-type)
@@ -676,7 +676,7 @@
   `(ash (double-float-bits ,x) -32))
 (define-source-transform double-float-low-bits (x)
   `(ldb (byte 32 0) (double-float-bits ,x)))
-
+
 ;;;; Float mode hackery:
 
 (sb-xc:deftype float-modes () '(unsigned-byte 32))
@@ -715,7 +715,7 @@
       ;; (inst mtfsf 255 fp-temp) ; FIXME: gets sigfpe
       (move res new))))
 
-
+
 ;;;; Complex float VOPs
 
 (define-vop (make-complex-single-float)

--- a/src/compiler/ppc64/insts.lisp
+++ b/src/compiler/ppc64/insts.lisp
@@ -21,7 +21,7 @@
             ;; TNs and offsets
             sb-vm::zero-tn sb-vm::lip-tn
             sb-vm::zero-offset sb-vm::null-offset)))
-
+
 ;;;; Constants, types, conversion functions, some disassembler stuff.
 
 (defun reg-tn-encoding (tn)
@@ -282,7 +282,7 @@
           (write addr :base 16 :radix t :stream stream))))
 
 
-
+
 ;;;; dissassem:define-instruction-formats
 
 (defmacro ppc-byte (startbit &optional (endbit startbit))
@@ -397,7 +397,7 @@
   frs ra d)
 
 
-
+
 ;;; There are around ... oh, 28 or so ... variants on the "X" format.
 ;;;  Some of them are only used by one instruction; some are used by dozens.
 ;;;  Some aren't used by instructions that we generate ...
@@ -462,7 +462,7 @@
 (def-ppc-iformat (x-27 '(:name))
   (xo xo21-30))
 
-
+
 ;;;;
 
 (def-ppc-iformat (xl '(:name :tab bt "," ba "," bb))
@@ -477,7 +477,7 @@
 (def-ppc-iformat (xl-xo '(:name))
   (xo xo21-30))
 
-
+
 ;;;;
 
 (def-ppc-iformat (xfx)
@@ -489,7 +489,7 @@
 (def-ppc-iformat (xfl '(:name :tab flm "," frb))
   flm frb (xo xo21-30) rc)
 
-
+
 ;;;
 
 (def-ppc-iformat (xo '(:name :tab rt "," ra "," rb))
@@ -501,7 +501,7 @@
 (def-ppc-iformat (xo-a '(:name :tab rt "," ra))
   rt ra oe (xo xo22-30) rc)
 
-
+
 ;;;
 
 (def-ppc-iformat (a '(:name :tab frt "," fra "," frb "," frc))
@@ -515,7 +515,7 @@
 
 (def-ppc-iformat (a-tbc '(:name :tab frt "," frb "," frc))
   frt frb frc (xo xo26-30) rc)
-
+
 
 (def-ppc-iformat (m '(:name :tab ra "," rs "," rb "," mb "," me))
   rs ra rb mb me rc)
@@ -529,7 +529,7 @@
   (data :field (byte 16 0) :reader xinstr-data))
 
 
-
+
 ;;;; Primitive emitters.
 
 
@@ -572,7 +572,7 @@
 
 (define-bitfield-emitter emit-ds-form-inst 32
   (byte 6 26) (byte 5 21) (byte 5 16) (byte 14 2) (byte 2 0))
-
+
 
 (eval-when (:compile-toplevel :execute)
 (defun classify-dependencies (deplist)
@@ -1768,7 +1768,7 @@
 
 
 
-
+
 ;;; Here in the future, macros are our friends.
 
   (define-instruction-macro subis (rt ra simm)
@@ -2006,7 +2006,7 @@
 (define-instruction-macro blrl ()
   `(inst bclrl :bo-u 0))
 
-
+
 ;;; Some more macros
 
 (defun %lr (reg value)
@@ -2053,7 +2053,7 @@
   `(%lr ,reg ,value))
 
 
-
+
 ;;;; Instructions for dumping data and header objects.
 
 (define-instruction dword (segment dword)
@@ -2096,7 +2096,7 @@
   (:emitter
    (emit-header-data segment return-pc-widetag)))
 
-
+
 ;;;; Instructions for converting between code objects, functions, and lras.
 (defun emit-compute-inst (segment vop dst src label temp calc)
   (emit-chooser

--- a/src/compiler/ppc64/macros.lisp
+++ b/src/compiler/ppc64/macros.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Instruction-like macros.
 
 (defmacro move (dst src)
@@ -137,7 +137,7 @@
      (inst lra-header-word)))
 
 
-
+
 ;;;; Stack TN's
 
 ;;; Move a stack TN to a register and vice-versa.
@@ -168,7 +168,7 @@
           ((control-stack)
            (loadw ,n-reg cfp-tn (tn-offset ,n-stack))))))))
 
-
+
 ;;;; Storage allocation:
 
 ;;; This is the main mechanism for allocating memory in the lisp heap.
@@ -316,7 +316,7 @@
     (storew zero-tn csp-tn -1)
     (emit-label aligned)))
 
-
+
 ;;;; Error Code
 (defun emit-error-break (vop kind code values)
   (assemble ()
@@ -335,7 +335,7 @@
       (emit-label start-lab)
       (emit-error-break vop error-trap (error-number-or-lose error-code) values)
       start-lab)))
-
+
 ;;;; PSEUDO-ATOMIC
 
 ;;; handy macro for making sequences look atomic

--- a/src/compiler/ppc64/memory.lisp
+++ b/src/compiler/ppc64/memory.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Cell-Ref and Cell-Set are used to define VOPs like CAR, where the offset to
 ;;; be read or written is a property of the VOP used.
 ;;;
@@ -30,7 +30,7 @@
   (:policy :fast-safe)
   (:generator 4
     (storew value object offset lowtag)))
-
+
 ;;;; Indexed references:
 
 ;;; Define some VOPs for indexed memory reference.

--- a/src/compiler/ppc64/move.lisp
+++ b/src/compiler/ppc64/move.lisp
@@ -67,7 +67,7 @@
   (let ((nfp (current-nfp-tn vop)))
     (storew x nfp (tn-offset y))))
 
-
+
 ;;;; The Move VOP:
 (define-vop (move)
   (:args (x :target y
@@ -104,7 +104,7 @@
 (define-move-vop move-arg :move-arg
   (any-reg descriptor-reg)
   (any-reg descriptor-reg))
-
+
 ;;;; Moves and coercions:
 
 ;;; These MOVE-TO-WORD VOPs move a tagged integer to a raw full-word

--- a/src/compiler/ppc64/nlx.lisp
+++ b/src/compiler/ppc64/nlx.lisp
@@ -17,7 +17,7 @@
 (defun make-nlx-entry-arg-start-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn ocfp-offset))
 
-
+
 ;;; These VOPs are used in the reentered function to restore the
 ;;; appropriate dynamic environment. Currently we only save the
 ;;; CURRENT-CATCH and binding stack pointer. We don't need to
@@ -71,7 +71,7 @@
   (:generator 1
     (move nsp-tn nsp)))
 
-
+
 ;;;; Unwind block hackery:
 
 ;;; Compute the address of the catch block from its TN, then store into the
@@ -151,7 +151,7 @@
     (loadw block block unwind-block-uwp-slot)
     (store-tl-symbol-value block *current-unwind-protect-block* temp)))
 
-
+
 ;;;; NLX entry VOPs:
 
 

--- a/src/compiler/ppc64/parms.lisp
+++ b/src/compiler/ppc64/parms.lisp
@@ -104,7 +104,7 @@
 
 (defconstant float-fast-bit 2)         ; Non-IEEE mode
 
-
+
 ;;;; Where to put the different spaces.
 
 ;;; On non-gencgc we need large dynamic and static spaces for PURIFY
@@ -157,7 +157,7 @@
   (progn
     (defparameter dynamic-0-space-start #x10000000)
     (defparameter dynamic-0-space-end   #x3ffff000)))
-
+
 (defenum (:start 8)
   halt-trap
   pending-interrupt-trap
@@ -168,7 +168,7 @@
   single-step-around-trap
   single-step-before-trap
   error-trap)
-
+
 ;;;; Static symbols.
 
 

--- a/src/compiler/ppc64/pred.lisp
+++ b/src/compiler/ppc64/pred.lisp
@@ -4,7 +4,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; The Branch VOP.
 
 ;;; The unconditional branch, emitted when we can't drop through to the desired
@@ -15,7 +15,7 @@
   (:generator 5
     (inst b dest)))
 
-
+
 ;;;; Generic conditional VOPs
 
 ;;; The generic conditional branch, emitted immediately after test
@@ -31,7 +31,7 @@
   (declare (ignore node dst-tn x-tn y-tn))
   nil)
 
-
+
 ;;;; Conditional VOPs:
 
 (define-vop (if-eq)

--- a/src/compiler/ppc64/sap.lisp
+++ b/src/compiler/ppc64/sap.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged SAP to an untagged representation.
@@ -77,7 +77,7 @@
 ;;; descriptor passing location.
 (define-move-vop move-arg :move-arg
   (sap-reg) (descriptor-reg))
-
+
 ;;;; SAP-INT and INT-SAP
 (define-vop (sap-int)
   (:args (sap :scs (sap-reg) :target int))
@@ -98,7 +98,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move sap int)))
-
+
 ;;;; POINTER+ and POINTER-
 (define-vop (pointer+)
   (:translate sap+)
@@ -132,7 +132,7 @@
   (:result-types signed-num)
   (:generator 1
     (inst sub res ptr1 ptr2)))
-
+
 ;;;; mumble-SYSTEM-REF and mumble-SYSTEM-SET
 (macrolet ((def-system-ref-and-set
                (ref-name set-name sc type size &optional signed)
@@ -253,7 +253,7 @@
     single-reg single-float :single)
   (def-system-ref-and-set sap-ref-double %set-sap-ref-double
     double-reg double-float :double))
-
+
 ;;; Noise to convert normal lisp data objects into SAPs.
 (define-vop (vector-sap)
   (:translate vector-sap)

--- a/src/compiler/ppc64/subprim.lisp
+++ b/src/compiler/ppc64/subprim.lisp
@@ -4,7 +4,7 @@
 (in-package "SB-VM")
 
 
-
+
 ;;;; Length
 
 (define-vop (length/list)

--- a/src/compiler/ppc64/system.lisp
+++ b/src/compiler/ppc64/system.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Type frobbing VOPs
 
 (define-vop (widetag-of)
@@ -123,7 +123,7 @@
     (inst andi. res ptr lowtag-mask)
     (inst sldi res res 1)))
 
-
+
 ;;;; Allocation
 
 (define-vop (dynamic-space-free-pointer)
@@ -150,7 +150,7 @@
   (:generator 1
     (move int csp-tn)))
 
-
+
 ;;;; Code object frobbing.
 
 (define-vop (code-instructions)
@@ -182,7 +182,7 @@
     (inst add func code ndescr)))
 
 
-
+
 ;;;; Other random VOPs.
 
 
@@ -208,7 +208,7 @@
 (define-vop (halt)
   (:generator 1
     (inst unimp halt-trap)))
-
+
 ;;;; Dynamic vop count collection support
 
 (define-vop (count-me)
@@ -222,7 +222,7 @@
       (inst lwz count count-vector offset)
       (inst addi count count 1)
       (inst stw count count-vector offset))))
-
+
 ;;;; Memory barrier support
 
 (define-vop (%compiler-barrier)

--- a/src/compiler/ppc64/type-vops.lisp
+++ b/src/compiler/ppc64/type-vops.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (defun %test-fixnum (value temp target not-p)
   (assemble ()
     (inst andi. temp value fixnum-tag-mask)
@@ -118,7 +118,7 @@
                           (inst b? (if not-p :gt :le) target)
                           (inst ble when-true))))))))))
         (emit-label drop-through)))))
-
+
 ;;;; Other integer ranges.
 
 ;;; A (SIGNED-BYTE 64) can be represented with either fixnum or a bignum with
@@ -185,7 +185,7 @@
         (inst b? :cr1 (if not-p :lt :ge) target)
 
         (emit-label not-target)))))
-
+
 ;;;; List/symbol types:
 ;;;
 ;;; symbolp (or symbol (eq nil))

--- a/src/compiler/ppc64/vm.lisp
+++ b/src/compiler/ppc64/vm.lisp
@@ -21,7 +21,7 @@
   (* #-darwin 2
      #+darwin 8
      n-word-bytes))
-
+
 ;;;; Define the registers
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -89,7 +89,7 @@
  (defparameter register-arg-names '(a0 a1 a2 a3)))
 
 
-
+
 ;;;; SB and SC definition:
 
 (!define-storage-bases
@@ -221,7 +221,7 @@
 
   (catch-block control-stack :element-size catch-block-size)
   (unwind-block control-stack :element-size unwind-block-size))
-
+
 ;;;; Make some random tns for important registers.
 
 (macrolet ((defregtn (name sc)
@@ -246,7 +246,7 @@
   (defregtn cfp any-reg)
   (defregtn ocfp any-reg)
   (defregtn nsp any-reg))
-
+
 ;;; If VALUE can be represented as an immediate constant, then return the
 ;;; appropriate SC number, otherwise return NIL.
 (defun immediate-constant-sc (value)
@@ -267,7 +267,7 @@
   (or (eql sc zero-sc-number)
       (eql sc null-sc-number)
       (eql sc immediate-sc-number)))
-
+
 ;;;; function call parameters
 
 ;;; the SC numbers for register and stack arguments/return values
@@ -307,7 +307,7 @@
 
 ;;; This is used by the debugger.
 (defconstant single-value-return-byte-offset 8)
-
+
 ;;; This function is called by debug output routines that want a pretty name
 ;;; for a TN's location.  It returns a thing that can be printed with PRINC.
 (defun location-print-name (tn)

--- a/src/compiler/represent.lisp
+++ b/src/compiler/represent.lisp
@@ -14,7 +14,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; error routines
 ;;;;
 ;;;; Problems in the VM definition often show up here, so we try to be
@@ -179,7 +179,7 @@
           ~S (SC ~S)"
          val (sc-name (tn-sc val))
          pass (sc-name (tn-sc pass))))
-
+
 ;;;; VM consistency checking
 ;;;;
 ;;;; We do some checking of the consistency of the VM definition at
@@ -206,7 +206,7 @@
               (warn "no move function defined to save SC ~S to alternate ~
                      SC ~S"
                     (sc-name sc) (sc-name alt)))))))))
-
+
 ;;;; representation selection
 
 ;;; VOPs that we ignore in initial cost computation. We ignore SET in

--- a/src/compiler/riscv/alloc.lisp
+++ b/src/compiler/riscv/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 
 (define-vop (list-or-list*)
   (:args (things :more t))
@@ -64,7 +64,7 @@
 (define-vop (list* list-or-list*)
   (:variant t))
 
-
+
 ;;;; Special purpose inline allocators.
 
 (define-vop (make-fdefn)
@@ -171,7 +171,7 @@
     (with-fixed-allocation (result pa-flag value-cell-widetag value-cell-size
                             :stack-allocate-p stack-allocate-p)
       (storew value result value-cell-value-slot other-pointer-lowtag))))
-
+
 ;;;; Automatic allocators for primitive objects.
 
 (define-vop (make-unbound-marker)

--- a/src/compiler/riscv/arith.lisp
+++ b/src/compiler/riscv/arith.lisp
@@ -454,7 +454,7 @@
     (let ((zero (generate-error-code vop 'division-by-zero-error x y)))
       (inst beq y zero-tn zero))))
 
-
+
 ;;;; Binary conditional VOPs.
 
 ;;; Unlike other backends, it is not worth defining vops which
@@ -532,7 +532,7 @@
   (:arg-types * tagged-num)
   (:variant-cost 7))
 
-
+
 ;;;; Logical operations
 
 (define-vop (shift-towards-someplace)
@@ -555,7 +555,7 @@
   (:generator 1
     (inst sll r num amount)))
 
-
+
 ;;;; Modular arithmetic
 (defmacro define-mod-binop ((name prototype) function)
   `(define-vop (,name ,prototype)

--- a/src/compiler/riscv/array.lisp
+++ b/src/compiler/riscv/array.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Allocator for the array header.
 (define-vop (make-array-header)
   (:policy :fast-safe)
@@ -63,7 +63,7 @@
         (storew pa-flag header 0 other-pointer-lowtag)))
     (move result header)))
 
-
+
 ;;;; Additional accessors and setters for the array header.
 (define-full-reffer %array-dimension *
   array-dimensions-offset other-pointer-lowtag
@@ -357,7 +357,7 @@
   (def-small-data-vector-frobs simple-array-unsigned-byte-2 2)
   (def-small-data-vector-frobs simple-array-unsigned-byte-4 4))
 
-
+
 ;;; These vops are useful for accessing the bits of a vector irrespective of
 ;;; what type of vector it is.
 (define-full-reffer vector-raw-bits * vector-data-offset other-pointer-lowtag

--- a/src/compiler/riscv/c-call.lisp
+++ b/src/compiler/riscv/c-call.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 
 (defconstant-eqx c-saved-registers
     (list* lr-offset
@@ -212,7 +212,7 @@
       (let ((delta (logandc2 (+ amount +number-stack-alignment-mask+)
                              +number-stack-alignment-mask+)))
         (inst addi nsp-tn nsp-tn delta)))))
-
+
 ;;; Callback
 #-sb-xc-host
 (defun alien-callback-accessor-form (type sap offset)

--- a/src/compiler/riscv/call.lisp
+++ b/src/compiler/riscv/call.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 
 (defconstant arg-count-sc (make-sc+offset immediate-arg-scn nargs-offset))
 (defconstant closure-sc (make-sc+offset descriptor-reg-sc-number lexenv-offset))
@@ -51,7 +51,7 @@
 ;;; passed when we are using non-standard conventions.
 (defun make-arg-count-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn nargs-offset))
-
+
 
 ;;;; Frame hackery:
 
@@ -248,7 +248,7 @@
         ;; Deallocate the callee stack frame.
         (move csp-tn ocfp-tn))))
   (values))
-
+
 ;;;; Unknown values receiving:
 
 ;;;    Emit code needed at the return point for an unknown-values call for an
@@ -298,7 +298,7 @@
   (:temporary (:sc any-reg :offset nargs-offset
                :from :eval :to (:result 1))
               nvals))
-
+
 ;;; This hook in the codegen pass lets us insert code before fall-thru
 ;;; entry points, local-call entry points, and tail-call entry points.
 ;;; The default does nothing.
@@ -307,7 +307,7 @@
   (when trampoline-label
     (emit-label trampoline-label))
   (emit-label start-label))
-
+
 ;;;; Local call with unknown values convention return:
 
 ;;; Non-TR local call for a fixed number of values passed according to the
@@ -395,7 +395,7 @@
       (when cur-nfp
         (load-stack-tn cur-nfp nfp-save)))))
 
-
+
 ;;;; Local call with known values return:
 
 ;;; Non-TR local call with known return locations.  Known-value return works
@@ -458,7 +458,7 @@
     (move cfp-tn old-fp-temp)
     (lisp-return return-pc-temp :known)))
 
-
+
 ;;;; Full call:
 ;;;
 ;;; There is something of a cross-product effect with full calls.
@@ -753,7 +753,7 @@
     ;; And jump to the assembly routine.
     (invoke-asm-routine 'tail-call-variable t)))
 
-
+
 ;;;; Unknown values return:
 
 (defun clear-number-stack (vop)
@@ -865,7 +865,7 @@
 
     (invoke-asm-routine 'return-multiple t)))
 
-
+
 ;;;; XEP hackery:
 
 ;;; Get the lexical environment from its passing location.

--- a/src/compiler/riscv/cell.lisp
+++ b/src/compiler/riscv/cell.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Data object ref/set stuff.
 
 (define-vop (slot)
@@ -281,7 +281,7 @@
 
 (define-full-setter code-header-set * 0 other-pointer-lowtag
   (descriptor-reg any-reg) * code-header-set)
-
+
 ;;;; raw instance slot accessors
 
 (macrolet ((define-raw-slot-word-vops (name value-sc value-primtype)

--- a/src/compiler/riscv/char.lisp
+++ b/src/compiler/riscv/char.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged char to an untagged representation.
@@ -72,7 +72,7 @@
 ;;; a descriptor passing location.
 (define-move-vop move-arg :move-arg
   (character-reg) (any-reg descriptor-reg))
-
+
 ;;;; Other operations:
 (define-vop (char-code)
   (:translate char-code)
@@ -93,7 +93,7 @@
   (:result-types character)
   (:generator 1
     (inst srli res code n-fixnum-tag-bits)))
-
+
 ;;; Comparison of characters.
 (define-vop (character-compare)
   (:args (x :scs (character-reg))

--- a/src/compiler/riscv/float.lisp
+++ b/src/compiler/riscv/float.lisp
@@ -11,7 +11,7 @@
 
 (in-package "SB-VM")
 
-
+
 ;;;; Move functions:
 (define-move-fun (load-single 1) (vop x y)
   ((single-stack) (single-reg))
@@ -28,7 +28,7 @@
 (define-move-fun (store-double 2) (vop x y)
   ((double-reg) (double-stack))
   (inst fstore :double x (current-nfp-tn vop) (tn-byte-offset y)))
-
+
 ;;;; Move VOPs:
 
 (macrolet ((frob (vop sc format)
@@ -131,7 +131,7 @@
                   (,sc descriptor-reg) (,sc)))))
   (frob move-single-float-arg single-reg single-stack :single)
   (frob move-double-float-arg double-reg double-stack :double))
-
+
 ;;;; Complex float move functions
 (defun format-sc (format)
   (ecase format (:single 'single-reg) (:double 'double-reg)))
@@ -168,7 +168,7 @@
   (def load-complex-single 2 complex-single-stack complex-single-reg fload y x)
   (def store-complex-single 2 complex-single-reg complex-single-stack fstore x y))
 
-
+
 ;;;
 ;;; Complex float register to register moves.
 ;;;
@@ -350,7 +350,7 @@
 
 (define-move-vop move-complex-double-float-arg :move-arg
   (complex-double-reg descriptor-reg) (complex-double-reg))
-
+
 ;;;; Unboxed-to-boxed MOVE-ARG handling:
 
 ;; This little gem here says to use the VOP MOVE-ARG to move any float
@@ -360,7 +360,7 @@
 (define-move-vop move-arg :move-arg
   (single-reg double-reg complex-single-reg complex-double-reg)
   (descriptor-reg))
-
+
 ;;;; Arithmetic VOPs:
 
 (define-vop (float-op)
@@ -430,7 +430,7 @@
   (frob %sqrt/single-float :single single-reg single-float)
   (frob %sqrt/double-float :double double-reg double-float))
 
-
+
 ;;;; Comparison:
 (define-vop (float-compare)
   (:args (x) (y))
@@ -474,7 +474,7 @@
   (frob >= flt t >=/single-float >=/double-float)
   (frob = feq nil =/single-float =/double-float))
 
-
+
 ;;;; Conversion:
 (macrolet ((frob (name translate
                        from-sc from-type from-format
@@ -663,7 +663,7 @@
              (- (* double-float-value-slot n-word-bytes)
                 other-pointer-lowtag))))))
 
-
+
 ;;;; Float mode hackery:
 (sb-xc:deftype float-modes () '(unsigned-byte 32))
 (defknown floating-point-modes () float-modes (flushable))
@@ -688,7 +688,7 @@
   (:generator 3
     (inst csrw :fcsr new)
     (move res new)))
-
+
 ;;;; Complex float VOPs
 
 (define-vop (make-complex-single-float)

--- a/src/compiler/riscv/insts.lisp
+++ b/src/compiler/riscv/insts.lisp
@@ -22,7 +22,7 @@
             sb-vm::short-immediate-fixnum
             sb-vm::u+i-immediate)))
 
-
+
 ;;;; disassembler field definitions
 
 (define-arg-type reg :printer #'print-reg)
@@ -38,7 +38,7 @@
 (define-arg-type store-annotation :printer #'print-store-annotation)
 (define-arg-type jalr-annotation :printer #'print-jalr-annotation)
 
-
+
 (define-instruction byte (segment byte)
   (:emitter (emit-byte segment byte)))
 

--- a/src/compiler/riscv/macros.lisp
+++ b/src/compiler/riscv/macros.lisp
@@ -76,7 +76,7 @@ byte-ordering issues."
   (emit-label label)
   (inst lra-header-word))
 
-
+
 ;;;; Three Way Comparison
 (defun three-way-comparison (x y condition flavor not-p target)
   (ecase condition
@@ -94,7 +94,7 @@ byte-ordering issues."
                     (inst bge x y target)
                     (inst blt x y target)))))))
 
-
+
 (defun emit-error-break (vop kind code values)
   (assemble ()
     (when vop (note-this-location vop :internal-error))
@@ -116,7 +116,7 @@ byte-ordering issues."
                             error-trap)
                         (error-number-or-lose error-code) values)
       start-lab)))
-
+
 ;;;; PSEUDO-ATOMIC
 
 ;;; handy macro for making sequences look atomic
@@ -458,7 +458,7 @@ and
                   (inst fstore ,format imag-tn lip (- (+ (* ,offset n-word-bytes) ,size) ,lowtag))))))
          (move-complex ,format result value)))))
 
-
+
 ;;;; Stack TN's
 
 ;;; Move a stack TN to a register and vice-versa.
@@ -498,7 +498,7 @@ and
     (storew zero-tn csp-tn -1)
     (emit-label aligned)))
 
-
+
 ;;;; Storage allocation:
 
 ;;; This is the main mechanism for allocating memory in the lisp heap.

--- a/src/compiler/riscv/memory.lisp
+++ b/src/compiler/riscv/memory.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Cell-Ref and Cell-Set are used to define VOPs like CAR, where the offset to
 ;;; be read or written is a property of the VOP used.
 

--- a/src/compiler/riscv/move.lisp
+++ b/src/compiler/riscv/move.lisp
@@ -74,7 +74,7 @@
    (signed-reg) (signed-stack)
    (unsigned-reg) (unsigned-stack))
   (storew x (current-nfp-tn vop) (tn-offset y)))
-
+
 
 ;;;; The Move VOP:
 ;;;
@@ -101,7 +101,7 @@
   (any-reg descriptor-reg)
   (any-reg descriptor-reg))
 
-
+
 ;;;    The Move-Argument VOP is used for moving descriptor values into another
 ;;; frame for argument or known value passing.
 ;;;
@@ -121,7 +121,7 @@
 (define-move-vop move-arg :move-arg
   (any-reg descriptor-reg)
   (any-reg descriptor-reg))
-
+
 ;;;; Moves and coercions:
 
 ;;; These MOVE-TO-WORD VOPs move a tagged integer to a raw full-word
@@ -191,7 +191,7 @@
 
 (define-move-vop move-from-word/fixnum :move
   (signed-reg unsigned-reg) (any-reg descriptor-reg))
-
+
 ;;; RESULT may be a bignum, so we have to check.  Use a worst-case
 ;;; cost to make sure people know they may be number consing.
 (define-vop (move-from-signed)

--- a/src/compiler/riscv/nlx.lisp
+++ b/src/compiler/riscv/nlx.lisp
@@ -15,7 +15,7 @@
 ;;; non-local entry.
 (defun make-nlx-entry-arg-start-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn ocfp-offset))
-
+
 ;;; Save and restore dynamic environment.
 ;;;
 ;;; These VOPs are used in the reentered function to restore the appropriate
@@ -68,7 +68,7 @@
   (:args (nsp :scs (any-reg descriptor-reg)))
   (:generator 1
     (move nsp-tn nsp)))
-
+
 ;;;; Unwind block hackery:
 
 ;;; Compute the address of the catch block from its TN, then store into the
@@ -139,7 +139,7 @@
     (load-symbol-value block *current-unwind-protect-block*)
     (loadw block block unwind-block-uwp-slot)
     (store-symbol-value block *current-unwind-protect-block*)))
-
+
 ;;;; NLX entry VOPs:
 
 (define-vop (nlx-entry)
@@ -226,7 +226,7 @@
       (inst bne dst csp-tn loop)
 
       (emit-label done))))
-
+
 ;;; This VOP is just to force the TNs used in the cleanup onto the stack.
 ;;;
 (define-vop (uwp-entry)

--- a/src/compiler/riscv/parms.lisp
+++ b/src/compiler/riscv/parms.lisp
@@ -86,7 +86,7 @@
 (defconstant-eqx float-exceptions-byte (byte 5 0) #'equalp)
 (defconstant float-fast-bit (ash 1 24)) ;; Flush-to-zero mode
 
-
+
 ;;;; Where to put the different spaces.
 
 ;;; On non-gencgc we need large dynamic and static spaces for PURIFY
@@ -114,7 +114,7 @@
   (progn
     (defparameter dynamic-0-space-start #x4f000000)
     (defparameter dynamic-0-space-end   #x66fff000)))
-
+
 ;;;; other miscellaneous constants
 
 (defenum (:start 8)
@@ -127,7 +127,7 @@
   single-step-before-trap
   invalid-arg-count-trap
   error-trap)
-
+
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defparameter *runtime-asm-routines* '(call-into-lisp do-pending-interrupt)))
@@ -172,7 +172,7 @@
     two-arg-eqv)
   #'equalp)
 
-
+
 ;;;; Assembler parameters:
 
 ;;; The number of bits per element in the assemblers code vector.

--- a/src/compiler/riscv/pred.lisp
+++ b/src/compiler/riscv/pred.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; The Branch VOP.
 
 ;;; The unconditional branch, emitted when we can't drop through to the desired
@@ -20,7 +20,7 @@
   (:generator 3
     (inst j dest)))
 
-
+
 ;;;; Generic conditional VOPs
 
 ;;; The generic conditional branch, emitted immediately after test
@@ -35,7 +35,7 @@
   (declare (ignore node dst-tn x-tn y-tn))
   nil)
 
-
+
 ;;;; Conditional VOPs:
 
 (define-vop (if-eq)

--- a/src/compiler/riscv/sap.lisp
+++ b/src/compiler/riscv/sap.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Moves and coercions:
 
 ;;; Move a tagged SAP to an untagged representation.
@@ -73,7 +73,7 @@
 ;;; descriptor passing location.
 (define-move-vop move-arg :move-arg
   (sap-reg) (descriptor-reg))
-
+
 ;;;; SAP-INT and INT-SAP
 
 ;;; The function SAP-INT is used to generate an integer corresponding
@@ -101,7 +101,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move sap int)))
-
+
 ;;;; POINTER+ and POINTER-
 (define-vop (pointer+)
   (:translate sap+)
@@ -135,7 +135,7 @@
   (:result-types signed-num)
   (:generator 1
     (inst sub res ptr1 ptr2)))
-
+
 ;;;; mumble-SYSTEM-REF and mumble-SYSTEM-SET
 (defun sap-ref (result sap offset signed size)
   (ecase size
@@ -262,7 +262,7 @@
     single-reg single-float :single)
   (def-system-ref-and-set sap-ref-double %set-sap-ref-double
     double-reg double-float :double))
-
+
 ;;; Noise to convert normal lisp data objects into SAPs.
 (define-vop (vector-sap)
   (:translate vector-sap)

--- a/src/compiler/riscv/subprim.lisp
+++ b/src/compiler/riscv/subprim.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Length
 
 (define-vop (length/list)

--- a/src/compiler/riscv/system.lisp
+++ b/src/compiler/riscv/system.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; Type frobbing VOPs
 
 (define-vop (widetag-of)
@@ -139,7 +139,7 @@
     (inst andi res ptr (lognot lowtag-mask))
     (inst srli res res (- n-lowtag-bits n-fixnum-tag-bits))))
 
-
+
 ;;;; Allocation
 
 (define-vop (dynamic-space-free-pointer)
@@ -166,7 +166,7 @@
   (:generator 1
     (move int csp-tn)))
 
-
+
 ;;;; Code object frobbing.
 
 (define-vop (code-instructions)
@@ -257,7 +257,7 @@
     (move res null-tn)
     NOT-EQUAL))
 
-
+
 ;;;; Other random VOPs.
 
 (defknown sb-unix::receive-pending-interrupt () (values))

--- a/src/compiler/riscv/type-vops.lisp
+++ b/src/compiler/riscv/type-vops.lisp
@@ -111,7 +111,7 @@
                  :drop-through drop-through
                  :value-tn-ref value-tn-ref))
 
-
+
 ;;;; Other integer ranges.
 
 ;;; A (SIGNED-BYTE N-WORD-BITS) can be represented with either fixnum or a

--- a/src/compiler/riscv/vm.lisp
+++ b/src/compiler/riscv/vm.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defvar *register-names* (make-array 32 :initial-element nil)))
 
@@ -68,7 +68,7 @@
   (defregset boxed-regs a0 a1 a2 a3 l0 l1 l2 l3 ocfp lra lexenv code)
 
   (define-argument-register-set a0 a1 a2 a3))
-
+
 (!define-storage-bases
  (define-storage-base registers :finite :size 32)
  (define-storage-base control-stack :unbounded :size 8)

--- a/src/compiler/saptran.lisp
+++ b/src/compiler/saptran.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; DEFKNOWNs
 
 #+linkage-table
@@ -94,7 +94,7 @@
   (defsapref sap-ref-long long-float)
 ) ; MACROLET
 
-
+
 ;;;; transforms for converting sap relation operators
 
 (macrolet ((def (sap-fun int-fun)
@@ -105,7 +105,7 @@
   (def sap= =)
   (def sap>= >=)
   (def sap> >))
-
+
 ;;;; transforms for optimizing SAP+
 
 (deftransform sap+ ((sap offset))
@@ -187,7 +187,7 @@
     %set-sap-ref-32 %set-sap-ref-64)
   (def %set-signed-sap-ref-word (sap offset value)
     %set-signed-sap-ref-32 %set-signed-sap-ref-64))
-
+
 ;;; Transforms for 64-bit SAP accessors on 32-bit platforms.
 
 #-64-bit-registers

--- a/src/compiler/seqtran.lisp
+++ b/src/compiler/seqtran.lisp
@@ -31,7 +31,7 @@
 ;;; Moreover, it would be nice if some of the declarations were commented
 ;;; with their reason for existence.
 
-
+
 ;;;; mapping onto lists: the MAPFOO functions
 
 ;; This expander allows a compiler-macro for FN to take effect by eliding
@@ -127,7 +127,7 @@
 
 (define-source-transform mapcon (function list &rest more-lists)
   (mapfoo-transform function (cons list more-lists) :nconc nil))
-
+
 ;;;; mapping onto sequences: the MAP function
 
 ;;; MAP is %MAP plus a check to make sure that any length specified in
@@ -377,7 +377,7 @@
             (t
              (%give-up))))))
 
-
+
 ;;; FIXME: once the confusion over doing transforms with known-complex
 ;;; arrays is over, we should also transform the calls to (AND (ARRAY
 ;;; * (*)) (NOT (SIMPLE-ARRAY * (*)))) objects.
@@ -782,7 +782,7 @@
   `(sb-sequence:fill seq item
                      :start start
                      :end (%check-generic-sequence-bounds seq start end)))
-
+
 ;;;; hairy sequence transforms
 
 ;;; FIXME: no hairy sequence transforms in SBCL?
@@ -793,7 +793,7 @@
 ;;; transforms might want to look at it for inspiration, even though
 ;;; the actual code is ancient CMUCL -- and hence bitrotted. The code
 ;;; was deleted in 1.0.7.23.
-
+
 ;;;; string operations
 
 ;;; We transform the case-sensitive string predicates into a non-keyword
@@ -896,7 +896,7 @@
 
 (deftransform string ((x) (symbol)) '(symbol-name x))
 (deftransform string ((x) (string)) '(progn x))
-
+
 ;;;; transforms for sequence functions
 
 ;;; FIXME: In the copy loops below, we code the loops in a strange
@@ -1267,7 +1267,7 @@
 
 (deftransform copy-seq ((seq) ((and sequence (not vector) (not list))))
   '(sb-sequence:copy-seq seq))
-
+
 (deftransform search ((pattern text &key start1 start2 end1 end2 test test-not
                                key from-end)
                       ((constant-arg sequence) * &rest *))
@@ -1769,7 +1769,7 @@
                          ,@(coerce-constants vars 'vector))
                        `(%concatenate-to-vector
                          ,vector-widetag ,@(coerce-constants vars 'list))))))))))
-
+
 ;;;; CONS accessor DERIVE-TYPE optimizers
 
 (defoptimizer (car derive-type) ((cons))
@@ -1789,7 +1789,7 @@
            null-type)
           ((cons-type-p type)
            (cons-type-cdr-type type)))))
-
+
 ;;;; FIND, POSITION, and their -IF and -IF-NOT variants
 
 (defoptimizer (find derive-type) ((item sequence &key key test
@@ -2277,7 +2277,7 @@
   (define-trimmer-transform string-right-trim nil t)
   (define-trimmer-transform string-trim t t))
 
-
+
 ;;; (partially) constant-fold backq-* functions, or convert to their
 ;;; plain CL equivalent (now that they're not needed for pprinting).
 
@@ -2339,7 +2339,7 @@
       `(lambda ,gensyms
          (declare (ignore ,@ignored))
          (append ,@arguments)))))
-
+
 (deftransform reverse ((sequence) (vector) * :important nil)
   `(sb-impl::vector-reverse sequence))
 
@@ -2351,7 +2351,7 @@
 
 (deftransform nreverse ((sequence) (list) * :important nil)
   `(sb-impl::list-nreverse sequence))
-
+
 (deftransforms (intersection nintersection)
     ((list1 list2 &key key test test-not))
   (let ((null-type (specifier-type 'null)))
@@ -2441,7 +2441,7 @@
            'list1)
           (t
            (give-up-ir1-transform)))))
-
+
 (deftransform tree-equal ((list1 list2 &key test test-not))
   (cond ((and (same-leaf-ref-p list1 list2)
               (not test-not)

--- a/src/compiler/sparc/alloc.lisp
+++ b/src/compiler/sparc/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; LIST and LIST*
 (define-vop (list-or-list*)
   (:args (things :more t))
@@ -69,7 +69,7 @@
 (define-vop (list* list-or-list*)
   (:variant t))
 
-
+
 ;;;; Special purpose inline allocators.
 
 (define-vop (make-fdefn)
@@ -114,7 +114,7 @@
     (with-fixed-allocation
         (result temp value-cell-widetag value-cell-size)
       (storew value result value-cell-value-slot other-pointer-lowtag))))
-
+
 ;;;; Automatic allocators for primitive objects.
 
 (define-vop (make-unbound-marker)

--- a/src/compiler/sparc/arith.lisp
+++ b/src/compiler/sparc/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; unary operations.
 
 (define-vop (fast-safe-arith-op)
@@ -49,7 +49,7 @@
   (:translate lognot)
   (:generator 2
     (inst not res x)))
-
+
 ;;;; Binary fixnum operations.
 
 ;;; Assume that any constant operand is the second arg...
@@ -464,7 +464,7 @@
   (def fast-ash-left/fixnum=>fixnum any-reg tagged-num any-reg 2)
   (def fast-ash-left/unsigned=>unsigned unsigned-reg unsigned-num unsigned-reg 3))
 
-
+
 (define-vop (signed-byte-32-len)
   (:translate integer-length)
   (:note "inline (signed-byte 32) integer-length")
@@ -602,7 +602,7 @@
   (:generator 3
     (inst mulx r x y)))
 
-
+
 ;;;; Modular functions:
 (define-modular-fun lognot-mod32 (x) lognot :untagged nil 32)
 (define-vop (lognot-mod32/unsigned=>unsigned)
@@ -653,7 +653,7 @@
   (when (sb-c::constant-lvar-p count)
     (sb-c::give-up-ir1-transform))
   '(%primitive fast-ash-left-mod32/unsigned=>unsigned integer count))
-
+
 ;;;; Binary conditional VOPs:
 
 (define-vop (fast-conditional)
@@ -766,7 +766,7 @@
   (:arg-types * (:constant (signed-byte 11)))
   (:variant-cost 6))
 
-
+
 ;;;; 32-bit logical operations
 
 (define-vop (shift-towards-someplace)
@@ -788,7 +788,7 @@
   (:note "shift-towards-end")
   (:generator 1
     (inst srl r num amount)))
-
+
 ;;;; Bignum stuff.
 (define-vop (bignum-length get-header-data)
   (:translate sb-bignum:%bignum-length)
@@ -1106,7 +1106,7 @@
   (:translate sb-bignum:%ashl)
   (:generator 1
     (inst sll result digit count)))
-
+
 (in-package "SB-C")
 
 (deftransform * ((x y)

--- a/src/compiler/sparc/array.lisp
+++ b/src/compiler/sparc/array.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; allocator for the array header.
 (define-vop (make-array-header)
   (:translate make-array-header)
@@ -36,7 +36,7 @@
       (inst srl ndescr ndescr n-fixnum-tag-bits)
       (storew ndescr header 0 other-pointer-lowtag))
     (move result header)))
-
+
 ;;;; Additional accessors and setters for the array header.
 (define-vop (%array-dimension word-index-ref)
   (:translate %array-dimension)
@@ -59,7 +59,7 @@
     (inst sra temp n-widetag-bits)
     (inst sub temp (1- array-dimensions-offset))
     (inst sll res temp n-fixnum-tag-bits)))
-
+
 ;;;; Bounds checking routine.
 (define-vop (check-bound)
   (:translate %check-bound)
@@ -76,7 +76,7 @@
       (inst cmp index bound)
       (inst b :geu error)
       (inst nop))))
-
+
 ;;;; Accessors/Setters
 
 ;;; Variants built on top of word-index-ref, etc.  I.e. those vectors whos
@@ -398,7 +398,7 @@
     (unless (location= result value)
       (move-long-reg result value))))
 
-
+
 ;;; XXX FIXME: Don't we have these above, in DEF-DATA-VECTOR-FROBS?
 (define-vop (data-vector-ref/simple-array-signed-byte-8 signed-byte-index-ref)
   (:note "inline array access")
@@ -440,7 +440,7 @@
   (:results (result :scs (signed-reg)))
   (:result-types tagged-num))
 
-
+
 ;;; Complex float arrays.
 
 (define-vop (data-vector-ref/simple-array-complex-single-float)
@@ -589,7 +589,7 @@
       (unless (location= result-imag value-imag)
         (move-long-reg result-imag value-imag)))))
 
-
+
 ;;; These vops are useful for accessing the bits of a vector irrespective of
 ;;; what type of vector it is.
 (define-vop (vector-raw-bits word-index-ref)

--- a/src/compiler/sparc/call.lisp
+++ b/src/compiler/sparc/call.lisp
@@ -58,7 +58,7 @@
 ;;; passed when we are using non-standard conventions.
 (defun make-arg-count-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn nargs-offset))
-
+
 ;;;; Frame hackery:
 
 ;;; Return the number of bytes needed for the current non-descriptor
@@ -159,7 +159,7 @@
 
 
 
-
+
 ;;; Emit code needed at the return-point from an unknown-values call
 ;;; for a fixed number of values.  Values is the head of the TN-REF
 ;;; list for the locations that the values are to be received into.
@@ -293,7 +293,7 @@ default-value-8
         (inst compute-code-from-lra code-tn code-tn lra-label temp)))
   (values))
 
-
+
 ;;; Emit code needed at the return point for an unknown-values call
 ;;; for an arbitrary number of values.
 ;;;
@@ -355,7 +355,7 @@ default-value-8
               nvals)
   (:temporary (:scs (non-descriptor-reg)) temp))
 
-
+
 ;;; This hook in the codegen pass lets us insert code before fall-thru entry
 ;;; points, local-call entry points, and tail-call entry points.  The default
 ;;; does nothing.
@@ -365,7 +365,7 @@ default-value-8
     (emit-label trampoline-label))
   (emit-label start-label))
 
-
+
 ;;;; Local call with unknown values convention return:
 
 ;;; Non-TR local call for a fixed number of values passed according to the
@@ -456,7 +456,7 @@ default-value-8
       (when cur-nfp
         (load-stack-tn cur-nfp nfp-save)))))
 
-
+
 ;;;; Local call with known values return:
 
 ;;; Non-TR local call with known return locations.  Known-value return works
@@ -525,7 +525,7 @@ default-value-8
     (inst j return-pc-temp (- n-word-bytes other-pointer-lowtag))
     (move cfp-tn old-fp-temp)))
 
-
+
 ;;;; Full call:
 ;;;
 ;;; There is something of a cross-product effect with full calls.
@@ -849,7 +849,7 @@ default-value-8
     (inst ji temp (make-fixup 'tail-call-variable :assembly-routine))
     (inst nop)))
 
-
+
 ;;;; Unknown values return:
 
 
@@ -979,7 +979,7 @@ default-value-8
       (inst nop))))
 
 
-
+
 ;;;; XEP hackery:
 
 ;;; Get the lexical environment from it's passing location.

--- a/src/compiler/sparc/cell.lisp
+++ b/src/compiler/sparc/cell.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; data object ref/set stuff.
 (define-vop (slot)
   (:args (object :scs (descriptor-reg)))
@@ -33,7 +33,7 @@
 (define-vop (init-slot set-slot)
   (:info name dx-p offset lowtag)
   (:ignore name dx-p))
-
+
 ;;;; Symbol hacking VOPs:
 
 ;;; The compiler likes to be able to directly SET symbols.
@@ -103,7 +103,7 @@
   (:translate sym-global-val))
 (define-vop (fast-symbol-global-value fast-symbol-value)
   (:translate sym-global-val))
-
+
 ;;;; FDEFINITION (fdefn) objects.
 (define-vop (fdefn-fun cell-ref)
   (:variant fdefn-fun-slot other-pointer-lowtag))
@@ -157,7 +157,7 @@
     (move result fdefn)))
 
 
-
+
 ;;;; Binding and Unbinding.
 
 ;;; Establish VAL as a binding for SYMBOL.  Save the old value and the
@@ -216,7 +216,7 @@
       (inst nop)
 
       (emit-label done))))
-
+
 ;;;; closure indexing.
 
 (define-vop (closure-index-ref word-index-ref)
@@ -250,7 +250,7 @@
   (:info offset)
   (:generator 4
     (storew cfp-tn object (+ closure-info-offset offset) fun-pointer-lowtag)))
-
+
 ;;;; value cell hackery.
 
 (define-vop (value-cell-ref cell-ref)
@@ -258,7 +258,7 @@
 
 (define-vop (value-cell-set cell-set)
   (:variant value-cell-value-slot other-pointer-lowtag))
-
+
 ;;;; instance hackery:
 
 (define-vop (instance-length)
@@ -283,7 +283,7 @@
   (:translate %instance-set)
   (:variant instance-slots-offset instance-pointer-lowtag)
   (:arg-types * positive-fixnum *))
-
+
 ;;;; Code object frobbing.
 
 (define-vop (code-header-ref word-index-ref)
@@ -297,7 +297,7 @@
   (:variant 0 other-pointer-lowtag))
 
 
-
+
 ;;;; raw instance slot accessors
 
 (define-vop (raw-instance-ref/word)

--- a/src/compiler/sparc/char.lisp
+++ b/src/compiler/sparc/char.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; moves and coercions:
 
 ;;; Move a tagged char to an untagged representation.
@@ -77,7 +77,7 @@
   (character-reg) (any-reg descriptor-reg))
 
 
-
+
 ;;;; Other operations:
 
 (define-vop (char-code)
@@ -100,7 +100,7 @@
   (:generator 1
     (inst srl res code n-fixnum-tag-bits)))
 
-
+
 ;;; Comparison of characters.
 (define-vop (character-compare)
   (:args (x :scs (character-reg))

--- a/src/compiler/sparc/float.lisp
+++ b/src/compiler/sparc/float.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; float move functions
 
 (define-move-fun (load-single 1) (vop x y)
@@ -94,7 +94,7 @@
         (offset (tn-byte-offset y)))
     (store-long-reg x nfp offset)))
 
-
+
 ;;;; Move VOPs:
 
 ;;; Exploit the V9 double-float move instruction. This is conditional
@@ -255,7 +255,7 @@
 (define-move-vop move-long-float-arg :move-arg
   (long-reg descriptor-reg) (long-reg))
 
-
+
 ;;;; Complex float move functions
 
 (defun complex-single-reg-real-tn (x)
@@ -598,7 +598,7 @@
    complex-single-reg complex-double-reg #+long-float complex-long-reg)
   (descriptor-reg))
 
-
+
 ;;;; Arithmetic VOPs:
 
 (define-vop (float-op)
@@ -647,7 +647,7 @@
   (frob * fmulq */long-float 6)
   (frob / fdivq //long-float 20))
 
-
+
 (macrolet ((frob (name inst translate sc type)
              `(define-vop (,name)
                 (:args (x :scs (,sc)))
@@ -783,7 +783,7 @@
                        :offset (+ i 1 (tn-offset x)))))
            (inst fmovs y-odd x-odd)))))))
 
-
+
 ;;;; Comparison:
 
 (define-vop (float-compare)
@@ -841,7 +841,7 @@
         (= (long-float-high-bits x) (long-float-high-bits y))
         (= (long-float-exp-bits x) (long-float-exp-bits y))))
 
-
+
 ;;;; Conversion:
 
 (macrolet ((frob (name translate inst to-sc to-type)
@@ -1237,7 +1237,7 @@
        (loadw lo-bits float (+ 3 long-float-value-slot)
               other-pointer-lowtag)))))
 
-
+
 ;;;; Float mode hackery:
 
 (sb-xc:deftype float-modes () '(unsigned-byte 32))
@@ -1342,7 +1342,7 @@
       (inst ldxfsr nfp offset)
       (move res new))))
 
-
+
 ;;;; Special functions.
 
 #-long-float
@@ -1378,7 +1378,7 @@
     (note-this-location vop :internal-error)
     (inst fsqrtq y x)))
 
-
+
 ;;;; Complex float VOPs
 
 (define-vop (make-complex-single-float)
@@ -1565,7 +1565,7 @@
   (:note "complex long float imagpart")
   (:variant :imag))
 
-
+
 
 ;;;; Complex float arithmetic
 

--- a/src/compiler/sparc/insts.lisp
+++ b/src/compiler/sparc/insts.lisp
@@ -23,7 +23,7 @@
             ;; TNs and offsets
             sb-vm::zero-tn
             sb-vm::zero-offset sb-vm::null-offset sb-vm::alloc-offset)))
-
+
 ;;; Constants, types, conversion functions, some disassembler stuff.
 (defun reg-tn-encoding (tn)
   (declare (type tn tn))
@@ -201,7 +201,7 @@ about function addresses and register values.")
       (error "Unknown fp-branch condition: ~S~%Must be one of: ~S"
              condition branch-fp-conditions)))
 
-
+
 ;;;; dissassem:define-instruction-formats
 
 (define-instruction-format
@@ -458,7 +458,7 @@ about function addresses and register values.")
   (x     :field (byte 1 12))
   (immed :field (byte 12 0) :sign-extend nil))
 
-
+
 ;;; Conditional moves (only available for Sparc V9 architectures)
 
 ;; The names of all of the condition registers on the V9: 4 FP
@@ -611,7 +611,7 @@ about function addresses and register values.")
   `(:name opf1 :tab rs1 ", " rs2 ", " rd)
   #'equalp)
 
-
+
 ;;;; Primitive emitters.
 
 (define-bitfield-emitter emit-word 32
@@ -679,7 +679,7 @@ about function addresses and register values.")
   (byte 2 30) (byte 5 25) (byte 6 19) (byte 5 14) (byte 1 13) (byte 2 11)
   (byte 11 0))
 
-
+
 ;;;; Most of the format-3-instructions.
 
 (defun emit-format-3-inst (segment op op3 dst src1 src2
@@ -927,7 +927,7 @@ about function addresses and register values.")
 
 ) ; MACROLET
 
-
+
 ;;;; Random instructions.
 
 ;; ldfsr is deprecated on the Sparc V9.  Use ldxfsr instead
@@ -1028,7 +1028,7 @@ about function addresses and register values.")
   (:emitter (emit-format-2-unimp segment 0 0 0 data)))
 
 
-
+
 ;;;; Branch instructions.
 
 ;; The branch instruction is deprecated on the Sparc V9.  Use the
@@ -1306,7 +1306,7 @@ about function addresses and register values.")
                            0)))))
 
 
-
+
 ;;;; Unary and binary fp insts.
 
 (macrolet ((define-unary-fp-inst (name opf &key reads extended)
@@ -1463,7 +1463,7 @@ about function addresses and register values.")
   (define-cmp-fp-inst fcmpeq #b0111 :extended t)        ; v8
 
 ) ; MACROLET
-
+
 ;;;; li, jali, ji, nop, cmp, not, neg, move, and more
 
 (defun %li (reg value)
@@ -1585,7 +1585,7 @@ about function addresses and register values.")
                                0 0 0 (reg-tn-encoding src1))))
 
 
-
+
 ;;;; Instructions for dumping data and header objects.
 
 (define-instruction word (segment word)
@@ -1628,7 +1628,7 @@ about function addresses and register values.")
   (:emitter
    (emit-header-data segment return-pc-widetag)))
 
-
+
 ;;;; Instructions for converting between code objects, functions, and lras.
 
 (defun emit-compute-inst (segment vop dst src label temp calc)
@@ -1694,7 +1694,7 @@ about function addresses and register values.")
                       (lambda (label posn delta-if-after)
                           (+ (label-position label posn delta-if-after)
                              (component-header-length))))))
-
+
 ;;; Sparc V9 additions
 
 

--- a/src/compiler/sparc/macros.lisp
+++ b/src/compiler/sparc/macros.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Instruction-like macros.
 
 (defmacro move (dst src)
@@ -96,7 +96,7 @@
      (inst lra-header-word)))
 
 
-
+
 ;;;; stack TN's
 
 ;;; Move a stack TN to a register and vice-versa.
@@ -128,8 +128,8 @@
           ((control-stack)
            (loadw ,n-reg cfp-tn (tn-offset ,n-stack))))))))
 
-
-
+
+
 ;;;; Storage allocation:
 
 ;;;; Allocation macro
@@ -280,7 +280,7 @@
     (storew zero-tn csp-tn 0) ; sneaky use of delay slot
     (inst add csp-tn csp-tn n-word-bytes)
     (emit-label aligned)))
-
+
 ;;;; Error Code
 (defun emit-error-break (vop kind code values)
   (assemble ()
@@ -299,7 +299,7 @@
       (emit-label start-lab)
       (apply #'error-call vop error-code values)
       start-lab)))
-
+
 ;;; a handy macro for making sequences look atomic
 (defmacro pseudo-atomic ((&optional) &rest forms)
   (let ()

--- a/src/compiler/sparc/memory.lisp
+++ b/src/compiler/sparc/memory.lisp
@@ -30,7 +30,7 @@
   (:generator 4
     (storew value object offset lowtag)))
 
-
+
 ;;;; Indexed references:
 
 ;;; Define some VOPs for indexed memory reference.

--- a/src/compiler/sparc/move.lisp
+++ b/src/compiler/sparc/move.lisp
@@ -91,7 +91,7 @@
   (let ((nfp (current-nfp-tn vop)))
     (storew x nfp (tn-offset y))))
 
-
+
 ;;;; The Move VOP:
 
 (define-vop (move)
@@ -129,7 +129,7 @@
 (define-move-vop move-arg :move-arg
   (any-reg descriptor-reg)
   (any-reg descriptor-reg))
-
+
 ;;;; moves and coercions:
 
 ;;; These MOVE-TO-WORD VOPs move a tagged integer to a raw full-word

--- a/src/compiler/sparc/nlx.lisp
+++ b/src/compiler/sparc/nlx.lisp
@@ -16,7 +16,7 @@
 ;;; entry.
 (defun make-nlx-entry-arg-start-location ()
   (make-wired-tn *fixnum-primitive-type* immediate-arg-scn ocfp-offset))
-
+
 ;;; save and restore dynamic environment.
 ;;;
 ;;; These VOPs are used in the reentered function to restore the
@@ -70,7 +70,7 @@
   (:args (nsp :scs (any-reg descriptor-reg)))
   (:generator 1
     (move nsp-tn nsp)))
-
+
 ;;;; unwind block hackery:
 
 ;;; Compute the address of the catch block from its TN, then store
@@ -144,7 +144,7 @@
     (loadw block block unwind-block-uwp-slot)
     (store-symbol-value block *current-unwind-protect-block*)))
 
-
+
 ;;;; NLX entry VOPs:
 
 

--- a/src/compiler/sparc/parms.lisp
+++ b/src/compiler/sparc/parms.lisp
@@ -28,7 +28,7 @@
 ;;; The minimum size at which we release address ranges to the OS.
 ;;; This must be a multiple of the OS page size.
 (defconstant gencgc-release-granularity +backend-page-bytes+)
-
+
 ;;;; Machine Architecture parameters:
 (eval-when (:compile-toplevel :load-toplevel :execute)
 
@@ -106,7 +106,7 @@
 
 ); eval-when
 
-
+
 ;;;; Description of the target address space.
 
 #+gencgc ; sensibly small read-only and static spaces
@@ -159,7 +159,7 @@
 ;; src/runtime/sparc-arch.c
 (defconstant linkage-table-entry-size 16)
 
-
+
 (defenum (:start 8)
   halt-trap
   pending-interrupt-trap
@@ -171,7 +171,7 @@
   single-step-before-trap
   #+gencgc allocation-trap
   error-trap)
-
+
 ;;;; static symbols.
 
 ;;; These symbols are loaded into static space directly after NIL so
@@ -193,7 +193,7 @@
     two-arg-and two-arg-ior two-arg-xor two-arg-eqv
     two-arg-gcd two-arg-lcm)
   #'equalp)
-
+
 ;;;; Pseudo-atomic trap number
 
 ;;; KLUDGE: Linux on the SPARC doesn't seem to conform to any kind of

--- a/src/compiler/sparc/pred.lisp
+++ b/src/compiler/sparc/pred.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; the Branch VOP.
 
 ;;; The unconditional branch, emitted when we can't drop through to
@@ -22,7 +22,7 @@
     (inst b dest)
     (inst nop)))
 
-
+
 ;;;; Generic conditional VOPs
 
 ;;; The generic conditional branch, emitted immediately after test
@@ -38,7 +38,7 @@
   (declare (ignore node dst-tn x-tn y-tn))
   nil)
 
-
+
 ;;;; conditional VOPs:
 
 (define-vop (if-eq)

--- a/src/compiler/sparc/sap.lisp
+++ b/src/compiler/sparc/sap.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; moves and coercions:
 
 ;;; Move a tagged SAP to an untagged representation.
@@ -77,7 +77,7 @@
 ;;; descriptor passing location.
 (define-move-vop move-arg :move-arg
   (sap-reg) (descriptor-reg))
-
+
 ;;;; SAP-INT and INT-SAP
 
 (define-vop (sap-int)
@@ -99,7 +99,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move sap int)))
-
+
 ;;;; POINTER+ and POINTER-
 
 (define-vop (pointer+)
@@ -134,7 +134,7 @@
   (:result-types signed-num)
   (:generator 1
     (inst sub res ptr1 ptr2)))
-
+
 ;;;; mumble-SYSTEM-REF and mumble-SYSTEM-SET
 
 (macrolet ((def-system-ref-and-set (ref-name set-name sc type size &optional signed)
@@ -260,7 +260,7 @@
   (def-system-ref-and-set sap-ref-long %set-sap-ref-long
     long-reg long-float :long-float)
 ) ; MACROLET
-
+
 ;;; noise to convert normal lisp data objects into SAPs.
 
 (define-vop (vector-sap)

--- a/src/compiler/sparc/subprim.lisp
+++ b/src/compiler/sparc/subprim.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; LENGTH
 (define-vop (length/list)
   (:translate length)

--- a/src/compiler/sparc/system.lisp
+++ b/src/compiler/sparc/system.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; type frobbing VOPs
 
 (define-vop (widetag-of)
@@ -125,7 +125,7 @@
     (inst sll res ptr 3)
     (inst srl res res 1)))
 
-
+
 ;;;; allocation
 
 (define-vop (dynamic-space-free-pointer)
@@ -152,7 +152,7 @@
   (:generator 1
     (move int csp-tn)))
 
-
+
 ;;;; code object frobbing.
 
 (define-vop (code-instructions)
@@ -180,7 +180,7 @@
     (inst add func code ndescr)))
 
 
-
+
 ;;;; other random VOPs.
 
 
@@ -199,7 +199,7 @@
     (inst unimp halt-trap)))
 
 
-
+
 ;;;; dynamic VOP count collection support
 
 (define-vop (count-me)

--- a/src/compiler/sparc/type-vops.lisp
+++ b/src/compiler/sparc/type-vops.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 
 (defun %test-fixnum (value temp target not-p)
   (declare (ignore temp))
@@ -124,7 +124,7 @@
                           (inst b :le when-true))))))))))
         (inst nop)
         (emit-label drop-through)))))
-
+
 ;;;; Other integer ranges.
 
 ;;; A (signed-byte 32) can be represented with either fixnum or a
@@ -205,7 +205,7 @@
                   (inst nop)
 
                   (emit-label not-target)))))
-
+
 ;;;; List/symbol types:
 
   ;; symbolp (or symbol (eq nil))

--- a/src/compiler/sparc/vm.lisp
+++ b/src/compiler/sparc/vm.lisp
@@ -94,7 +94,7 @@
 
   (defregset *register-arg-offsets*
       a0 a1 a2 a3 a4 a5))
-
+
 ;;;; SB and SC definition
 
 (!define-storage-bases
@@ -262,7 +262,7 @@
 
   (catch-block control-stack :element-size catch-block-size)
   (unwind-block control-stack :element-size unwind-block-size))
-
+
 ;;;; Make some miscellaneous TNs for important registers.
 (macrolet ((defregtn (name sc)
                (let ((offset-sym (symbolicate name "-OFFSET"))
@@ -283,7 +283,7 @@
   (defregtn cfp any-reg)
   (defregtn ocfp any-reg)
   (defregtn nsp any-reg))
-
+
 ;;; If VALUE can be represented as an immediate constant, then return the
 ;;; appropriate SC number, otherwise return NIL.
 (defun immediate-constant-sc (value)
@@ -304,7 +304,7 @@
   (or (eql sc zero-sc-number)
       (eql sc null-sc-number)
       (eql sc immediate-sc-number)))
-
+
 ;;;; function call parameters
 
 ;;; the SC numbers for register and stack arguments/return values.
@@ -336,7 +336,7 @@
 
 ;;; This is used by the debugger.
 (defconstant single-value-return-byte-offset 8)
-
+
 ;;; This function is called by debug output routines that want a
 ;;; pretty name for a TN's location. It returns a thing that can be
 ;;; printed with PRINC.

--- a/src/compiler/srctran.lisp
+++ b/src/compiler/srctran.lisp
@@ -63,7 +63,7 @@
      (t
       (give-up-ir1-transform
        "The function doesn't have a fixed argument count.")))))
-
+
 ;;;; list hackery
 
 ;;; Translate CxR into CAR/CDR combos.
@@ -298,7 +298,7 @@
                    'l
                    `(cdr ,(frob (1- n))))))
       `(car ,(frob n)))))
-
+
 ;;;; arithmetic and numerology
 
 (define-source-transform plusp (x) `(sb-xc:> ,x 0))
@@ -390,7 +390,7 @@
     `(if (ratiop ,n-num)
          (%denominator ,n-num)
          1)))
-
+
 ;;;; interval arithmetic for computing bounds
 ;;;;
 ;;;; This is a set of routines for operating on intervals. It
@@ -1114,7 +1114,7 @@
 (defun interval-sqr (x)
   (declare (type interval x))
   (interval-func (lambda (x) (* x x)) (interval-abs x)))
-
+
 ;;;; numeric DERIVE-TYPE methods
 
 ;;; a utility for defining derive-type methods of integer operations. If
@@ -1345,7 +1345,7 @@
                       (first results)))))))
     (derive (lvar-type arg1) (lvar-type arg2)
             (same-leaf-ref-p arg1 arg2))))
-
+
 #+sb-xc-host ; (See CROSS-FLOAT-INFINITY-KLUDGE.)
 (progn
 (defoptimizer (+ derive-type) ((x y))
@@ -2111,7 +2111,7 @@
 (floor-rem-bound (make-interval :low '(-20.3) :high 10.3))
 => #S(INTERVAL :LOW (-20.3) :HIGH (20.3))
 |#
-
+
 ;;; same functions for CEILING
 (defun ceiling-quotient-bound (quot)
   ;; Take the ceiling of the quotient and then massage it into what we
@@ -2208,7 +2208,7 @@
 (ceiling-rem-bound (make-interval :low '(-20.3) :high 10.3))
 => #S(INTERVAL :LOW (-20.3) :HIGH (20.3))
 |#
-
+
 (defun truncate-quotient-bound (quot)
   ;; For positive quotients, truncate is exactly like floor. For
   ;; negative quotients, truncate is exactly like ceiling. Otherwise,
@@ -2400,7 +2400,7 @@
 (defoptimizer (random derive-type) ((bound &optional state))
   (declare (ignore state))
   (one-arg-derive-type bound #'random-derive-type-aux nil))
-
+
 ;;;; miscellaneous derive-type methods
 
 (defoptimizer (integer-length derive-type) ((x))
@@ -2545,7 +2545,7 @@
 
 (defoptimizer (signum derive-type) ((num))
   (one-arg-derive-type num #'signum-derive-type-aux nil))
-
+
 ;;;; byte operations
 ;;;;
 ;;;; We try to turn byte operations into simple logical operations.
@@ -2713,7 +2713,7 @@
               (specifier-type `(signed-byte ,size-high))
               *universal-type*))
         *universal-type*)))
-
+
 ;;; Rightward ASH
 
 ;;; Assert correctness of build order. (Need not be exhaustive)
@@ -2833,7 +2833,7 @@
     `(ash 1 ,(if (= base 2)
                  `power
                  `(* power ,(1- (integer-length base)))))))
-
+
 ;;; Modular functions
 
 ;;; (ldb (byte s 0) (foo                 x  y ...)) =
@@ -3130,7 +3130,7 @@
                 (declare (ignore xact yact))
                 nil) ; After fixing above, replace with T
               )))))))
-
+
 ;;; Handle the case of a constant BOOLE-CODE.
 (deftransform boole ((op x y) * *)
   "convert to inline logical operations"
@@ -3157,7 +3157,7 @@
       (t
        (abort-ir1-transform "~S is an illegal control arg to BOOLE."
                             control)))))
-
+
 ;;;; converting special case multiply/divide to shifts
 
 ;;; If arg is a constant power of two, turn * into a shift.
@@ -3393,7 +3393,7 @@
             (rem (ldb (byte #.sb-vm:n-word-bits 0)
                       (- x (* quot ,y)))))
        (values quot rem))))
-
+
 ;;;; arithmetic and logical identity operation elimination
 
 ;;; Flush calls to various arith functions that convert to the
@@ -3650,7 +3650,7 @@
   (def ffloor t)
   (def fceiling t))
 
-
+
 ;;;; character operations
 
 (deftransform two-arg-char-equal ((a b) (base-char base-char) *
@@ -3703,7 +3703,7 @@
                   (< n-code 223)))
          (code-char (logxor #x20 n-code))
          x)))
-
+
 ;;;; equality predicate transforms
 
 ;;; If X and Y are the same leaf, then the result is true. Otherwise,
@@ -4078,7 +4078,7 @@
 
 (deftransform char> ((x y) (character character) *)
   (ir1-transform-char< y x x y 'char<))
-
+
 ;;;; converting N-arg comparisons
 ;;;;
 ;;;; We convert calls to N-arg comparison functions such as < into
@@ -4240,7 +4240,7 @@
 (deftransform = ((x y) (integer (constant-arg ratio)))
   "constant-fold INTEGER to RATIO comparison"
   nil)
-
+
 ;;;; converting N-arg arithmetic functions
 ;;;;
 ;;;; N-arg arithmetic and logic functions are associated into two-arg
@@ -4360,7 +4360,7 @@
   (source-transform-intransitive '- '+ args '(%negate)))
 (define-source-transform / (&rest args)
   (source-transform-intransitive '/ '* args '(/ 1)))
-
+
 ;;;; transforming APPLY
 
 ;;; We convert APPLY into MULTIPLE-VALUE-CALL so that the compiler
@@ -4538,7 +4538,7 @@
   (if (rest-var-more-context-ok list)
       `(not (eql 0 count))
       `list))
-
+
 ;;;; transforming FORMAT
 ;;;;
 ;;;; If the control string is a compile-time constant, then replace it
@@ -5025,7 +5025,7 @@
            `(sb-impl::stable-sort-vector sequence
                                          (%coerce-callable-to-fun predicate)
                                          (and key (%coerce-callable-to-fun key)))))))
-
+
 ;;;; debuggers' little helpers
 
 ;;; for debugging when transforms are behaving mysteriously,
@@ -5055,7 +5055,7 @@
     (give-up-ir1-transform "not a real transform"))
   (defun /report-lvar (x message)
     (declare (ignore x message))))
-
+
 ;;; Can fold only when time-zone is supplied.
 (defoptimizer (encode-universal-time optimizer)
     (#1=(second minute hour date month year time-zone) node)
@@ -5090,7 +5090,7 @@
   #-64-bit `(truly-the (and fixnum unsigned-byte)
              (ash (sb-vm::%symbol-tls-index ,sym) sb-vm:n-fixnum-tag-bits)))
 
-
+
 (deftransform make-string-output-stream ((&key element-type))
   (case (cond ((not element-type) #+sb-unicode 'character #-sb-unicode 'base-char)
               ((not (constant-lvar-p element-type)) nil)

--- a/src/compiler/stack.lisp
+++ b/src/compiler/stack.lisp
@@ -16,7 +16,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;; Scan through BLOCK looking for uses of :UNKNOWN lvars that have
 ;;; their DEST outside of the block. We do some checking to verify the
 ;;; invariant that all pushes come after the last pop.
@@ -44,7 +44,7 @@
 
       (setf (ir2-block-pushed 2block) (pushed))))
   (values))
-
+
 ;;;; Computation of live UVL sets
 (defun nle-block-p (block)
   (and (eq (component-head (block-component block))
@@ -272,7 +272,7 @@
              (setf (ir2-block-start-stack 2block) start)
              t)))))
 
-
+
 ;;;; Ordering of live UVL stacks
 
 (defun ordered-list-intersection (ordered-list other-list)
@@ -376,7 +376,7 @@
              ;; of STACK analysis, so abort now if we're in trouble.
              (aver (not (plusp todo))))
         while (plusp todo)))
-
+
 ;;; This is called when we discover that the stack-top unknown-values
 ;;; lvar at the end of BLOCK1 is different from that at the start of
 ;;; BLOCK2 (its successor).
@@ -460,7 +460,7 @@
             (setf (ir2-block-end-stack 2block) start-stack))))))
 
   (values))
-
+
 ;;;; stack analysis
 
 ;;; Return a list of all the blocks containing genuine uses of one of

--- a/src/compiler/target-disassem.lisp
+++ b/src/compiler/target-disassem.lisp
@@ -14,7 +14,7 @@
 ;;;; FIXME: A lot of stupid package prefixes would go away if DISASSEM
 ;;;; would use the SB-DI package. And some more would go away if it would
 ;;;; use SB-SYS (in order to get to the SAP-FOO operators).
-
+
 (defstruct (instruction (:conc-name inst-)
                         (:constructor
                          make-instruction (name format-name print-name
@@ -103,7 +103,7 @@
              (setf (inst-specializers master)
                    (order-specializers (remove master insts)))
              master)))))
-
+
 ;;;; choosing an instruction
 
 #-sb-fluid (declaim (inline inst-matches-p choose-inst-specialization))
@@ -125,7 +125,7 @@
         (when (inst-matches-p spec chunk)
           (return spec)))
       inst))
-
+
 ;;;; an instruction space holds all known machine instructions in a
 ;;;; form that can be easily searched
 
@@ -168,7 +168,7 @@
          (declare (type inst-space-choice choice))
          (when (dchunk= id (ischoice-common-id choice))
            (return (find-inst chunk (ischoice-subspace choice)))))))))
-
+
 ;;;; building the instruction space
 
 ;;; Returns an instruction-space object corresponding to the list of
@@ -215,7 +215,7 @@
                                                        submask)
                                             :common-id (car bucket)))
                                          buckets))))))))))
-
+
 ;;;; an inst-space printer for debugging purposes
 
 (defun print-masked-binary (num mask word-size &optional (show word-size))
@@ -258,9 +258,9 @@
             (print-inst-space (ischoice-subspace choice)
                               (+ 4 indent)))
           (ispace-choices inst-space)))))
-
+
 ;;;; (The actual disassembly part follows.)
-
+
 ;;; Code object layout:
 ;;;     header-word
 ;;;     code-size (starting from first inst, in bytes)
@@ -296,7 +296,7 @@
     (ash num sb-vm:word-shift))
   ) ; EVAL-WHEN
 
-
+
 (defstruct (offs-hook (:copier nil))
   (offset 0 :type offset)
   (fun (missing-arg) :type function)
@@ -310,7 +310,7 @@
               (= (seg-virtual-location seg) addr)
               (seg-virtual-location seg)
               (seg-code seg)))))
-
+
 ;;;; function ops
 
 ;;; the offset of FUNCTION from the start of its code-component's
@@ -320,7 +320,7 @@
   (- (get-lisp-obj-address simple-fun)
      sb-vm:fun-pointer-lowtag
      (sap-int (code-instructions (fun-code-header simple-fun)))))
-
+
 ;;;; operations on code-components (which hold the instructions for
 ;;;; one or more functions)
 
@@ -350,7 +350,7 @@
 (defun code-insts-offs-to-segment-offs (offset segment)
   (- offset (seg-initial-offset segment)))
 
-
+
 ;;; Is ADDRESS aligned on a SIZE byte boundary?
 (declaim (inline aligned-p))
 (defun aligned-p (address size)
@@ -406,7 +406,7 @@
             dstate)))
   (incf (dstate-next-offs dstate)
         (words-to-bytes sb-vm:simple-fun-insts-offset)))
-
+
 ;;; Return ADDRESS aligned *upward* to a SIZE byte boundary.
 ;;; KLUDGE: should be ALIGN-UP but old Slime uses it
 (declaim (inline align))
@@ -704,7 +704,7 @@
         (setf (dstate-filtered-arg-pool-in-use dstate) nil)
         (setf (dstate-inst-properties dstate) 0)))))))
 
-
+
 (defun collect-labelish-operands (args cache)
   (awhen (remove-if-not #'arg-use-label args)
     (let* ((list (mapcar (lambda (arg &aux (fun (arg-use-label arg))
@@ -799,7 +799,7 @@
             (setf (gethash (car label) label-hash)
                   (format nil "L~W" max)))))
       (setf (dstate-labels dstate) labels))))
-
+
 (defun compute-mask-id (args)
   (let ((mask dchunk-zero)
         (id dchunk-zero))
@@ -875,7 +875,7 @@
         (setf ispace (build-inst-space insts)))
       (setf *disassem-inst-space* ispace))
     ispace))
-
+
 (defun set-location-printing-range (dstate from length)
   (setf (dstate-addr-print-len dstate) ; in characters
         ;; 4 bits per hex digit
@@ -949,7 +949,7 @@
     ;; move to the instruction column
     (tab0 (+ location-column-width 1 label-column-width) stream)
     ))
-
+
 (macrolet ((with-print-restrictions (&rest body)
              `(let ((*print-pretty* t)
                     (*print-lines* 2)
@@ -1003,7 +1003,7 @@
       (unless (zerop offs)
         (write-string ", " stream))
       (format stream "#X~2,'0x" (sap-ref-8 sap (+ offs start-offs))))))
-
+
 (defvar *default-dstate-hooks*
   (list* #-(or x86 x86-64) #'lra-hook nil))
 
@@ -1056,7 +1056,7 @@
                :fun (let ((i i)) ; capture the _current_ I, not the final value
                       (lambda (stream dstate) (fun-header-hook i stream dstate))))
               (seg-hooks segment))))))
-
+
 ;;; A SAP-MAKER is a no-argument function that returns a SAP.
 
 (declaim (inline sap-maker))
@@ -1094,7 +1094,7 @@
            (type address address))
   (let ((sap (int-sap address)))
     (lambda () sap)))
-
+
 (defstruct (source-form-cache (:conc-name sfcache-)
                               (:copier nil))
   (debug-source nil :type (or null debug-source))
@@ -1177,7 +1177,7 @@
 (defun make-memory-segment (code address &rest args)
   (declare (type address address))
   (apply #'make-segment code (memory-sap-maker address) args))
-
+
 ;;; just for fun
 (defun print-fun-headers (function)
   (declare (type compiled-function function))
@@ -1195,7 +1195,7 @@
               (%simple-fun-name fun)
               (%simple-fun-arglist fun)
               (%simple-fun-type fun)))))
-
+
 ;;; getting at the source code...
 
 (defun get-different-source-form (loc context &optional cache)
@@ -1219,7 +1219,7 @@
                 (code-location-form-number loc))
           (setf (sfcache-last-location-retrieved cache) loc))
         (values form t))))
-
+
 ;;;; stuff to use debugging info to augment the disassembly
 
 (defun code-fun-map (code)
@@ -1435,7 +1435,7 @@
     (when *disassemble-annotate*
       (add-source-tracking-hooks segment debug-fun sfcache))))
 
-
+
 ;;; Return a list of the segments of memory containing machine code
 ;;; instructions for FUNCTION.
 (defun get-fun-segments (function)
@@ -1548,7 +1548,7 @@
                        last-debug-fun))
             while next))
     (nreverse segments)))
-
+
 ;;; Compute labels for all the memory segments in SEGLIST and adds
 ;;; them to DSTATE. It's important to call this function with all the
 ;;; segments you're interested in, so that it can find references from
@@ -1632,7 +1632,7 @@
               (print-segment-name seg))
             (disassemble-segment seg stream dstate)))))))
 
-
+
 ;;;; top level functions
 
 ;;; Disassemble the machine code instructions for FUNCTION.
@@ -1778,7 +1778,7 @@
           (incf (dstate-cur-offs dstate) sb-vm:n-word-bytes))
 |#
     (disassemble-segments segments stream dstate)))
-
+
 ;;;; code to disassemble assembler segments
 
 ;;; Disassemble the machine code instructions associated with
@@ -1794,7 +1794,7 @@
                   ranges)))
     (label-segments disassem-segments dstate)
     (disassemble-segments disassem-segments stream dstate)))
-
+
 ;;; routines to find things in the Lisp environment
 
 ;;; an alist of (SYMBOL-SLOT-OFFSET . ACCESS-FUN-NAME) for slots
@@ -1926,7 +1926,7 @@
                      (return-from find-assembler-routine
                       (values name 0)))))))
            (values nil nil)))))
-
+
 ;;;; some handy function for machine-dependent code to use...
 
 (defun sap-ref-int (sap offset length byte-order)
@@ -1963,7 +1963,7 @@
                    length
                    (dstate-byte-order dstate))
       (incf (dstate-next-offs dstate) length))))
-
+
 ;;;; optional routines to make notes about code
 
 ;;; Store NOTE (which can be either a string or a function with a
@@ -2137,7 +2137,7 @@
                      do (return-from found const))))
            (return-from maybe-note-static-symbol))))
     (note (lambda (s) (prin1 symbol s)) dstate)))
-
+
 (defun get-internal-error-name (errnum)
   (cadr (svref sb-c:+backend-internal-errors+ errnum)))
 

--- a/src/compiler/target-dump.lisp
+++ b/src/compiler/target-dump.lisp
@@ -32,7 +32,7 @@
           (sub-dump-object (subseq vector start end) file)))
     (dump-fop 'fop-array file rank)
     (eq-save-object array file)))
-
+
 #+(and long-float x86)
 (defun dump-long-float (float file)
   (declare (long-float float))

--- a/src/compiler/target-main.lisp
+++ b/src/compiler/target-main.lisp
@@ -12,7 +12,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; CL:COMPILE
 
 ;;; Handle the following:

--- a/src/compiler/tn.lisp
+++ b/src/compiler/tn.lisp
@@ -31,7 +31,7 @@
               (unless ,tn (go ,outer))
        ,inner (progn ,@body)
               (if (setq ,tn (tn-next ,tn)) (go ,inner) (go ,outer)))))
-
+
 (defun set-ir2-physenv-live-tns (value instance)
   (setf (ir2-physenv-live-tns instance) value))
 
@@ -103,7 +103,7 @@
       (delete-some #'ir2-component-wired-tns
                    #'set-ir2-component-wired-tns)))
   (values))
-
+
 ;;;; TN creation
 
 ;;; Create a packed TN of the specified primitive-type in the
@@ -306,7 +306,7 @@
 
     (push-in tn-next res (ir2-component-constant-tns component))
     res))
-
+
 ;;;; TN referencing
 
 ;;; Make a TN-REF that references TN and return it. WRITE-P should be
@@ -359,7 +359,7 @@
       (push-in tn-ref-next ref (tn-writes tn))
       (push-in tn-ref-next ref (tn-reads tn)))
   (values))
-
+
 ;;;; miscellaneous utilities
 
 ;;; Emit a move-like template determined at run-time, with X as the

--- a/src/compiler/typetran.lisp
+++ b/src/compiler/typetran.lisp
@@ -13,7 +13,7 @@
 ;;;; files for more information.
 
 (in-package "SB-C")
-
+
 ;;;; type predicate translation
 ;;;;
 ;;;; We maintain a bidirectional association between type predicates
@@ -48,7 +48,7 @@
                         :key #'cdr)))
     (%deftransform name '(function (t) *) #'fold-type-predicate)
     name))
-
+
 ;;;; IR1 transforms
 
 ;;; If we discover the type argument is constant during IR1
@@ -157,7 +157,7 @@
          (cell (find-classoid-cell name :create t)))
     `(or (classoid-cell-classoid ',cell)
          (error "Class not yet defined: ~S" name))))
-
+
 (defoptimizer (%typep-wrapper constraint-propagate-if)
     ((test-value variable type) node gen)
   (declare (ignore test-value gen))
@@ -187,7 +187,7 @@
               (t
                (delay-ir1-transform node :constraint)
                'test-value)))))
-
+
 ;;;; standard type predicates, i.e. those defined in package COMMON-LISP,
 ;;;; plus at least one oddball (%INSTANCEP)
 ;;;;
@@ -230,7 +230,7 @@
   (define-type-predicate symbolp symbol)
   (define-type-predicate vectorp vector))
 (!define-standard-type-predicates)
-
+
 ;;;; transforms for type predicates not implemented primitively
 ;;;;
 ;;;; See also VM dependent transforms.
@@ -248,7 +248,7 @@
 
 (deftransform symbolp ((x) ((not null)) * :important nil)
   '(non-null-symbol-p x))
-
+
 ;;;; TYPEP source transform
 
 ;;; Return a form that tests the variable N-OBJECT for being in the
@@ -1065,7 +1065,7 @@
       (with-current-source-form (spec)
         (source-transform-typep object (cadr spec)))
       (values nil t)))
-
+
 ;;;; coercion
 
 ;;; Constant-folding.

--- a/src/compiler/vmdef.lisp
+++ b/src/compiler/vmdef.lisp
@@ -33,12 +33,12 @@
 
 (defun sc-number-or-lose (x)
   (the sc-number (sc-number (sc-or-lose x))))
-
+
 ;;;; side effect classes
 
 (!def-boolean-attribute vop
   any)
-
+
 ;;;; move/coerce definition
 
 ;;; Compute at compiler load time the costs for moving between all SCs that
@@ -60,7 +60,7 @@
                  (old (svref vec scn)))
             (unless (and old (< old total))
               (setf (svref vec scn) total))))))))
-
+
 ;;;; primitive type definition
 
 ;;; Return the primitive type corresponding to the specified name, or
@@ -82,7 +82,7 @@
         (when (or (member sc (sc-alternate-scs allowed-sc))
                   (member sc (sc-constant-scs allowed-sc)))
           (return t))))))
-
+
 ;;;; generation of emit functions
 
 (eval-when (:compile-toplevel :load-toplevel :execute)
@@ -181,7 +181,7 @@
                     (aref refs (ldb (byte 8 8) target))
                     (aref refs (ldb (byte 8 0) target)))))))
     vop))
-
+
 ;;;; function translation stuff
 
 ;;; Add Template into List, removing any old template with the same name.
@@ -193,7 +193,7 @@
                       :key #'template-name))
         #'<=
         :key #'template-cost))
-
+
 ;;; Return a function type specifier describing TEMPLATE's type computed
 ;;; from the operand type restrictions.
 #-sb-fluid (declaim (inline template-conditional-p))

--- a/src/compiler/vop.lisp
+++ b/src/compiler/vop.lisp
@@ -92,7 +92,7 @@
 ;;; the different policies we can use to determine the coding strategy
 (def!type ltn-policy ()
   '(member :safe :small :small-safe :fast :fast-safe))
-
+
 ;;;; PRIMITIVE-TYPEs
 
 ;;; A PRIMITIVE-TYPE is used to represent the aspects of type
@@ -113,7 +113,7 @@
 
 (defprinter (primitive-type)
   name)
-
+
 ;;;; IR1 annotations used for IR2 conversion
 
 ;;; BLOCK-INFO
@@ -498,7 +498,7 @@
   home
   save-sp
   dynamic-state)
-
+
 ;;;; VOPs and templates
 
 ;;; A VOP is a Virtual Operation. It represents an operation and the
@@ -729,7 +729,7 @@
   write-p
   (vop :test vop :prin1 (vop-info-name (vop-info vop))))
 
-
+
 ;;;; SBs and SCs
 
 ;;; copied from docs/internals/retargeting.tex by WHN 19990707:
@@ -928,7 +928,7 @@
   (reserve-locations (missing-arg) :type sc-locations :read-only t))
 (defprinter (storage-class :conc-name "SC-")
   name)
-
+
 ;;;; TNs
 
 (def!struct (tn (:include sset-element)

--- a/src/compiler/x86-64/alloc.lisp
+++ b/src/compiler/x86-64/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; allocation helpers
 
 ;;; Most allocation is done by inline code with sometimes help
@@ -263,7 +263,7 @@
 
 (define-vop (list* list-or-list*)
   (:variant t))
-
+
 ;;;; special-purpose inline allocators
 
 ;;; Special variant of 'storew' which might have a shorter encoding
@@ -494,7 +494,7 @@
          (inst jmp :ne loop))
         (storew nil-value tail cons-cdr-slot list-pointer-lowtag))
       done)))
-
+
 #-immobile-space
 (define-vop (make-fdefn)
   (:policy :fast-safe)
@@ -544,7 +544,7 @@
   (:generator 10
     (alloc-other result value-cell-widetag value-cell-size node stack-allocate-p)
     (storew value result value-cell-value-slot other-pointer-lowtag)))
-
+
 ;;;; automatic allocators for primitive objects
 
 (define-vop (make-unbound-marker)

--- a/src/compiler/x86-64/arith.lisp
+++ b/src/compiler/x86-64/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 
 ;; If 'plausible-signed-imm32-operand-p' is true, use it; otherwise use a RIP-relative constant.
 ;; I couldn't think of a more accurate name for this other than maybe
@@ -77,7 +77,7 @@
   (:generator 2
     (move res x)
     (inst not res)))
-
+
 ;;;; binary fixnum operations
 
 ;;; Assume that any constant operand is the second arg...
@@ -372,7 +372,7 @@
                                (location= x r))))
          (y :scs (signed-reg signed-stack)))
   (:arg-types unsigned-num signed-num))
-
+
 
 (define-vop (fast-+-c/signed=>signed fast-safe-arith-op)
   (:translate +)
@@ -445,7 +445,7 @@
                   (inst inc r))
                  (t
                   (inst add r (constantize y))))))))
-
+
 ;;;; multiplication and division
 
 (define-vop (fast-*/fixnum=>fixnum fast-safe-arith-op)
@@ -714,7 +714,7 @@
     (move rem edx)))
 
 
-
+
 ;;;; Shifting
 (define-vop (fast-ash-c/fixnum=>fixnum)
   (:translate ash)
@@ -1076,7 +1076,7 @@ constant shift greater than word length")))
     (inst shl result :cl)
 
     DONE))
-
+
 (define-vop (signed-byte-64-len)
   (:translate integer-length)
   (:note "inline (signed-byte 64) integer-length")
@@ -1175,7 +1175,7 @@ constant shift greater than word length")))
     POS
     (inst or res 1)
     (inst bsr res res)))
-
+
 ;;;; binary conditional VOPs
 
 (define-vop (fast-conditional)
@@ -1497,7 +1497,7 @@ constant shift greater than word length")))
   (:args (x :scs (any-reg descriptor-reg) :load-if t))
   (:arg-types * (:constant fixnum))
   (:variant-cost 6))
-
+
 ;;;; 64-bit logical operations
 
 ;;; Only the lower 6 bits of the shift amount are significant.
@@ -1525,7 +1525,7 @@ constant shift greater than word length")))
     (move r num)
     (move ecx amount)
     (inst shl r :cl)))
-
+
 ;;;; Modular functions
 
 (defmacro define-mod-binop ((name prototype) function)
@@ -1720,7 +1720,7 @@ constant shift greater than word length")))
   `(lognot (logior ,x ,y)))
 (define-source-transform lognand (x y)
   `(lognot (logand ,x ,y)))
-
+
 ;;;; bignum stuff
 
 (define-vop (bignum-length get-header-data)
@@ -2098,7 +2098,7 @@ constant shift greater than word length")))
                     (= mask most-positive-word))
           (inst and r (or (plausible-signed-imm32-operand-p mask)
                           (constantize mask))))))))
-
+
 (in-package "SB-C")
 
 (defun *-transformer (y node fun)

--- a/src/compiler/x86-64/array.lisp
+++ b/src/compiler/x86-64/array.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 
 ;; For use in constant indexing; we can't use INDEX since the displacement
 ;; field of an EA can't contain 64 bit values.
@@ -63,7 +63,7 @@
       (storew* header result 0 0 t)
       (inst or :byte result other-pointer-lowtag)))))
 
-
+
 ;;;; additional accessors and setters for the array header
 (define-full-reffer %array-dimension *
   array-dimensions-offset other-pointer-lowtag
@@ -111,7 +111,7 @@
           (ea (1+ (- other-pointer-lowtag)) array)
           (+ rank
              (1- array-dimensions-offset)))))
-
+
 ;;;; bounds checking routine
 (define-vop (check-bound)
   (:translate %check-bound)
@@ -190,7 +190,7 @@
                 (:or unsigned-num signed-num))
   (:variant nil)
   (:variant-cost 5))
-
+
 ;;;; accessors/setters
 
 ;;; variants built on top of WORD-INDEX-REF, etc. I.e., those vectors
@@ -221,7 +221,7 @@
   vector-data-offset other-pointer-lowtag
   (descriptor-reg any-reg) *
   %compare-and-swap-svref)
-
+
 ;;;; integer vectors whose elements are smaller than a byte, i.e.,
 ;;;; bit, 2-bit, and 4-bit vectors
 
@@ -722,7 +722,7 @@
     (inst movapd (make-ea-for-float-ref object index offset 16) value)
     (move result value)))
 
-
+
 
 ;;; {un,}signed-byte-{8,16,32} and characters
 (macrolet ((define-data-vector-frobs (ptype mov-inst operand-size
@@ -822,14 +822,14 @@
   (define-data-vector-frobs simple-character-string movzx :dword
     character character-reg))
 
-
+
 ;;; These vops are useful for accessing the bits of a vector
 ;;; irrespective of what type of vector it is.
 (define-full-reffer vector-raw-bits * vector-data-offset other-pointer-lowtag
   (unsigned-reg) unsigned-num %vector-raw-bits)
 (define-full-setter set-vector-raw-bits * vector-data-offset other-pointer-lowtag
   (unsigned-reg) unsigned-num %set-vector-raw-bits)
-
+
 ;;;; ATOMIC-INCF for arrays
 
 (define-vop (array-atomic-incf/word)

--- a/src/compiler/x86-64/avx2-insts.lisp
+++ b/src/compiler/x86-64/avx2-insts.lisp
@@ -59,7 +59,7 @@
 (define-arg-type vex-b
   :prefilter  (lambda (dstate value)
                 (dstate-setprop dstate (if (plusp value) 0 +rex-b+))))
-
+
 (define-instruction-format (vex2 16)
                            (vex :field (byte 8 0) :value #xC5)
                            (r :field (byte 1 (+ 8 7)) :type 'vex-r)
@@ -162,7 +162,7 @@
                                 '(:name :tab reg ", " reg/mem))
   (reg :field (byte 3 (+ start 11))
        :type 'reg))
-
+
 (eval-when (#-sb-xc :compile-toplevel :load-toplevel :execute)
   (defun vex-encode-pp (pp)
     (ecase pp
@@ -276,7 +276,7 @@
                              (reg-encoding reg segment)))
   (emit-byte segment imm))
 
-
+
 (eval-when (#-sb-xc :compile-toplevel :load-toplevel :execute)
   (defun avx2-inst-printer-list (inst-format-stem prefix opcode
                                  &key more-fields printer
@@ -832,7 +832,7 @@
   (def vmovmskpd  #x66 #x50 :reg-only t)
   (def vmovmskps  nil  #x50 :reg-only t)
   (def vpmovmskb  #x66 #xd7 :reg-only t))
-
+
 ;;; AVX/AVX2 instructions
 
 (define-instruction vzeroupper (segment)
@@ -1009,7 +1009,7 @@
 
   (def vpsllvd #x66 #x47 0)
   (def vpsllvq #x66 #x47 1))
-
+
 (define-arg-type vmx/y
   :prefilter #'prefilter-reg/mem
   :printer #'print-vmx/y)

--- a/src/compiler/x86-64/call.lisp
+++ b/src/compiler/x86-64/call.lisp
@@ -62,7 +62,7 @@
 ;;; are using non-standard conventions.
 (defun make-arg-count-location ()
   (make-wired-tn *fixnum-primitive-type* any-reg-sc-number rcx-offset))
-
+
 ;;;; frame hackery
 
 ;;; This is used for setting up the Old-FP in local call.
@@ -239,7 +239,7 @@
             (t
              (inst lea res (ea (- fp-offset) rsp-tn))
              (inst sub rsp-tn stack-size))))))
-
+
 ;;; Emit code needed at the return-point from an unknown-values call
 ;;; for a fixed number of values. Values is the head of the TN-REF
 ;;; list for the locations that the values are to be received into.
@@ -351,7 +351,7 @@
                     (emit-label (car default))
                     (inst mov (cdr default) nil-value))
                   (inst jmp defaulting-done)))))))))))
-
+
 ;;;; unknown values receiving
 
 ;;; Emit code needed at the return point for an unknown-values call
@@ -432,7 +432,7 @@
               nvals)
   (:results (start :scs (any-reg control-stack))
             (count :scs (any-reg control-stack))))
-
+
 ;;;; local call with unknown values convention return
 
 (defun check-ocfp-and-return-pc (old-fp return-pc)
@@ -520,7 +520,7 @@
     (inst call target)
     (note-this-location vop :unknown-return)
     (receive-unknown-values values-start nvals start count node)))
-
+
 ;;;; local call with known values return
 
 ;;; Non-TR local call with known return locations. Known-value return
@@ -544,7 +544,7 @@
     (note-this-location vop :call-site)
     (inst call target)
     (note-this-location vop :known-return)))
-
+
 ;;; From Douglas Crosher
 ;;; Return from known values call. We receive the return locations as
 ;;; arguments to terminate their lifetimes in the returning function. We
@@ -563,7 +563,7 @@
     (inst mov rsp-tn rbp-tn)
     (inst pop rbp-tn)
     (inst ret)))
-
+
 ;;;; full call
 ;;;
 ;;; There is something of a cross-product effect with full calls.
@@ -924,7 +924,7 @@
                                  'tail-call-variable
                                  'tail-call-callable-variable)
                         vop)))
-
+
 ;;;; unknown values return
 
 ;;; Return a single-value using the Unknown-Values convention.
@@ -1061,7 +1061,7 @@
     (move rsi vals)
     (move rcx nvals)
     (invoke-asm-routine 'jmp 'return-multiple vop)))
-
+
 ;;;; XEP hackery
 
 ;;; Get the lexical environment from its passing location.

--- a/src/compiler/x86-64/cell.lisp
+++ b/src/compiler/x86-64/cell.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; data object ref/set stuff
 
 (define-vop (slot)
@@ -94,7 +94,7 @@
      (inst cmpxchg (ea (- (* offset n-word-bytes) lowtag) object)
            new :lock)
      (move result rax)))
-
+
 ;;;; symbol hacking VOPs
 
 (define-vop (%set-symbol-global-value)
@@ -366,7 +366,7 @@
     ;; ensure this is explained in the comment in objdef.lisp
     (loadw res symbol symbol-hash-slot other-pointer-lowtag)
     (inst and res (lognot fixnum-tag-mask))))
-
+
 ;;;; fdefinition (FDEFN) objects
 
 (define-vop (fdefn-fun cell-ref)        ; /pfw - alpha
@@ -449,7 +449,7 @@
      (storew (make-fixup 'undefined-tramp :assembly-routine)
              fdefn fdefn-raw-addr-slot other-pointer-lowtag))
     (move result fdefn)))
-
+
 ;;;; binding and unbinding
 
 ;;; BIND -- Establish VAL as a binding for SYMBOL. Save the old value and
@@ -591,7 +591,7 @@
   (:temporary (:sc complex-double-reg) zero)
   (:generator 0
     (unbind-to-here where symbol value bsp zero)))
-
+
 ;;;; closure indexing
 
 (define-full-reffer closure-index-ref *
@@ -625,7 +625,7 @@
   (:info offset)
   (:generator 4
     (storew rbp-tn object (+ closure-info-offset offset) fun-pointer-lowtag)))
-
+
 ;;;; value cell hackery
 
 (define-vop (value-cell-ref cell-ref)
@@ -633,7 +633,7 @@
 
 (define-vop (value-cell-set cell-set)
   (:variant value-cell-value-slot other-pointer-lowtag))
-
+
 ;;;; structure hackery
 
 (define-vop (instance-length)
@@ -697,7 +697,7 @@
 (define-full-compare-and-swap %raw-instance-cas/word instance
   instance-slots-offset instance-pointer-lowtag
   (unsigned-reg) unsigned-num %raw-instance-cas/word)
-
+
 ;;;; code object frobbing
 
 (define-full-reffer code-header-ref * 0 other-pointer-lowtag
@@ -710,7 +710,7 @@
 (define-full-setter (code-header-set :no-constant-variant)
   * 0 other-pointer-lowtag
   (any-reg descriptor-reg) * code-header-set)
-
+
 ;;;; raw instance slot accessors
 
 (flet ((instance-slot-ea (object index)

--- a/src/compiler/x86-64/char.lisp
+++ b/src/compiler/x86-64/char.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;; Space optimization: As the upper 32 bits of (tagged or untagged)
 ;;; characters are always zero many operations can be done on 32-bit
 ;;; registers. This often leads to smaller encodings as the REX prefix
@@ -86,7 +86,7 @@
 ;;; to a descriptor passing location.
 (define-move-vop move-arg :move-arg
   (character-reg) (any-reg descriptor-reg))
-
+
 ;;;; other operations
 
 (define-vop (char-code)
@@ -118,7 +118,7 @@
     ;; Those considerations do not pertain to the 64-bit vm.
     (unless (location= code res)
       (inst mov :dword res code))))
-
+
 ;;; comparison of CHARACTERs
 (define-vop (character-compare)
   (:args (x :scs (character-reg character-stack))

--- a/src/compiler/x86-64/float.lisp
+++ b/src/compiler/x86-64/float.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (macrolet ((ea-for-xf-desc (tn slot)
              `(ea (- (* ,slot n-word-bytes) other-pointer-lowtag) ,tn)))
   (defun ea-for-df-desc (tn)
@@ -68,7 +68,7 @@
     (ea-for-cxf-stack tn :double :real base))
   (defun ea-for-cdf-imag-stack (tn &optional (base rbp-tn))
     (ea-for-cxf-stack tn :double :imag base)))
-
+
 ;;;; move functions
 
 ;;; X is source, Y is destination.
@@ -113,7 +113,7 @@
 
 (eval-when (:compile-toplevel :execute)
   (setf *read-default-float-format* 'cl:single-float))
-
+
 ;;;; complex float move functions
 
 ;;; X is source, Y is destination.
@@ -132,7 +132,7 @@
 (define-move-fun (store-complex-double 2) (vop x y)
   ((complex-double-reg) (complex-double-stack))
   (inst movupd (ea-for-cdf-data-stack y) x))
-
+
 ;;;; move VOPs
 
 ;;; float register to register moves
@@ -153,7 +153,7 @@
   (frob complex-single-move complex-single-reg)
   (frob complex-double-move complex-double-reg))
 
-
+
 ;;; Move from float to a descriptor reg. allocating a new float
 ;;; object in the process.
 (define-vop (move-from-single)
@@ -219,7 +219,7 @@
     (inst movsd y (ea-for-df-desc x))))
 (define-move-vop move-to-double :move (descriptor-reg) (double-reg))
 
-
+
 ;;; Move from complex float to a descriptor reg. allocating a new
 ;;; complex float object in the process.
 (define-vop (move-from-complex-single)
@@ -264,7 +264,7 @@
                 (define-move-vop ,name :move (descriptor-reg) (,sc)))))
   (frob move-to-complex-single complex-single-reg :single)
   (frob move-to-complex-double complex-double-reg :double))
-
+
 ;;;; the move argument vops
 ;;;;
 ;;;; Note these are also used to stuff fp numbers onto the c-call
@@ -330,7 +330,7 @@
    complex-single-reg complex-double-reg)
   (descriptor-reg))
 
-
+
 ;;;; arithmetic VOPs
 
 (define-vop (float-op)
@@ -842,7 +842,7 @@
        (inst xorpd y y))
      (note-float-location 'sqrt vop x)
      (inst sqrtsd y x)))
-
+
 (macrolet ((frob ((name translate sc type) &body body)
              `(define-vop (,name)
                   (:args (x :scs (,sc) :target y))
@@ -877,7 +877,7 @@
   (frob (abs/single-float abs single-reg single-float)
         (inst andps y (register-inline-constant :oword (ldb (byte 31 0) -1)))))
 
-
+
 ;;;; comparison
 
 (define-vop (float-compare)
@@ -1106,7 +1106,7 @@
   (define-</> <= <=single-float <=double-float not :p :a)
   (define-</> >= >=single-float >=double-float not :p :b))
 
-
+
 ;;;; conversion
 
 (macrolet ((frob (name translate inst to-sc to-type)
@@ -1387,7 +1387,7 @@
          (inst mov :dword lo-bits
                (make-ea-for-object-slot float double-float-value-slot
                                         other-pointer-lowtag))))))
-
+
 
 ;;;; complex float VOPs
 
@@ -1523,7 +1523,7 @@
   (:note "complex float imagpart")
   (:variant 1))
 
-
+
 ;;; hack dummy VOPs to bias the representation selection of their
 ;;; arguments towards a FP register, which can help avoid consing at
 ;;; inappropriate locations

--- a/src/compiler/x86-64/insts.lisp
+++ b/src/compiler/x86-64/insts.lisp
@@ -114,7 +114,7 @@
                  (:word (typep imm '(integer #xFF80 #xFFFF)))
                  (:dword (typep imm '(integer #xFFFFFF80 #xFFFFFFFF))))
            (sb-c::mask-signed-field 8 imm)))))
-
+
 ;;;; disassembler argument types
 
 ;;; Used to capture the lower four bits of the REX prefix all at once ...
@@ -303,7 +303,7 @@
 
 (defun conditional-opcode (condition)
   (cdr (assoc condition +conditions+ :test #'eq)))
-
+
 ;;;; disassembler instruction formats
 
 (defun swap-if (direction field1 separator field2)
@@ -531,7 +531,7 @@
                                         :default-printer
                                         '(:name :tab reg/mem ", " imm))
   (imm :type 'imm-byte))
-
+
 ;;;; XMM instructions
 
 ;;; All XMM instructions use an extended opcode (#x0F as the first
@@ -935,7 +935,7 @@
   (reg/mem :fields (list (byte 2 38) (byte 3 32)) :type 'sized-reg/mem)
   (reg     :field  (byte 3 35) :type 'reg))
 
-
+
 ;;;; primitive emitters
 
 (define-bitfield-emitter emit-word 16
@@ -969,7 +969,7 @@
 (define-bitfield-emitter emit-sib-byte 8
   (byte 2 6) (byte 3 3) (byte 3 0))
 
-
+
 ;;;; fixup emitters
 
 (defun emit-absolute-fixup (segment fixup &optional quad-p)
@@ -983,7 +983,7 @@
   (note-fixup segment :relative fixup)
   (emit-signed-dword segment (fixup-offset fixup)))
 
-
+
 (defmacro emit-bytes (segment &rest bytes)
   `(progn ,@(mapcar (lambda (x) `(emit-byte ,segment ,x)) bytes)))
 (defun opcode+size-bit (opcode size)
@@ -1444,7 +1444,7 @@
     (:dword (emit-dword segment value))
     (:qword (emit-signed-dword segment value))
     (:word  (emit-word segment value))))
-
+
 ;;;; prefixes
 
 (define-instruction rex (segment)
@@ -1807,7 +1807,7 @@
    (emit-prefixes segment dst nil (operand-size dst))
    (emit-bytes segment #x0F #xC7)
    (emit-ea segment dst 6)))
-
+
 ;;;; flag control instructions
 
 (macrolet ((def (mnemonic opcode)
@@ -1828,7 +1828,7 @@
   (def cld   #xFC) ; Clear Direction Flag.
   (def std   #xFD) ; Set Direction Flag.
 )
-
+
 ;;;; arithmetic
 
 (flet ((emit* (name segment maybe-size dst src lockp opcode allowp)
@@ -2034,7 +2034,7 @@
      (emit-bytes segment #x0F (opcode+size-bit #xC0 size))
      (emit-ea segment dst src))))
 
-
+
 ;;;; logic
 
 (define-instruction-format
@@ -2131,7 +2131,7 @@
            (t
             (emit-byte segment (opcode+size-bit #x84 size))
             (emit-ea segment this that))))))
-
+
 ;;;; string manipulation
 
 (flet ((emit* (segment opcode size)
@@ -2175,7 +2175,7 @@
   (:emitter
    (emit-byte segment #b11010111)))
 
-
+
 ;;;; bit manipulation
 
 (flet ((emit* (segment opcode dst src)
@@ -2226,7 +2226,7 @@
     (define btr 6)
     (define btc 7)))
 
-
+
 ;;;; control transfer
 
 (define-instruction call (segment where)
@@ -2353,7 +2353,7 @@
   (:emitter
    (emit-byte segment #xE0)
    (emit-byte-displacement-backpatch segment target)))
-
+
 ;;;; conditional move
 (define-instruction cmov (segment maybe-size cond dst &optional src)
   (:printer cond-move ())
@@ -2380,7 +2380,7 @@
    (emit-byte segment #x0F)
    (emit-byte segment (dpb (conditional-opcode cond) (byte 4 0) #b10010000))
    (emit-ea segment dst #b000)))
-
+
 ;;;; enter/leave
 
 (define-instruction enter (segment disp &optional (level 0))
@@ -2395,7 +2395,7 @@
 (define-instruction leave (segment)
   (:printer byte ((op #xC9)))
   (:emitter (emit-byte segment #xC9)))
-
+
 ;;;; interrupt instructions
 
 (define-instruction break (segment &optional (code nil codep))
@@ -2425,7 +2425,7 @@
 (define-instruction iret (segment)
   (:printer byte ((op #xCF)))
   (:emitter (emit-byte segment #xCF)))
-
+
 ;;;; processor control
 
 (define-instruction nop (segment)
@@ -2465,7 +2465,7 @@
   (:printer two-bytes ((op '(#x0F #x05))))
   (:emitter (emit-bytes segment #x0F #x05)))
 
-
+
 ;;;; miscellaneous hackery
 
 (define-instruction byte (segment byte)
@@ -2488,7 +2488,7 @@
 (define-instruction simple-fun-header-word (segment)
   (:emitter
    (emit-header-data segment simple-fun-widetag)))
-
+
 ;;;; Instructions required to do floating point operations using SSE
 
 ;; Return a one- or two-element list of printers for SSE instructions.

--- a/src/compiler/x86-64/macros.lisp
+++ b/src/compiler/x86-64/macros.lisp
@@ -90,7 +90,7 @@
 (defmacro popw (ptr &optional (slot 0) (lowtag 0))
   `(inst pop (make-ea-for-object-slot ,ptr ,slot ,lowtag)))
 
-
+
 ;;;; macros to generate useful values
 
 (defmacro load-symbol (reg symbol)
@@ -150,7 +150,7 @@
 
 (defmacro store-binding-stack-pointer (reg)
   `(store-tl-symbol-value ,reg *binding-stack-pointer*))
-
+
 ;;;; error code
 (defun emit-error-break (vop kind code values)
   (assemble ()
@@ -181,7 +181,7 @@
                         values)
       start-lab)))
 
-
+
 ;;;; PSEUDO-ATOMIC
 
 ;;; This is used to wrap operations which leave untagged memory lying
@@ -226,7 +226,7 @@
          ;; trap instead.  Let's take the opportunity to trigger that
          ;; safepoint right now.
          (emit-safepoint)))))
-
+
 ;;;; indexed references
 
 (sb-xc:deftype load/store-index (scale lowtag min-offset

--- a/src/compiler/x86-64/move.lisp
+++ b/src/compiler/x86-64/move.lisp
@@ -53,7 +53,7 @@
    (signed-reg) (signed-stack)
    (unsigned-reg) (unsigned-stack))
   (inst mov y x))
-
+
 ;;;; the MOVE VOP
 (define-vop (move)
   (:args (x :scs (any-reg descriptor-reg immediate) :target y
@@ -140,7 +140,7 @@
 (define-move-vop move-arg :move-arg
   (any-reg descriptor-reg)
   (any-reg descriptor-reg))
-
+
 ;;;; moves and coercions
 
 ;;; These MOVE-TO-WORD VOPs move a tagged integer to a raw full-word

--- a/src/compiler/x86-64/nlx.lisp
+++ b/src/compiler/x86-64/nlx.lisp
@@ -22,7 +22,7 @@
 (defun unwind-block-ea (tn)
   (aver (sc-is tn unwind-block))
   (ea (frame-byte-offset (+ -1 (tn-offset tn) unwind-block-size)) rbp-tn))
-
+
 ;;;; Save and restore dynamic environment.
 ;;;;
 ;;;; These VOPs are used in the reentered function to restore the
@@ -55,7 +55,7 @@
   (:results (res :scs (any-reg descriptor-reg)))
   (:generator 1
     (load-binding-stack-pointer res)))
-
+
 ;;;; unwind block hackery
 
 ;;; Compute the address of the catch block from its TN, then store into the
@@ -146,7 +146,7 @@
     (load-tl-symbol-value block *current-unwind-protect-block*)
     (loadw block block unwind-block-uwp-slot)
     (store-tl-symbol-value block *current-unwind-protect-block*)))
-
+
 ;;;; NLX entry VOPs
 (define-vop (nlx-entry)
   ;; Note: we can't list an sc-restriction, 'cause any load vops would

--- a/src/compiler/x86-64/parms.lisp
+++ b/src/compiler/x86-64/parms.lisp
@@ -54,7 +54,7 @@
 ;;; are talking about stuff the rest of the lisp system might be
 ;;; interested in, we use ``word'' to mean the size of a descriptor
 ;;; object, which is 64 bits.
-
+
 ;;;; machine architecture parameters
 
 ;;; the number of bits per word, where a word holds one lisp descriptor
@@ -111,7 +111,7 @@
 (defconstant-eqx float-traps-byte        (byte 6  7) #'equalp)
 (defconstant-eqx float-exceptions-byte   (byte 6  0) #'equalp)
 (defconstant float-fast-bit 0) ; no fast mode on x86-64
-
+
 ;;;; description of the target address space
 
 ;;; where to put the different spaces.
@@ -140,7 +140,7 @@
 
 (defconstant linkage-table-entry-size 16)
 
-
+
 (defenum (:start 8)
   halt-trap
   pending-interrupt-trap
@@ -154,7 +154,7 @@
   #+sb-safepoint global-safepoint-trap
   #+sb-safepoint csp-safepoint-trap
   error-trap)
-
+
 ;;;; static symbols
 
 ;;; These symbols are loaded into static space directly after NIL so

--- a/src/compiler/x86-64/pred.lisp
+++ b/src/compiler/x86-64/pred.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; the branch VOP
 
 ;;; The unconditional branch, emitted when we can't drop through to the desired
@@ -20,7 +20,7 @@
   (:generator 5
     (inst jmp dest)))
 
-
+
 ;;;; Generic conditional VOPs
 
 ;;; The generic conditional branch, emitted immediately after test
@@ -190,7 +190,7 @@
   #+sb-unicode
   (def-move-if move-if/char character character-reg character-stack)
   (def-move-if move-if/sap system-area-pointer sap-reg sap-stack))
-
+
 ;;;; conditional VOPs
 
 ;;; Note: a constant-tn is allowed in CMP; it uses an EA displacement,

--- a/src/compiler/x86-64/sap.lisp
+++ b/src/compiler/x86-64/sap.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; moves and coercions
 
 ;;; Move a tagged SAP to an untagged representation.
@@ -71,7 +71,7 @@
 ;;; descriptor passing location.
 (define-move-vop move-arg :move-arg
   (sap-reg) (descriptor-reg))
-
+
 ;;;; SAP-INT and INT-SAP
 
 ;;; The function SAP-INT is used to generate an integer corresponding
@@ -98,7 +98,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move sap int)))
-
+
 ;;;; POINTER+ and POINTER-
 
 (define-vop (pointer+)
@@ -149,7 +149,7 @@
   (:generator 1
     (move res ptr1)
     (inst sub res ptr2)))
-
+
 ;;;; mumble-SYSTEM-REF and mumble-SYSTEM-SET
 
 ;; from 'llvm/projects/compiler-rt/lib/msan/msan.h':
@@ -244,7 +244,7 @@
     sap-reg system-area-pointer :qword)
   (def-system-ref-and-set sap-ref-lispobj %set-sap-ref-lispobj mov
     descriptor-reg * :qword))
-
+
 ;;;; SAP-REF-DOUBLE
 
 (define-vop (sap-ref-double)
@@ -294,7 +294,7 @@
   (:generator 4
     (inst movsd (ea offset sap) value)
     (move result value)))
-
+
 ;;;; SAP-REF-SINGLE
 
 (define-vop (sap-ref-single)
@@ -345,7 +345,7 @@
     (inst movss (ea offset sap) value)
     (move result value)))
 
-
+
 ;;; noise to convert normal lisp data objects into SAPs
 
 (define-vop (vector-sap)

--- a/src/compiler/x86-64/simd-pack-256.lisp
+++ b/src/compiler/x86-64/simd-pack-256.lisp
@@ -10,13 +10,13 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (defun float-avx2-p (tn)
   (sc-is tn single-avx2-reg single-avx2-stack single-avx2-immediate
             double-avx2-reg double-avx2-stack double-avx2-immediate))
 (defun int-avx2-p (tn)
   (sc-is tn int-avx2-reg int-avx2-stack int-avx2-immediate))
-
+
 #+sb-xc-host
 (progn ; the host compiler will complain about absence of these
   (defun %simd-pack-256-0 (x) (error "Called %SIMD-PACK-256-0 ~S" x))
@@ -146,7 +146,7 @@
   (int-avx2-reg double-avx2-reg single-avx2-reg)
   (descriptor-reg))
 
-
+
 (define-vop (%simd-pack-256-0)
   (:translate %simd-pack-256-0)
   (:args (x :scs (int-avx2-reg double-avx2-reg single-avx2-reg)))

--- a/src/compiler/x86-64/simd-pack.lisp
+++ b/src/compiler/x86-64/simd-pack.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (defun ea-for-sse-stack (tn &optional (base rbp-tn))
   (ea (frame-byte-offset (1+ (tn-offset tn))) base))
 
@@ -19,7 +19,7 @@
             double-sse-reg double-sse-stack double-sse-immediate))
 (defun int-sse-p (tn)
   (sc-is tn int-sse-reg int-sse-stack int-sse-immediate))
-
+
 #+sb-xc-host
 (progn ; the host compiler will complain about absence of these
   (defun %simd-pack-low (x) (error "Called %SIMD-PACK-LOW ~S" x))
@@ -143,7 +143,7 @@
   (int-sse-reg double-sse-reg single-sse-reg)
   (descriptor-reg))
 
-
+
 (define-vop (%simd-pack-low)
   (:translate %simd-pack-low)
   (:args (x :scs (int-sse-reg double-sse-reg single-sse-reg)))

--- a/src/compiler/x86-64/subprim.lisp
+++ b/src/compiler/x86-64/subprim.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; LENGTH
 
 (define-vop (length/list)

--- a/src/compiler/x86-64/system.lisp
+++ b/src/compiler/x86-64/system.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; type frobbing VOPs
 
 ;;; For non-list pointer descriptors, return the header's widetag byte.
@@ -231,7 +231,7 @@
      (move rax old)
      (inst cmpxchg :dword (ea (- 4 other-pointer-lowtag) object) new :lock)
      (inst lea result (ea nil rax (ash 1 n-fixnum-tag-bits)))))
-
+
 (define-vop (pointer-hash)
   (:translate pointer-hash)
   (:args (ptr :scs (any-reg descriptor-reg) :target res))
@@ -241,7 +241,7 @@
     (move res ptr)
     (inst and res (constantize (dpb -1 (byte (- n-word-bits n-fixnum-tag-bits 1)
                                              n-fixnum-tag-bits) 0)))))
-
+
 ;;;; allocation
 
 (define-vop (binding-stack-pointer-sap)
@@ -259,7 +259,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move int rsp-tn)))
-
+
 ;;;; code object frobbing
 
 (define-vop (code-instructions)
@@ -355,7 +355,7 @@
     (inst mov temp nil-value)
     (inst test :byte res fixnum-tag-mask)
     (inst cmov :e res temp)))
-
+
 ;;;; other miscellaneous VOPs
 
 (defknown sb-unix::receive-pending-interrupt () (values))
@@ -391,7 +391,7 @@
 (define-vop (halt)
   (:generator 1
     (inst break halt-trap)))
-
+
 ;;;; Miscellany
 
 ;;; the RDTSC instruction (present on Pentium processors and
@@ -463,7 +463,7 @@ number of CPU cycles elapsed as secondary value. EXPERIMENTAL."
     (inst inc (ea (- (* (+ vector-data-offset index) n-word-bytes)
                      other-pointer-lowtag)
                   count-vector))))
-
+
 ;;;; Memory barrier support
 
 (define-vop (%compiler-barrier)

--- a/src/compiler/x86-64/type-vops.lisp
+++ b/src/compiler/x86-64/type-vops.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; test generation utilities
 
 (defun generate-fixnum-test (value)
@@ -190,7 +190,7 @@
                   (inst cmp :byte temp (- end start))
                   (inst jmp less-or-equal target))))))))
       (emit-label drop-through))))
-
+
 ;;;; other integer ranges
 
 (define-vop (fixnump/unsigned-byte-64 simple-type-predicate)
@@ -359,7 +359,7 @@
        (inst cmp value (constantize fixnum-hi))
        (inst jmp (if not-p :a :be) target)
        (emit-label skip))))
-
+
 ;;;; list/symbol types
 ;;;
 ;;; symbolp (or symbol (eq nil))
@@ -382,7 +382,7 @@
       (inst jmp :e is-not-cons-label)
       (test-type value temp target not-p (list-pointer-lowtag)))
     DROP-THRU))
-
+
 (define-vop (widetag=)
   (:translate widetag=)
   (:policy :fast-safe)

--- a/src/compiler/x86-64/vm.lisp
+++ b/src/compiler/x86-64/vm.lisp
@@ -100,7 +100,7 @@
   (defregset    *c-call-register-arg-offsets* rdi rsi rdx rcx r8 r9)
   #+win32
   (defregset    *c-call-register-arg-offsets* rcx rdx r8 r9))
-
+
 ;;;; SB definitions
 
 (!define-storage-bases
@@ -114,7 +114,7 @@
 (define-storage-base immediate-constant :non-packed)
 (define-storage-base noise :unbounded :size 2)
 )
-
+
 ;;;; SC definitions
 
 (eval-when (:compile-toplevel :execute)
@@ -332,7 +332,7 @@
                           (#.*complex-sc-names* :complex))))
                   (append class-spec (if size (list :operand-size size)))))
               *storage-class-defs*))
-
+
 ;;;; miscellaneous TNs for the various registers
 
 (macrolet ((def-gpr-tns (sc-name name-array &aux (i -1))
@@ -467,7 +467,7 @@
                                  character-widetag)
                          (char-code val)))))
       tn))
-
+
 ;;;; miscellaneous function call parameters
 
 ;;; Offsets of special stack frame locations relative to RBP.
@@ -493,7 +493,7 @@
 
 ;;; This is used by the debugger.
 (defconstant single-value-return-byte-offset 3)
-
+
 ;;; This function is called by debug output routines that want a pretty name
 ;;; for a TN's location. It returns a thing that can be printed with PRINC.
 (defun location-print-name (tn)

--- a/src/compiler/x86/alloc.lisp
+++ b/src/compiler/x86/alloc.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; allocation helpers
 
 ;;; Allocation within alloc_region (which is thread local) can be done
@@ -223,7 +223,7 @@
 
 (define-vop (list* list-or-list*)
   (:variant t))
-
+
 ;;;; special-purpose inline allocators
 
 ;;; ALLOCATE-VECTOR
@@ -310,7 +310,7 @@
     (inst rep)
     (inst stos zero)))
 
-
+
 (define-vop (make-fdefn)
   (:policy :fast-safe)
   (:translate make-fdefn)
@@ -353,7 +353,7 @@
   (:generator 10
     (alloc-other result value-cell-widetag value-cell-size node stack-allocate-p)
     (storew value result value-cell-value-slot other-pointer-lowtag)))
-
+
 ;;;; automatic allocators for primitive objects
 
 (define-vop (make-unbound-marker)

--- a/src/compiler/x86/arith.lisp
+++ b/src/compiler/x86/arith.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; unary operations
 
 (define-vop (fast-safe-arith-op)
@@ -69,7 +69,7 @@
   (:generator 2
     (move res x)
     (inst not res)))
-
+
 ;;;; binary fixnum operations
 
 ;;; Assume that any constant operand is the second arg...
@@ -357,7 +357,7 @@
     DONE
     (unless (= mask most-positive-word)
       (inst and r mask))))
-
+
 
 (define-vop (fast-+-c/signed=>signed fast-safe-arith-op)
   (:translate +)
@@ -420,7 +420,7 @@
            (if (= y 1)
                (inst inc r)
              (inst add r y))))))
-
+
 ;;;; multiplication and division
 
 (define-vop (fast-*/fixnum=>fixnum fast-safe-arith-op)
@@ -651,7 +651,7 @@
     (move rem edx)))
 
 
-
+
 ;;;; Shifting
 (define-vop (fast-ash-c/fixnum=>fixnum)
   (:translate ash)
@@ -1033,7 +1033,7 @@ constant shift greater than word length")))
     (inst shl result :cl)
 
     DONE))
-
+
 (define-vop (signed-byte-32-len)
   (:translate integer-length)
   (:note "inline (signed-byte 32) integer-length")
@@ -1140,7 +1140,7 @@ constant shift greater than word length")))
     (inst shr result 16)
     (inst add result temp)
     (inst and result #xff)))
-
+
 ;;;; binary conditional VOPs
 
 (define-vop (fast-conditional)
@@ -1347,7 +1347,7 @@ constant shift greater than word length")))
   (:args (x :scs (any-reg descriptor-reg control-stack)))
   (:arg-types * (:constant (signed-byte 30)))
   (:variant-cost 6))
-
+
 ;;;; 32-bit logical operations
 
 ;;; Only the lower 5 bits of the shift amount are significant.
@@ -1375,7 +1375,7 @@ constant shift greater than word length")))
     (move r num)
     (move ecx amount)
     (inst shl r :cl)))
-
+
 ;;;; Modular functions
 (defmacro define-mod-binop ((name prototype) function)
   `(define-vop (,name ,prototype)
@@ -1584,7 +1584,7 @@ constant shift greater than word length")))
   `(lognot (logior ,x ,y)))
 (define-source-transform lognand (x y)
   `(lognot (logand ,x ,y)))
-
+
 ;;;; bignum stuff
 
 (define-vop (bignum-length get-header-data)
@@ -1852,7 +1852,7 @@ constant shift greater than word length")))
     (move result digit)
     (move ecx count)
     (inst shl result :cl)))
-
+
 ;;; Support for the Mersenne Twister, MT19937, random number generator
 ;;; due to Matsumoto and Nishimura.
 ;;;

--- a/src/compiler/x86/array.lisp
+++ b/src/compiler/x86/array.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; allocator for the array header
 
 (define-vop (make-array-header)
@@ -57,7 +57,7 @@
      (pseudo-atomic ()
       (allocation result bytes node nil other-pointer-lowtag)
       (storew header result 0 other-pointer-lowtag)))))
-
+
 ;;;; additional accessors and setters for the array header
 (define-full-reffer %array-dimension *
   array-dimensions-offset other-pointer-lowtag
@@ -77,7 +77,7 @@
     (loadw res x 0 other-pointer-lowtag)
     (inst shr res n-widetag-bits)
     (inst sub res (1- array-dimensions-offset))))
-
+
 ;;;; bounds checking routine
 (define-vop (check-bound)
   (:translate %check-bound)
@@ -155,7 +155,7 @@
                 (:or unsigned-num signed-num))
   (:variant nil)
   (:variant-cost 5))
-
+
 ;;;; accessors/setters
 
 ;;; variants built on top of WORD-INDEX-REF, etc. I.e., those vectors
@@ -185,7 +185,7 @@
   vector-data-offset other-pointer-lowtag
   (descriptor-reg any-reg) *
   %compare-and-swap-svref)
-
+
 ;;;; integer vectors whose elements are smaller than a byte, i.e.,
 ;;;; bit, 2-bit, and 4-bit vectors
 
@@ -624,7 +624,7 @@
         (inst fstd result-imag))
       (inst fxch value-imag))))
 
-
+
 ;;; {un,}signed-byte-8, simple-base-string
 
 (macrolet ((define-data-vector-frobs (ptype element-type ref-inst
@@ -757,7 +757,7 @@
   (define-data-vector-frobs simple-array-signed-byte-16 tagged-num
     movsx signed-reg))
 
-
+
 ;;; These vops are useful for accessing the bits of a vector
 ;;; irrespective of what type of vector it is.
 (define-full-reffer vector-raw-bits * vector-data-offset other-pointer-lowtag
@@ -765,7 +765,7 @@
 (define-full-setter set-vector-raw-bits * vector-data-offset other-pointer-lowtag
  (unsigned-reg) unsigned-num %set-vector-raw-bits)
 
-
+
 ;;;; ATOMIC-INCF for arrays
 
 (define-vop (array-atomic-incf/word)

--- a/src/compiler/x86/call.lisp
+++ b/src/compiler/x86/call.lisp
@@ -62,7 +62,7 @@
 ;;; are using non-standard conventions.
 (defun make-arg-count-location ()
   (make-wired-tn *fixnum-primitive-type* any-reg-sc-number ecx-offset))
-
+
 ;;;; frame hackery
 
 ;;; This is used for setting up the Old-FP in local call.
@@ -276,7 +276,7 @@
     (inst lea res (make-ea :dword :base esp-tn
                            :disp (- (* sp->fp-offset n-word-bytes))))
     (inst sub esp-tn (* (max nargs 3) n-word-bytes))))
-
+
 ;;; Emit code needed at the return-point from an unknown-values call
 ;;; for a fixed number of values. Values is the head of the TN-REF
 ;;; list for the locations that the values are to be received into.
@@ -483,7 +483,7 @@
          (inst mov esp-tn ebx-tn)
          (inst cld)))))
   (values))
-
+
 ;;;; unknown values receiving
 
 ;;; Emit code needed at the return point for an unknown-values call
@@ -552,7 +552,7 @@
               nvals)
   (:results (start :scs (any-reg control-stack))
             (count :scs (any-reg control-stack))))
-
+
 ;;;; local call with unknown values convention return
 
 (defun check-ocfp-and-return-pc (old-fp return-pc)
@@ -639,7 +639,7 @@
     (inst call target)
     (note-this-location vop :unknown-return)
     (receive-unknown-values values-start nvals start count node)))
-
+
 ;;;; local call with known values return
 
 ;;; Non-TR local call with known return locations. Known-value return
@@ -663,7 +663,7 @@
     (note-this-location vop :call-site)
     (inst call target)
     (note-this-location vop :known-return)))
-
+
 ;;; From Douglas Crosher
 ;;; Return from known values call. We receive the return locations as
 ;;; arguments to terminate their lifetimes in the returning function. We
@@ -682,7 +682,7 @@
     (inst mov esp-tn ebp-tn)
     (inst pop ebp-tn)
     (inst ret)))
-
+
 ;;;; full call
 ;;;
 ;;; There is something of a cross-product effect with full calls.
@@ -950,7 +950,7 @@
     (move eax function)
     ;; And jump to the assembly routine.
     (inst jmp (make-fixup 'tail-call-variable :assembly-routine))))
-
+
 ;;;; unknown values return
 
 ;;; Return a single-value using the Unknown-Values convention.
@@ -1089,7 +1089,7 @@
     (move esi vals)
     (move ecx nvals)
     (inst jmp (make-fixup 'return-multiple :assembly-routine))))
-
+
 ;;;; XEP hackery
 
 ;;; Get the lexical environment from its passing location.

--- a/src/compiler/x86/cell.lisp
+++ b/src/compiler/x86/cell.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; data object ref/set stuff
 
 (define-vop (slot)
@@ -69,7 +69,7 @@
                             :disp (- (* offset n-word-bytes) lowtag))
            new :lock)
      (move result eax)))
-
+
 ;;;; symbol hacking VOPs
 
 (define-vop (%compare-and-swap-symbol-value)
@@ -241,7 +241,7 @@
     ;; ensure this is explained in the comment in objdef.lisp
     (loadw res symbol symbol-hash-slot other-pointer-lowtag)
     (inst and res (lognot #b11))))
-
+
 ;;;; fdefinition (FDEFN) objects
 
 (define-vop (fdefn-fun cell-ref)        ; /pfw - alpha
@@ -288,7 +288,7 @@
     (storew (make-fixup 'undefined-tramp :assembly-routine)
             fdefn fdefn-raw-addr-slot other-pointer-lowtag)
     (move result fdefn)))
-
+
 ;;;; binding and unbinding
 
 ;;; BIND -- Establish VAL as a binding for SYMBOL. Save the old value and
@@ -405,7 +405,7 @@
     (store-binding-stack-pointer bsp)
 
     DONE))
-
+
 ;;;; closure indexing
 
 (define-full-reffer closure-index-ref *
@@ -439,7 +439,7 @@
   (:info offset)
   (:generator 4
     (storew ebp-tn object (+ closure-info-offset offset) fun-pointer-lowtag)))
-
+
 ;;;; value cell hackery
 
 (define-vop (value-cell-ref cell-ref)
@@ -447,7 +447,7 @@
 
 (define-vop (value-cell-set cell-set)
   (:variant value-cell-value-slot other-pointer-lowtag))
-
+
 ;;;; structure hackery
 
 (define-vop (instance-length)
@@ -478,7 +478,7 @@
 (define-full-compare-and-swap %raw-instance-cas/word instance
   instance-slots-offset instance-pointer-lowtag
   (unsigned-reg) unsigned-num %raw-instance-cas/word)
-
+
 ;;;; code object frobbing
 
 (define-full-reffer code-header-ref * 0 other-pointer-lowtag
@@ -499,7 +499,7 @@
     (inst push object)
     (inst call (make-fixup 'code-header-set :assembly-routine))
     (move result value)))
-
+
 ;;;; raw instance slot accessors
 
 (defun instance-slot-ea (object index &optional (displacement 0))

--- a/src/compiler/x86/char.lisp
+++ b/src/compiler/x86/char.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; moves and coercions
 
 ;;; Move a tagged char to an untagged representation.
@@ -112,7 +112,7 @@
 ;;; to a descriptor passing location.
 (define-move-vop move-arg :move-arg
   (character-reg) (any-reg descriptor-reg))
-
+
 ;;;; other operations
 
 (define-vop (char-code)
@@ -153,7 +153,7 @@
   (:generator 1
     (move eax code)
     (move res al-tn)))
-
+
 ;;; comparison of CHARACTERs
 (define-vop (character-compare)
   (:args (x :scs (character-reg character-stack))

--- a/src/compiler/x86/float.lisp
+++ b/src/compiler/x86/float.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 (macrolet ((ea-for-xf-desc (tn slot)
              `(make-ea-for-object-slot ,tn ,slot other-pointer-lowtag)))
   (defun ea-for-sf-desc (tn)
@@ -125,7 +125,7 @@
 (defun store-long-float (ea)
    (inst fstpl ea)
    (inst fldl ea))
-
+
 ;;;; move functions
 
 ;;; X is source, Y is destination.
@@ -222,7 +222,7 @@
          (inst fldd value))))))
 (eval-when (:compile-toplevel :execute)
   (setf *read-default-float-format* 'cl:single-float))
-
+
 ;;;; complex float move functions
 
 (defun complex-single-reg-real-tn (x)
@@ -320,7 +320,7 @@
     (store-long-float (ea-for-clf-imag-stack y))
     (inst fxch imag-tn)))
 
-
+
 ;;;; move VOPs
 
 ;;; float register to register moves
@@ -403,7 +403,7 @@
 #+long-float
 (define-move-vop complex-long-move :move
   (complex-long-reg) (complex-long-reg))
-
+
 ;;; Move from float to a descriptor reg. allocating a new float
 ;;; object in the process.
 (define-vop (move-from-single)
@@ -501,7 +501,7 @@
        (inst fldl (ea-for-lf-desc x)))))
 #+long-float
 (define-move-vop move-to-long :move (descriptor-reg) (long-reg))
-
+
 ;;; Move from complex float to a descriptor reg. allocating a new
 ;;; complex float object in the process.
 (define-vop (move-from-complex-single)
@@ -581,7 +581,7 @@
           (frob move-to-complex-double complex-double-reg :double)
           #+long-float
           (frob move-to-complex-double complex-long-reg :long))
-
+
 ;;;; the move argument vops
 ;;;;
 ;;;; Note these are also used to stuff fp numbers onto the c-call
@@ -724,7 +724,7 @@
    complex-single-reg complex-double-reg #+long-float complex-long-reg)
   (descriptor-reg))
 
-
+
 ;;;; arithmetic VOPs
 
 ;;; dtc: the floating point arithmetic vops
@@ -1142,7 +1142,7 @@
           fdiv fdivr //single-float 12
           fdivd fdivrd //double-float 12
           //long-float 12))
-
+
 (macrolet ((frob (name inst translate sc type)
              `(define-vop (,name)
                (:args (x :scs (,sc) :target fr0))
@@ -1175,7 +1175,7 @@
   (frob %negate/double-float fchs %negate double-reg double-float)
   #+long-float
   (frob %negate/long-float fchs %negate long-reg long-float))
-
+
 ;;;; comparison
 
 (define-vop (=/float)
@@ -1577,7 +1577,7 @@
   `(and (= (long-float-low-bits x) (long-float-low-bits y))
         (= (long-float-high-bits x) (long-float-high-bits y))
         (= (long-float-exp-bits x) (long-float-exp-bits y))))
-
+
 ;;;; conversion
 
 (macrolet ((frob (name translate to-sc to-type)
@@ -2039,7 +2039,7 @@
        (descriptor-reg
         (loadw lo-bits float long-float-value-slot
                other-pointer-lowtag)))))
-
+
 ;;;; float mode hackery
 
 (sb-xc:deftype float-modes () '(unsigned-byte 32)) ; really only 16
@@ -2092,7 +2092,7 @@
    (inst fldenv (make-ea :dword :base esp-tn))
    (inst add esp-tn npx-env-size)       ; Pop stack.
    (move res new)))
-
+
 #-long-float
 (progn
 
@@ -3100,7 +3100,7 @@
        ((0 1))
        (t (inst fstd r)))))
 ) ; PROGN #-LONG-FLOAT
-
+
 #+long-float
 (progn
 
@@ -4076,7 +4076,7 @@
        (t (inst fstd r)))))
 
 ) ; PROGN #+LONG-FLOAT
-
+
 ;;;; complex float VOPs
 
 (define-vop (make-complex-single-float)
@@ -4334,7 +4334,7 @@
   (:result-types long-float)
   (:note "complex float imagpart")
   (:variant 1))
-
+
 ;;; hack dummy VOPs to bias the representation selection of their
 ;;; arguments towards a FP register, which can help avoid consing at
 ;;; inappropriate locations

--- a/src/compiler/x86/insts.lisp
+++ b/src/compiler/x86/insts.lisp
@@ -24,7 +24,7 @@
 (deftype reg () '(unsigned-byte 3))
 
 (defconstant +default-operand-size+ :dword)
-
+
 (defparameter *default-address-size*
   ;; Actually, :DWORD is the only one really supported.
   :dword)
@@ -36,7 +36,7 @@
     (:dword 32)
     (:float 32)
     (:double 64)))
-
+
 ;;;; disassembler argument types
 
 (define-arg-type displacement
@@ -183,7 +183,7 @@
 
 (defun conditional-opcode (condition)
   (cdr (assoc condition +conditions+ :test #'eq)))
-
+
 ;;;; disassembler instruction formats
 
 (defun swap-if (direction field1 separator field2)
@@ -361,7 +361,7 @@
                                         :default-printer
                                         '(:name :tab reg/mem ", " imm))
   (imm :type 'imm-byte))
-
+
 ;;;; This section was added by jrd, for fp instructions.
 
 ;;; regular fp inst to/from registers/memory
@@ -492,7 +492,7 @@
   (op :field (byte 16 0))
   (code :field (byte 8 16) :reader word-imm-code))
 
-
+
 ;;;; primitive emitters
 
 (define-bitfield-emitter emit-word 16
@@ -506,7 +506,7 @@
 
 (define-bitfield-emitter emit-sib-byte 8
   (byte 2 6) (byte 3 3) (byte 3 0))
-
+
 ;;;; fixup emitters
 
 (defun emit-absolute-fixup (segment fixup)
@@ -541,7 +541,7 @@
 (defun emit-relative-fixup (segment fixup)
   (note-fixup segment :relative fixup)
   (emit-dword segment (fixup-offset fixup)))
-
+
 ;;;; the effective-address (ea) structure
 
 (declaim (ftype (sfunction (tn) (mod 8)) reg-tn-encoding))
@@ -688,7 +688,7 @@
 (defun accumulator-p (thing)
   (and (register-p thing)
        (= (tn-offset thing) 0)))
-
+
 ;;;; utilities
 
 (defconstant +operand-size-prefix-byte+ #b01100110)
@@ -727,7 +727,7 @@
     (:byte  (emit-byte segment value))
     (:dword (emit-dword segment value))
     (:word  (emit-word segment value))))
-
+
 ;;;; prefixes
 
 (define-instruction x66 (segment)
@@ -985,7 +985,7 @@
   (:emitter
    (emit-byte segment #xf3)
    (emit-byte segment #x90)))
-
+
 ;;;; flag control instructions
 
 ;;; CLC -- Clear Carry Flag.
@@ -1053,7 +1053,7 @@
   (:printer byte ((op #b11111011)))
   (:emitter
    (emit-byte segment #b11111011)))
-
+
 ;;;; arithmetic
 
 (defun emit-random-arith-inst (name segment dst src opcode
@@ -1294,7 +1294,7 @@
      (emit-byte segment (if (eq size :byte) #b11000000 #b11000001))
      (emit-ea segment dst (reg-tn-encoding src)))))
 
-
+
 ;;;; logic
 
 (defun emit-shift-inst (segment dst amount opcode)
@@ -1395,7 +1395,7 @@
      (maybe-emit-operand-size-prefix segment size)
      (emit-byte segment (if (eq size :byte) #b11110110 #b11110111))
      (emit-ea segment dst #b010))))
-
+
 ;;;; string manipulation
 
 (define-instruction cmps (segment size)
@@ -1455,7 +1455,7 @@
   (:emitter
    (emit-byte segment #b11010111)))
 
-
+
 ;;;; bit manipulation
 
 (define-instruction bsf (segment dst src)
@@ -1512,7 +1512,7 @@
   (define btr 6)
   (define btc 7))
 
-
+
 ;;;; control transfer
 
 (defun emit-byte-displacement-backpatch (segment target)
@@ -1649,7 +1649,7 @@
   (:emitter
    (emit-byte segment #b11100000)
    (emit-byte-displacement-backpatch segment target)))
-
+
 ;;;; conditional move
 (define-instruction cmov (segment cond dst src)
   (:printer cond-move ())
@@ -1670,7 +1670,7 @@
    (emit-byte segment #b00001111)
    (emit-byte segment (dpb (conditional-opcode cond) (byte 4 0) #b10010000))
    (emit-ea segment dst #b000)))
-
+
 ;;;; enter/leave
 
 (define-instruction enter (segment disp &optional (level 0))
@@ -1686,7 +1686,7 @@
   (:printer byte ((op #b11001001)))
   (:emitter
    (emit-byte segment #b11001001)))
-
+
 ;;;; prefetch
 (define-instruction prefetchnta (segment ea)
   (:printer prefetch ((op #b00011000) (reg #b000)))
@@ -1723,7 +1723,7 @@
    (emit-byte segment #b00001111)
    (emit-byte segment #b00011000)
    (emit-ea segment ea #b011)))
-
+
 ;;;; interrupt instructions
 
 (define-instruction break (segment &optional (code nil codep))
@@ -1769,7 +1769,7 @@
   (:printer byte ((op #b11001111)))
   (:emitter
    (emit-byte segment #b11001111)))
-
+
 ;;;; processor control
 
 (define-instruction hlt (segment)
@@ -1787,7 +1787,7 @@
   (:printer byte ((op #b10011011)))
   (:emitter
    (emit-byte segment #b10011011)))
-
+
 ;;;; miscellaneous hackery
 
 (define-instruction byte (segment byte)
@@ -1809,7 +1809,7 @@
 (define-instruction simple-fun-header-word (segment)
   (:emitter
    (emit-header-data segment simple-fun-widetag)))
-
+
 ;;;; fp instructions
 ;;;;
 ;;;; FIXME: This section said "added by jrd", which should end up in CREDITS.

--- a/src/compiler/x86/macros.lisp
+++ b/src/compiler/x86/macros.lisp
@@ -35,7 +35,7 @@
      ,@body
      (unless (zerop (tn-offset ,tn))
        (inst fxch ,tn))))                ; save into new dest and restore st(0)
-
+
 ;;;; instruction-like macros
 
 (defmacro move (dst src)
@@ -78,7 +78,7 @@
             :disp (- (+ (* vector-data-offset n-word-bytes)
                         (* ,offset ,scale))
                      other-pointer-lowtag)))
-
+
 ;;;; macros to generate useful values
 
 (defmacro load-symbol (reg symbol)
@@ -162,7 +162,7 @@
   "Loads the type bits of a pointer into target independent of
    byte-ordering issues."
   `(inst mov ,target (make-ea :byte :base ,source :disp ,offset)))
-
+
 ;;;; error code
 (defun emit-error-break (vop kind code values)
   (assemble ()
@@ -181,7 +181,7 @@
       (emit-error-break vop error-trap (error-number-or-lose error-code) values)
       start-lab)))
 
-
+
 ;;;; PSEUDO-ATOMIC
 
 ;;; This is used to wrap operations which leave untagged memory lying
@@ -232,7 +232,7 @@
          ;; trap instead.  Let's take the opportunity to trigger that
          ;; safepoint right now.
          (emit-safepoint)))))
-
+
 ;;;; indexed references
 
 (defmacro define-full-compare-and-swap

--- a/src/compiler/x86/move.lisp
+++ b/src/compiler/x86/move.lisp
@@ -53,7 +53,7 @@
    (signed-reg) (signed-stack)
    (unsigned-reg) (unsigned-stack))
   (inst mov y x))
-
+
 ;;;; the MOVE VOP
 (define-vop (move)
   (:args (x :scs (any-reg descriptor-reg immediate) :target y
@@ -109,7 +109,7 @@
 (define-move-vop move-arg :move-arg
   (any-reg descriptor-reg)
   (any-reg descriptor-reg))
-
+
 ;;;; moves and coercions
 
 ;;; These MOVE-TO-WORD VOPs move a tagged integer to a raw full-word

--- a/src/compiler/x86/nlx.lisp
+++ b/src/compiler/x86/nlx.lisp
@@ -25,7 +25,7 @@
   (make-ea :dword :base ebp-tn
            :disp (frame-byte-offset (+ -1 (tn-offset tn) unwind-block-size))))
 
-
+
 ;;;; Save and restore dynamic environment.
 ;;;;
 ;;;; These VOPs are used in the reentered function to restore the
@@ -59,7 +59,7 @@
   (:results (res :scs (any-reg descriptor-reg)))
   (:generator 1
     (load-binding-stack-pointer res)))
-
+
 ;;;; unwind block hackery
 
 ;;; Compute the address of the catch block from its TN, then store into the
@@ -144,7 +144,7 @@
       (inst mov (make-ea :dword :disp 0) seh-frame :fs))
     (loadw block block unwind-block-uwp-slot)
     (store-tl-symbol-value block *current-unwind-protect-block* tls)))
-
+
 ;;;; NLX entry VOPs
 (define-vop (nlx-entry)
   ;; Note: we can't list an sc-restriction, 'cause any load vops would

--- a/src/compiler/x86/parms.lisp
+++ b/src/compiler/x86/parms.lisp
@@ -51,7 +51,7 @@
 ;;; are talking about stuff the rest of the lisp system might be
 ;;; interested in, we use ``word'' to mean the size of a descriptor
 ;;; object, which is 32 bits.
-
+
 ;;;; machine architecture parameters
 
 ;;; the number of bits per word, where a word holds one lisp descriptor
@@ -123,7 +123,7 @@
 (defconstant-eqx float-exceptions-byte   (byte 6 16) #'equalp)
 (defconstant-eqx float-precision-control (byte 2  8) #'equalp)
 (defconstant float-fast-bit 0) ; no fast mode on x86
-
+
 ;;;; description of the target address space
 
 ;;; where to put the different spaces
@@ -202,7 +202,7 @@
 
 ;;; Size of one linkage-table entry in bytes.
 (defconstant linkage-table-entry-size 8)
-
+
 
 (defenum (:start 8)
   halt-trap
@@ -216,7 +216,7 @@
   #+sb-safepoint global-safepoint-trap
   #+sb-safepoint csp-safepoint-trap
   error-trap)
-
+
 ;;;; static symbols
 
 ;;; These symbols are loaded into static space directly after NIL so
@@ -273,6 +273,6 @@
     two-arg-lcm
     %coerce-callable-to-fun)
   #'equalp)
-
+
 #+win32
 (defconstant +win32-tib-arbitrary-field-offset+ #.(+ #xE10 (* 4 63)))

--- a/src/compiler/x86/pred.lisp
+++ b/src/compiler/x86/pred.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; the branch VOP
 
 ;;; The unconditional branch, emitted when we can't drop through to the desired
@@ -20,7 +20,7 @@
   (:generator 5
     (inst jmp dest)))
 
-
+
 ;;;; Generic conditional VOPs
 
 ;;; The generic conditional branch, emitted immediately after test
@@ -157,7 +157,7 @@
   (def-move-if move-if/char character character-reg character-stack)
   (def-move-if move-if/sap system-area-pointer sap-reg sap-stack))
 
-
+
 ;;;; conditional VOPs
 
 ;;; Note: a constant-tn is allowed in CMP; it uses an EA displacement,

--- a/src/compiler/x86/sap.lisp
+++ b/src/compiler/x86/sap.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; moves and coercions
 
 ;;; Move a tagged SAP to an untagged representation.
@@ -71,7 +71,7 @@
 ;;; descriptor passing location.
 (define-move-vop move-arg :move-arg
   (sap-reg) (descriptor-reg))
-
+
 ;;;; SAP-INT and INT-SAP
 
 ;;; The function SAP-INT is used to generate an integer corresponding
@@ -98,7 +98,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move sap int)))
-
+
 ;;;; POINTER+ and POINTER-
 
 (define-vop (pointer+)
@@ -139,7 +139,7 @@
   (:generator 1
     (move res ptr1)
     (inst sub res ptr2)))
-
+
 ;;;; mumble-SYSTEM-REF and mumble-SYSTEM-SET
 
 (macrolet ((def-system-ref-and-set (ref-name
@@ -226,7 +226,7 @@
     sap-reg system-area-pointer :dword)
   (def-system-ref-and-set sb-c::sap-ref-lispobj-with-offset sb-c::%set-sap-ref-lispobj-with-offset
     descriptor-reg * :dword))
-
+
 ;;;; SAP-REF-DOUBLE
 
 (define-vop (sap-ref-double-with-offset)
@@ -313,7 +313,7 @@
                   (unless (location= value result)
                     (inst fstd result))
                   (inst fxch value)))))))
-
+
 ;;;; SAP-REF-SINGLE
 
 (define-vop (sap-ref-single-with-offset)
@@ -399,7 +399,7 @@
                   (unless (location= value result)
                     (inst fst result))
                   (inst fxch value)))))))
-
+
 ;;;; SAP-REF-LONG
 
 (define-vop (sap-ref-long)
@@ -455,7 +455,7 @@
                   (unless (location= value result)
                     (inst fstd result))
                   (inst fxch value)))))))
-
+
 ;;; noise to convert normal lisp data objects into SAPs
 
 (define-vop (vector-sap)

--- a/src/compiler/x86/subprim.lisp
+++ b/src/compiler/x86/subprim.lisp
@@ -11,7 +11,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; LENGTH
 
 (define-vop (length/list)

--- a/src/compiler/x86/system.lisp
+++ b/src/compiler/x86/system.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; type frobbing VOPs
 
 (define-vop (widetag-of)
@@ -67,7 +67,7 @@
     (inst movzx result (make-ea :byte :base object
                                       :disp (- other-pointer-lowtag)))))
 
-
+
 (define-vop (fun-subtype)
   (:translate fun-subtype)
   (:policy :fast-safe)
@@ -113,7 +113,7 @@
     (load-type al-tn x (- other-pointer-lowtag))
     (storew eax x 0 other-pointer-lowtag)
     (move res x)))
-
+
 (define-vop (pointer-hash)
   (:translate pointer-hash)
   (:args (ptr :scs (any-reg descriptor-reg) :target res))
@@ -125,7 +125,7 @@
     ;; fixnum.
     (inst and res (lognot lowtag-mask))
     (inst shr res 1)))
-
+
 ;;;; allocation
 
 (define-vop (binding-stack-pointer-sap)
@@ -143,7 +143,7 @@
   (:policy :fast-safe)
   (:generator 1
     (move int esp-tn)))
-
+
 ;;;; code object frobbing
 
 (define-vop (code-instructions)
@@ -250,7 +250,7 @@
     (inst mov temp nil-value)
     (emit-optimized-test-inst res fixnum-tag-mask)
     (inst cmov :e res temp)))
-
+
 ;;;; other miscellaneous VOPs
 
 (defknown sb-unix::receive-pending-interrupt () (values))
@@ -305,7 +305,7 @@
   (:generator 1
     (note-next-instruction vop :internal-error)
     (inst wait)))
-
+
 ;;;; Miscellany
 
 ;;; the RDTSC instruction (present on Pentium processors and
@@ -375,7 +375,7 @@ number of CPU cycles elapsed as secondary value. EXPERIMENTAL."
   (:info index)
   (:generator 0
     (inst inc (make-ea-for-vector-data count-vector :offset index))))
-
+
 ;;;; Memory barrier support
 
 (define-vop (%compiler-barrier)

--- a/src/compiler/x86/type-vops.lisp
+++ b/src/compiler/x86/type-vops.lisp
@@ -10,7 +10,7 @@
 ;;;; files for more information.
 
 (in-package "SB-VM")
-
+
 ;;;; test generation utilities
 
 (defun generate-fixnum-test (value)
@@ -159,14 +159,14 @@
                         (inst cmp al-tn (- end start))
                         (inst jmp less-or-equal target))))))))))))
       (emit-label drop-through))))
-
+
 ;;; simpler VOP that don't need a temporary register
 (define-vop (simple-type-predicate)
   (:args (value :scs (any-reg descriptor-reg control-stack)))
   (:conditional)
   (:info target not-p)
   (:policy :fast-safe))
-
+
 ;;;; other integer ranges
 
 (define-vop (fixnump/unsigned-byte-32 simple-type-predicate)
@@ -318,7 +318,7 @@
        (inst jmp (if not-p :a :be) target)
        (emit-label skip))))
 
-
+
 ;;;; list/symbol types
 ;;;
 ;;; symbolp (or symbol (eq nil))

--- a/src/compiler/x86/vm.lisp
+++ b/src/compiler/x86/vm.lisp
@@ -92,7 +92,7 @@
   (eval-when (:compile-toplevel :load-toplevel :execute)
     (defparameter *register-arg-names* '(edx edi esi)))
   (defregset    *register-arg-offsets* edx edi esi))
-
+
 ;;;; SB definitions
 
 (!define-storage-bases
@@ -117,7 +117,7 @@
 (define-storage-base immediate-constant :non-packed)
 (define-storage-base noise :unbounded :size 2)
 )
-
+
 ;;;; SC definitions
 
 (eval-when (:compile-toplevel :execute)
@@ -310,7 +310,7 @@
                          (#.*double-sc-names*  :double))))
                   (append class-spec (if size (list :operand-size size)))))
               *storage-class-defs*))
-
+
 ;;;; miscellaneous TNs for the various registers
 
 (macrolet ((def-misc-reg-tns (sc-name &rest reg-names)
@@ -342,7 +342,7 @@
                   :sc (sc-or-lose 'fp-constant)
                   :offset 31))          ; Offset doesn't get used.
 |#
-
+
 ;;; If value can be represented as an immediate constant, then return
 ;;; the appropriate SC number, otherwise return NIL.
 (defun immediate-constant-sc (value)
@@ -387,7 +387,7 @@
           (character (logior (ash (char-code val) n-widetag-bits)
                              character-widetag))))
       tn))
-
+
 ;;;; miscellaneous function call parameters
 
 ;;; Offsets of special stack frame locations relative to EBP.
@@ -423,7 +423,7 @@
 
 ;;; This is used by the debugger.
 (defconstant single-value-return-byte-offset 2)
-
+
 ;;; This function is called by debug output routines that want a pretty name
 ;;; for a TN's location. It returns a thing that can be printed with PRINC.
 (defun location-print-name (tn)

--- a/src/compiler/xref.lisp
+++ b/src/compiler/xref.lisp
@@ -160,7 +160,7 @@
   (unless (internal-name-p what)
     (push (list :calls what path) (block-xrefs block))))
 
-
+
 ;;;; Packing of xref tables
 ;;;;
 ;;;; xref information can be transformed into the following "packed"

--- a/src/pcl/boot.lisp
+++ b/src/pcl/boot.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 #|
 
 The CommonLoops evaluator is meta-circular.
@@ -247,7 +247,7 @@ bootstrapping.
       (generic-function short-method-combination t)
       ()
       short-compute-effective-method))))
-
+
 (defmacro defgeneric (fun-name lambda-list &body options)
   (declare (type list lambda-list))
   (check-designator fun-name defgeneric)
@@ -420,7 +420,7 @@ bootstrapping.
             form.~@:>"
            context method-lambda))
   method-lambda)
-
+
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (fmakunbound 'defmethod))
 ;;; As per CLHS -
@@ -511,7 +511,7 @@ bootstrapping.
           (t
             (class-prototype (or (generic-function-method-class gf?)
                                  (find-class 'standard-method)))))))
-
+
 ;;; These are used to communicate the method name and lambda-list to
 ;;; MAKE-METHOD-LAMBDA-INTERNAL.
 (defvar *method-name* nil)
@@ -1407,7 +1407,7 @@ bootstrapping.
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defvar *allow-emf-call-tracing-p* nil)
   (defvar *enable-emf-call-tracing-p* #-sb-show nil #+sb-show t))
-
+
 ;;;; effective method functions
 
 (defvar *emf-call-trace-size* 200)
@@ -1587,7 +1587,7 @@ bootstrapping.
                  (clos-slots-ref slots (fast-instance-boundp-index emf)))))))
     (function
      (apply emf args))))
-
+
 
 (defmacro fast-call-next-method-body ((args next-method-call rest-arg)
                                       method-cell
@@ -1848,7 +1848,7 @@ bootstrapping.
        (if (eq **boot-state** 'complete)
            (standard-generic-function-p (gdefinition name))
            (funcallable-instance-p (gdefinition name)))))
-
+
 (defun method-plist-value (method key &optional default)
   (let ((plist (if (consp method)
                    (getf (early-method-initargs method) 'plist)
@@ -1860,7 +1860,7 @@ bootstrapping.
       (setf (getf (getf (early-method-initargs method) 'plist) key default)
             new-value)
       (setf (getf (object-plist method) key default) new-value)))
-
+
 (defun load-defmethod (class name quals specls ll initargs source-location)
   (let ((method-cell (getf initargs 'method-cell)))
     (setq initargs (copy-tree initargs))
@@ -1930,7 +1930,7 @@ bootstrapping.
           (when snl
             (setf (method-plist-value method :pv-table)
                   (intern-pv-table :slot-name-lists snl))))))))
-
+
 (defun analyze-lambda-list (lambda-list)
   (multiple-value-bind (llks required optional rest keywords)
       ;; We say "&MUMBLE is not allowed in a generic function lambda list"
@@ -1977,7 +1977,7 @@ bootstrapping.
                                     (when (or (ll-kwds-allowp llks) old-allowp)
                                       '(&allow-other-keys)))))
                  *))))
-
+
 ;;;; early generic function support
 
 (defvar *!early-generic-functions* ())
@@ -2555,7 +2555,7 @@ bootstrapping.
                 (apply #'make-instance generic-function-class
                        :name fun-name initargs))
         (note-gf-signature fun-name lambda-list-p lambda-list)))))
-
+
 (defun safe-gf-arg-info (generic-function)
   (if (eq (class-of generic-function) *the-class-standard-generic-function*)
       (clos-slots-ref (fsc-instance-slots generic-function)
@@ -2895,7 +2895,7 @@ bootstrapping.
             (set-methods gf (mapcar #'make-method methods)))))
 
   (/show "leaving !FIX-EARLY-GENERIC-FUNCTIONS"))
-
+
 ;;; PARSE-DEFMETHOD is used by DEFMETHOD to parse the &REST argument
 ;;; into the 'real' arguments. This is where the syntax of DEFMETHOD
 ;;; is really implemented.
@@ -2920,7 +2920,7 @@ bootstrapping.
   (flet ((unparse (spec)
            (unparse-specializer-using-class generic-function spec)))
     (mapcar #'unparse specializers)))
-
+
 (macrolet ((def (n name)
              `(defun ,name (lambda-list)
                 (nth-value ,n (parse-specialized-lambda-list lambda-list)))))
@@ -2968,9 +2968,9 @@ bootstrapping.
                             key))
             (make-lambda-list llks nil required optional rest key aux)
             specializers)))
-
+
 (setq **boot-state** 'early)
-
+
 ;;; FIXME: In here there was a #-CMU definition of SYMBOL-MACROLET
 ;;; which used %WALKER stuff. That suggests to me that maybe the code
 ;;; walker stuff was only used for implementing stuff like that; maybe

--- a/src/pcl/braid.lisp
+++ b/src/pcl/braid.lisp
@@ -30,7 +30,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 (defun allocate-standard-instance (wrapper)
   (let ((instance (%make-standard-instance
                    (make-array (layout-length wrapper)
@@ -110,7 +110,7 @@
                   (sort instance-slots #'< :key #'slot-definition-location)))
             class-slots
             custom-slots)))
-
+
 ;;;; BOOTSTRAP-META-BRAID
 ;;;;
 ;;;; This function builds the base metabraid from the early class definitions.
@@ -575,7 +575,7 @@
                                        supers subs
                                        (cons name cpl)
                                        wrapper prototype))))))
-
+
 (defun class-of (x)
   (declare (explicit-check))
   (wrapper-class* (layout-of x)))
@@ -631,7 +631,7 @@
 
 (pushnew 'ensure-deffoo-class sb-kernel::*defstruct-hooks*)
 (pushnew 'ensure-deffoo-class sb-kernel::*define-condition-hooks*)
-
+
 (defun !make-class-predicate (class name source-location)
   (let* ((gf (ensure-generic-function name :lambda-list '(object)
                                       'source source-location))

--- a/src/pcl/combin.lisp
+++ b/src/pcl/combin.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 (defun get-method-function (method &optional method-alist wrappers)
   (let ((fn (cadr (assoc method method-alist))))
     (if fn
@@ -566,7 +566,7 @@
             (t
              `(call-method ,(car around)
                            (,@(cdr around) (make-method ,main-method))))))))
-
+
 ;;; helper code for checking keywords in generic function calls.
 (defun compute-applicable-keywords (gf methods)
   (let ((any-keyp nil))
@@ -625,7 +625,7 @@
                ((eq t valid-keys))
                ((not (memq key valid-keys)) (invalid key))))
            (incf i))))))
-
+
 ;;;; the STANDARD method combination type. This is coded by hand
 ;;;; (rather than with DEFINE-METHOD-COMBINATION) for bootstrapping
 ;;;; and efficiency reasons. Note that the definition of the

--- a/src/pcl/compiler-support.lisp
+++ b/src/pcl/compiler-support.lisp
@@ -30,7 +30,7 @@
 ;;;; specification.
 
 (in-package "SB-C")
-
+
 ;;;; very low-level representation of instances with meta-class
 ;;;; STANDARD-CLASS
 

--- a/src/pcl/cpl.lisp
+++ b/src/pcl/cpl.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;;; COMPUTE-CLASS-PRECEDENCE-LIST and friends
 
 ;;; Knuth section 2.2.3 has some interesting notes on this.
@@ -190,7 +190,7 @@
       (dolist (after (cpd-after next-cpd))
         (when (zerop (decf (cpd-count after)))
           (push after candidates))))))
-
+
 ;;;; support code for signalling nice error messages
 
 (defun cpl-error (class format-string &rest format-args)

--- a/src/pcl/ctor.lisp
+++ b/src/pcl/ctor.lisp
@@ -113,7 +113,7 @@
           into default-initargs
         finally
           (return (append supplied-initargs default-initargs))))
-
+
 ;;; *****************
 ;;; CTORS   *********
 ;;; *****************
@@ -204,7 +204,7 @@
     (install-initial-constructor ctor :force-p t)
     (setf (gethash function-name *all-ctors*) ctor)
     ctor))
-
+
 ;;; *****************
 ;;; Inline CTOR cache
 ;;; *****************
@@ -408,7 +408,7 @@
                        (declare (notinline allocate-instance))
                        (allocate-instance class))
                      store)))))))
-
+
 ;;; ***********************************************
 ;;; Compile-Time Expansion of MAKE-INSTANCE *******
 ;;; ***********************************************
@@ -530,7 +530,7 @@
           ((and class-arg (not (constantp class-arg)))
            (make-ctor-inline-cache-form
             'ensure-cached-ctor class-arg `(',initargs ',safe-code-p) value-forms)))))))
-
+
 ;;; **************************************************
 ;;; Load-Time Constructor Function Generation  *******
 ;;; **************************************************
@@ -1107,7 +1107,7 @@
                   (setq slots remaining-slots)
                   (return (cons key locations)))))
 
-
+
 ;;; *******************************
 ;;; External Entry Points  ********
 ;;; *******************************

--- a/src/pcl/ctypes.lisp
+++ b/src/pcl/ctypes.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;; The built-in method combination types as taken from page 1-31 of
 ;;; 88-002R. Note that the STANDARD method combination type is defined
 ;;; by hand in the file combin.lisp.

--- a/src/pcl/defclass.lisp
+++ b/src/pcl/defclass.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;;; DEFCLASS macro and close personal friends
 
 (declaim (global  *the-class-t*
@@ -313,7 +313,7 @@
              (push entry *initfunctions-for-this-defclass*))
            (cadr entry)))))
 
-
+
 ;;; This is the early definition of LOAD-DEFCLASS. It just collects up
 ;;; all the class definitions in a list. Later, in braid1.lisp, these
 ;;; are actually defined.

--- a/src/pcl/defcombin.lisp
+++ b/src/pcl/defcombin.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;; FIXME: according to ANSI 3.4.10 this is supposed to allow &WHOLE
 ;;; in the long syntax. But it clearly does not, because if you write
 ;;; (&WHOLE v) then you get (LAMBDA (&WHOLE V ...) ...) which is illegal
@@ -51,7 +51,7 @@
       (or (cdr (assoc options (method-combination-info-cache info) :test #'equal))
           (cdar (push (cons options (funcall (method-combination-info-constructor info) options))
                       (method-combination-info-cache info)))))))
-
+
 ;;;; standard method combination
 (setf (gethash 'standard **method-combinations**)
       (make-method-combination-info
@@ -76,7 +76,7 @@
                  (flush-effective-method-cache gf)
                  (reinitialize-instance gf)))
           (maphash #'flush gfs))))))
-
+
 ;;;; short method combinations
 ;;;;
 ;;;; Short method combinations all follow the same rule for computing the
@@ -156,7 +156,7 @@
       of DEFINE-METHOD-COMBINATION and so requires all methods have ~
       either ~{the single qualifier ~S~^ or ~}.~@:>"
      method gf why type-name (short-method-combination-qualifiers type-name))))
-
+
 ;;;; long method combinations
 
 (defun expand-long-defcombin (form)

--- a/src/pcl/defs.lisp
+++ b/src/pcl/defs.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;; (These are left over from the days when PCL was an add-on package
 ;;; for a pre-CLOS Common Lisp. They shouldn't happen in a normal
 ;;; build, of course, but they might happen if someone is experimenting
@@ -37,7 +37,7 @@
           "Trying to load (or compile) PCL in an environment in which it~%~
            has already been partially loaded. This may not work, you may~%~
            need to get a fresh lisp (reboot) and then load PCL."))
-
+
 #-sb-fluid (declaim (inline gdefinition))
 (defun gdefinition (spec)
   ;; This is null layer right now, but once FDEFINITION stops bypasssing
@@ -50,7 +50,7 @@
   ;; that here.
   (sb-c::note-name-defined spec :function) ; FIXME: do we need this? Why?
   (setf (fdefinition spec) new-value))
-
+
 ;;;; type specifier hackery
 
 ;;; internal to this file
@@ -164,7 +164,7 @@
 
 (defvar *standard-method-combination*)
 (defvar *or-method-combination*)
-
+
 (defun plist-value (object name)
   (getf (object-plist object) name))
 
@@ -174,7 +174,7 @@
       (progn
         (remf (object-plist object) name)
         nil)))
-
+
 ;;;; built-in classes
 
 ;;; Grovel over SB-KERNEL::+!BUILT-IN-CLASSES+ in order to set
@@ -222,7 +222,7 @@
                                      file-stream string-stream)))
                        sb-kernel::+!built-in-classes+))))
 (/noshow "done setting up SB-PCL::*BUILT-IN-CLASSES*")
-
+
 ;;;; the classes that define the kernel of the metabraid
 
 (defclass t () ()

--- a/src/pcl/dfun.lisp
+++ b/src/pcl/dfun.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 #|
 
 This implementation of method lookup was redone in early August of 89.
@@ -78,7 +78,7 @@ And so, we are saved.
 Except see also BREAK-VICIOUS-METACIRCLE.  -- CSR, 2003-05-28
 
 |#
-
+
 ;;; an alist in which each entry is of the form
 ;;;   (<generator> . (<subentry> ...)).
 ;;; Each subentry is of the form
@@ -172,7 +172,7 @@ Except see also BREAK-VICIOUS-METACIRCLE.  -- CSR, 2003-05-28
                                  (car args-entry)))
                        collect))))
            (nreverse collect)))))
-
+
 ;;; Standardized class slot access: when trying to break vicious
 ;;; metacircles, we need a way to get at the values of slots of some
 ;;; standard classes without going through the whole meta machinery,
@@ -238,7 +238,7 @@ Except see also BREAK-VICIOUS-METACIRCLE.  -- CSR, 2003-05-28
 
 (defun standard-slot-value/class (class slot-name)
   (standard-slot-value class slot-name *the-class-standard-class*))
-
+
 ;;; When all the methods of a generic function are automatically
 ;;; generated reader or writer methods a number of special
 ;;; optimizations are possible. These are important because of the
@@ -374,7 +374,7 @@ Except see also BREAK-VICIOUS-METACIRCLE.  -- CSR, 2003-05-28
        (accessor-miss gf new arg dfun-info)))))
 
 #-sb-fluid (declaim (sb-ext:freeze-type dfun-info))
-
+
 (defun make-one-class-accessor-dfun (gf type wrapper index)
   (let ((emit (ecase type
                 (reader 'emit-one-class-reader)
@@ -493,7 +493,7 @@ Except see also BREAK-VICIOUS-METACIRCLE.  -- CSR, 2003-05-28
              (if (early-gf-p generic-function)
                  (early-gf-methods generic-function)
                  (generic-function-methods generic-function)))))
-
+
 (defun make-caching-dfun (generic-function &optional cache)
   (unless cache
     (when (use-constant-value-dfun-p generic-function)
@@ -700,7 +700,7 @@ Except see also BREAK-VICIOUS-METACIRCLE.  -- CSR, 2003-05-28
                     (make-cache :key-count nkeys :value (not (null valuep))
                                 :size 4))))
     (make-emf-cache generic-function valuep cache classes-list new-class)))
-
+
 (defvar *dfun-miss-gfs-on-stack* ())
 
 (defmacro dfun-miss ((gf args wrappers invalidp nemf
@@ -1005,7 +1005,7 @@ Except see also BREAK-VICIOUS-METACIRCLE.  -- CSR, 2003-05-28
           (unless (eq ncache ocache)
             (dfun-update generic-function
                          #'make-constant-value-dfun ncache)))))))
-
+
 ;;; Given a generic function and a set of arguments to that generic
 ;;; function, return a mess of values.
 ;;;
@@ -1600,7 +1600,7 @@ Except see also BREAK-VICIOUS-METACIRCLE.  -- CSR, 2003-05-28
                     (find-class root)
                     root)))
     nil))
-
+
 ;;; Not synchronized, as all the uses we have for it are multiple ones
 ;;; and need WITH-LOCKED-SYSTEM-TABLE in any case.
 ;;;
@@ -1699,7 +1699,7 @@ Except see also BREAK-VICIOUS-METACIRCLE.  -- CSR, 2003-05-28
          (when (dolist (spec (method-specializers method) nil)
                  (when (eql-specializer-p spec) (return t)))
            (return t)))))
-
+
 (defun update-dfun (generic-function &optional dfun cache info)
   (let ((early-p (early-gf-p generic-function)))
     (flet ((update ()
@@ -1737,7 +1737,7 @@ Except see also BREAK-VICIOUS-METACIRCLE.  -- CSR, 2003-05-28
             ;; case there are, better fetch it while interrupts are
             ;; still enabled...
             (sb-thread::call-with-recursive-system-lock #'update lock))))))
-
+
 ;;; These functions aren't used in SBCL, or documented anywhere that
 ;;; I'm aware of, but they look like they might be useful for
 ;;; debugging or performance tweaking or something, so I've just

--- a/src/pcl/dlisp.lisp
+++ b/src/pcl/dlisp.lisp
@@ -102,7 +102,7 @@
 
 (defun make-fast-method-call-lambda-list (nargs applyp)
   (list* '.pv. '.next-method-call. (make-dfun-lambda-list nargs applyp)))
-
+
 ;;; Emitting various accessors.
 
 (defun emit-one-class-reader (class-slot-p)

--- a/src/pcl/dlisp3.lisp
+++ b/src/pcl/dlisp3.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;; Rather than compiling the constructors here, just tickle the range
 ;;; of shapes defined above, leaving the generation of the
 ;;; constructors to precompile-dfun-constructors.

--- a/src/pcl/documentation.lisp
+++ b/src/pcl/documentation.lisp
@@ -260,7 +260,7 @@
 
 (defmethod (setf documentation) (new-value (x symbol) (doc-type (eql 'setf)))
   (setf (%doc-info x 'setf) new-value))
-
+
 ;;; method combinations
 (defmethod documentation ((x method-combination) (doc-type (eql 't)))
   (slot-value x '%documentation))
@@ -283,7 +283,7 @@
 (defmethod (setf documentation)
     (new-value (x symbol) (doc-type (eql 'method-combination)))
   (setf (random-documentation x 'method-combination) new-value))
-
+
 ;;; methods
 (defmethod documentation ((x standard-method) (doc-type (eql 't)))
   (slot-value x '%documentation))
@@ -291,7 +291,7 @@
 (defmethod (setf documentation)
     (new-value (x standard-method) (doc-type (eql 't)))
   (setf (slot-value x '%documentation) new-value))
-
+
 ;;; types, classes, and structure names
 
 (macrolet
@@ -349,7 +349,7 @@
   (define-type-documentation-lookup-methods type)
   (define-type-documentation-lookup-methods structure))
 
-
+
 ;;; variables
 (defmethod documentation ((x symbol) (doc-type (eql 'variable)))
   (values (info :variable :documentation x)))
@@ -368,7 +368,7 @@
     (new-value (slotd standard-slot-definition) (doc-type (eql 't)))
   (declare (ignore doc-type))
   (setf (slot-value slotd '%documentation) new-value))
-
+
 ;;; Now that we have created the machinery for setting documentation, we can
 ;;; set the documentation for the machinery for setting documentation.
 (setf (documentation 'documentation 'function)

--- a/src/pcl/early-low.lisp
+++ b/src/pcl/early-low.lisp
@@ -29,7 +29,7 @@
 (declaim (type (member nil early braid complete) **boot-state**))
 (define-load-time-global **boot-state** nil)
 
-
+
 ;;; The PCL package is internal and is used by code in potential
 ;;; bottlenecks. And since it's internal, no one should be
 ;;; doing things like deleting and recreating it in a running target Lisp.
@@ -69,7 +69,7 @@
 (defun condition-type-p (type)
   (and (symbolp type)
        (condition-classoid-p (find-classoid type nil))))
-
+
 ;;;; PCL instances
 
 (sb-kernel::!defstruct-with-alternate-metaclass standard-instance

--- a/src/pcl/env.lisp
+++ b/src/pcl/env.lisp
@@ -24,7 +24,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;; FIXME: This stuff isn't part of the ANSI spec, and isn't even
 ;;; exported from PCL, but it looks as though it might be useful,
 ;;; so I don't want to just delete it. Perhaps it should go in
@@ -136,7 +136,7 @@
   (eval `(trace ,name ,@options))
   (fdefinition name))
 |#
-
+
 #|
 ;;;; Helper for slightly newer trace implementation, based on
 ;;;; breakpoint stuff.  The above is potentially still useful, so it's
@@ -150,7 +150,7 @@
         (push spec result)
         (push (list* 'fast-method (cdr spec)) result)))))
 |#
-
+
 ;;;; MAKE-LOAD-FORM
 
 ;; Overwrite the old bootstrap non-generic MAKE-LOAD-FORM function with a

--- a/src/pcl/fngen.lisp
+++ b/src/pcl/fngen.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;; GET-FUN is the main user interface to this code. It is like
 ;;; COMPILE, only more efficient. It achieves this efficiency by
 ;;; reducing the number of times that the compiler needs to be called.
@@ -76,7 +76,7 @@
   (if (default-constantp form)
       (list (constant-form-value form))
       nil))
-
+
 (defstruct (fgen (:constructor make-fgen (gensyms generator generator-lambda system))
                  (:copier nil))
   gensyms
@@ -102,7 +102,7 @@
 
 (defun lookup-fgen (test)
   (gethash test *fgens*))
-
+
 (defun get-fun-generator (lambda test-converter code-converter)
   (let* ((test (compute-test lambda test-converter))
          (fgen (lookup-fgen test)))
@@ -163,7 +163,7 @@
                              (values f t))
                            f)))))
     collect))
-
+
 (defmacro precompile-function-generators (&optional system)
   (let (collect)
     (with-locked-system-table (*fgens*)

--- a/src/pcl/fsc.lisp
+++ b/src/pcl/fsc.lisp
@@ -32,7 +32,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 (defmethod wrapper-fetcher ((class funcallable-standard-class))
   '%funcallable-instance-layout)
 

--- a/src/pcl/generic-functions.lisp
+++ b/src/pcl/generic-functions.lisp
@@ -7,7 +7,7 @@
 ;;;; warranty. See the COPYING and CREDITS files for more information.
 
 (in-package "SB-PCL")
-
+
 ;;;; readers
 
 (defgeneric accessor-method-slot-definition (standard-accessor-method))
@@ -101,7 +101,7 @@
 (defgeneric specializer-object (class-eq-specializer))
 
 (defgeneric specializer-type (specializer))
-
+
 ;;;; writers
 
 (defgeneric (setf class-defstruct-constructor) (new-value structure-class))
@@ -174,7 +174,7 @@
   (new-value effective-slot-definition))
 
 (defgeneric (setf slot-definition-writers) (new-value slot-definition))
-
+
 ;;;; 1 argument
 
 (defgeneric accessor-method-slot-name (m))
@@ -246,7 +246,7 @@
 (defgeneric update-constructors (class))
 
 (defgeneric wrapper-fetcher (class))
-
+
 ;;;; 2 arguments
 
 (defgeneric add-dependent (metaobject dependent))
@@ -335,7 +335,7 @@ protocol. Interface subject to change."))
 
 (defgeneric invalid-superclass (class superclass))
 
-
+
 ;;;; 3 arguments
 
 (defgeneric (setf class-slot-value) (nv class slot-name))
@@ -395,7 +395,7 @@ not be declared, for example for efficiency reasons.
 
 NOTE: This generic function is part of an SBCL-specific experimental
 protocol. Interface subject to change."))
-
+
 ;;;; 4 arguments
 
 (defgeneric make-method-lambda
@@ -449,7 +449,7 @@ NOTE: This generic function is part of an SBCL-specific experimental
 protocol. Interface subject to change."))
 
 (defgeneric (setf slot-value-using-class) (new-value class object slotd))
-
+
 ;;;; 5 arguments
 
 ;;; FIXME: This is currently unused -- where should we call it? Or should we just
@@ -463,7 +463,7 @@ protocol. Interface subject to change."))
 (defgeneric make-method-initargs-form
     (proto-generic-function proto-method lambda-expression lambda-list
      environment))
-
+
 ;;;; 6 arguments
 
 (defgeneric make-method-lambda-using-specializers
@@ -488,7 +488,7 @@ Return three values:
 
 NOTE: This generic function is part of an SBCL-specific experimental
 protocol. Interface subject to change."))
-
+
 ;;;; optional arguments
 
 (defgeneric get-method (generic-function
@@ -506,7 +506,7 @@ protocol. Interface subject to change."))
                           slot-name
                           operation
                           &optional new-value))
-
+
 ;;;; &KEY arguments
 
 ;;; FIXME: make the declared &KEY arguments here agree with those that

--- a/src/pcl/gray-streams-class.lisp
+++ b/src/pcl/gray-streams-class.lisp
@@ -9,7 +9,7 @@
 ;;;; warranty. See the COPYING and CREDITS files for more information.
 
 (in-package "SB-GRAY")
-
+
 (defclass fundamental-stream (standard-object stream)
   ((open-p :initform t :accessor stream-open-p))
   (:documentation "Base class for all Gray streams."))
@@ -48,7 +48,7 @@ is a subtype of unsigned-byte or signed-byte."))
     (fundamental-output-stream fundamental-binary-stream) nil
   (:documentation "Superclass of all Gray output streams whose element-type
 is a subtype of unsigned-byte or signed-byte."))
-
+
 ;;; This is not in the Gray stream proposal, so it is left here
 ;;; as example code.
 ;;;

--- a/src/pcl/gray-streams.lisp
+++ b/src/pcl/gray-streams.lisp
@@ -30,7 +30,7 @@
      should go to the mailing lists referenced from ~
      <http://www.sbcl.org/>).~@:>"
    stream fun))
-
+
 (fmakunbound 'stream-element-type)
 
 (defgeneric stream-element-type (stream)
@@ -50,7 +50,7 @@
 
 (defmethod stream-element-type ((non-stream t))
   (error 'type-error :datum non-stream :expected-type 'stream))
-
+
 (fmakunbound 'open-stream-p)
 
 (defgeneric open-stream-p (stream)
@@ -70,7 +70,7 @@
 
 (defmethod open-stream-p ((non-stream t))
   (error 'type-error :datum non-stream :expected-type 'stream))
-
+
 (fmakunbound 'close)
 
 (defgeneric close (stream &key abort)
@@ -86,7 +86,7 @@
   (declare (ignore abort))
   (setf (stream-open-p stream) nil)
   t)
-
+
 (let ()
   (fmakunbound 'input-stream-p)
 
@@ -107,7 +107,7 @@
 
   (defmethod input-stream-p ((non-stream t))
     (error 'type-error :datum non-stream :expected-type 'stream)))
-
+
 (let ()
   (fmakunbound 'interactive-stream-p)
 
@@ -125,7 +125,7 @@
 
   (defmethod interactive-stream-p ((non-stream t))
     (error 'type-error :datum non-stream :expected-type 'stream)))
-
+
 (let ()
   (fmakunbound 'output-stream-p)
 
@@ -146,7 +146,7 @@
 
   (defmethod output-stream-p ((non-stream t))
     (error 'type-error :datum non-stream :expected-type 'stream)))
-
+
 ;;; character input streams
 ;;;
 ;;; A character input stream can be created by defining a class that
@@ -271,7 +271,7 @@
        (aver (not recursive-p))
        (stream-read-byte stream)))))
 
-
+
 ;;; character output streams
 ;;;
 ;;; A character output stream can be created by defining a class that
@@ -438,7 +438,7 @@
      seq stream start end stream-element-mode
      #'ill-out #'stream-write-byte)))
 
-
+
 ;;; binary streams
 ;;;
 ;;; Binary streams can be created by defining a class that includes
@@ -478,7 +478,7 @@
   (declare (ignore stream position-spec))
   nil)
 
-
+
 ;;; This is not in the Gray stream proposal, so it is left here
 ;;; as example code.
 #|
@@ -516,7 +516,7 @@
 
 (defmethod stream-clear-output ((stream character-output-stream))
   (clear-output (character-output-stream-lisp-stream stream)))
-
+
 ;;; example character input stream encapsulating a lisp-stream
 
 (defun make-character-input-stream (lisp-stream)

--- a/src/pcl/init.lisp
+++ b/src/pcl/init.lisp
@@ -24,7 +24,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 (defmethod make-instance ((class symbol) &rest initargs)
   (apply #'make-instance (find-class class) initargs))
 
@@ -268,7 +268,7 @@
                       (memq (slot-definition-name slotd) slot-names))
               (initialize-slot-from-initfunction class instance slotd))))
     instance))
-
+
 ;;; If initargs are valid return nil, otherwise signal an error.
 (defun check-initargs-1 (class initargs call-list
                          &optional (plist-p t) (error-p t))

--- a/src/pcl/low.lisp
+++ b/src/pcl/low.lisp
@@ -36,7 +36,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 (defmacro dotimes-fixnum ((var count &optional (result nil)) &body body)
   `(dotimes (,var (the fixnum ,count) ,result)
      (declare (fixnum ,var))
@@ -63,7 +63,7 @@
          (when (zerop ,drop-pos)
            (setf ,drops (random-fixnum)
                  ,drop-pos sb-vm:n-positive-fixnum-bits))))))
-
+
 (import 'sb-kernel:funcallable-instance-p) ; why?
 
 (defun set-funcallable-instance-function (fin new-value)
@@ -88,7 +88,7 @@
   `(truly-the simple-vector
               (%funcallable-instance-info
                ,fin ,(get-dsd-index standard-funcallable-instance clos-slots))))
-
+
 (declaim (inline clos-slots-ref (setf clos-slots-ref)))
 (declaim (ftype (function (simple-vector t) t) clos-slots-ref))
 (defun clos-slots-ref (slots index)
@@ -105,7 +105,7 @@
 (declaim (inline std-instance-p))
 (defun std-instance-p (x)
   (%instancep x))
-
+
 ;;; When given a funcallable instance, SET-FUN-NAME *must* side-effect
 ;;; that FIN to give it the name. When given any other kind of
 ;;; function SET-FUN-NAME is allowed to return a new function which is
@@ -144,7 +144,7 @@
                       (every #'symbolp (car (last new-name))))))
     (setf (fdefinition new-name) fun))
   fun)
-
+
 ;;; FIXME: probably no longer needed after init
 (defmacro precompile-random-code-segments (&optional system)
   `(progn
@@ -153,7 +153,7 @@
      (precompile-function-generators ,system)
      (precompile-dfun-constructors ,system)
      (precompile-ctors)))
-
+
 ;;; Return true of any object which is either a funcallable-instance,
 ;;; or an ordinary instance that is not a structure-object.
 ;;; This used to be implemented as (LAYOUT-FOR-STD-CLASS-P (LAYOUT-OF x))
@@ -203,7 +203,7 @@
     `(progn
        (aver (layout-for-std-class-p ,wrapper))
        ,wrapper)))
-
+
 ;;;; structure-instance stuff
 ;;;;
 ;;;; FIXME: Now that the code is SBCL-only, this extra layer of

--- a/src/pcl/macros.lisp
+++ b/src/pcl/macros.lisp
@@ -25,7 +25,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 (defglobal *optimize-speed*
   '(optimize (speed 3) (safety 0) (sb-ext:inhibit-warnings 3) (debug 0)))
 
@@ -54,7 +54,7 @@
                  (setq ,var (pop .dolist-carefully.))
                  ,@body)
                (,improper-list-handler)))))
-
+
 ;;;; FIND-CLASS
 ;;;;
 ;;;; This is documented in the CLOS specification.
@@ -109,7 +109,7 @@
                         (find-classoid-cell symbol)
                         errorp))
 
-
+
 (define-compiler-macro find-class (&whole form
                                    symbol &optional (errorp t) environment)
   (declare (ignore environment))
@@ -187,6 +187,6 @@
 
 (defmacro function-apply (form &rest args)
   `(apply (the function ,form) ,@args))
-
+
 (defun get-setf-fun-name (name)
   `(setf ,name))

--- a/src/pcl/methods.lisp
+++ b/src/pcl/methods.lisp
@@ -22,14 +22,14 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;; methods
 ;;;
 ;;; Methods themselves are simple inanimate objects. Most properties of
 ;;; methods are immutable, methods cannot be reinitialized. The following
 ;;; properties of methods can be changed:
 ;;;   METHOD-GENERIC-FUNCTION
-
+
 ;;; initialization
 ;;;
 ;;; Error checking is done in before methods. Because of the simplicity of
@@ -164,10 +164,10 @@
                                      &rest initargs &key ((method-cell method-cell)))
   (declare (ignore slot-names method-cell))
   (initialize-method-function initargs method))
-
+
 (define-load-time-global *the-class-standard-generic-function*
   (find-class 'standard-generic-function))
-
+
 (defmethod shared-initialize :before
            ((generic-function standard-generic-function)
             slot-names
@@ -211,7 +211,7 @@
            (initarg-error :method-combination
                           "not supplied"
                           "a method combination object")))))
-
+
 (defun find-generic-function (name &optional (errorp t))
   (let ((fun (and (fboundp name) (fdefinition name))))
     (cond
@@ -298,7 +298,7 @@
    ;; That one must be supplied as a pre-parsed #<EQL-SPECIALIZER> because if
    ;; not, we'd parse it into a specializer whose object is :X.
    (parse-specializers generic-function specializers) errorp t))
-
+
 ;;; Compute various information about a generic-function's arglist by looking
 ;;; at the argument lists of the methods. The hair for trying not to use
 ;;; &REST arguments lives here.
@@ -372,7 +372,7 @@
          (when restp
                `(&rest ,(format-symbol *package*
                                        "Discriminating Function &rest Arg")))))
-
+
 (defmethod generic-function-argument-precedence-order
     ((gf standard-generic-function))
   (aver (eq **boot-state** 'complete))
@@ -645,7 +645,7 @@
                             (update-dependent generic-function
                                               dep 'remove-method method)))))))
   generic-function)
-
+
 (defun compute-applicable-methods-function (generic-function arguments)
   (values (compute-applicable-methods-using-types
            generic-function
@@ -701,7 +701,7 @@
    (cons null)                          ; direct subclasses of list
    (string bit-vector)                  ; direct subclasses of vector
    ))
-
+
 (defmethod same-specializer-p ((specl1 specializer) (specl2 specializer))
   (eql specl1 specl2))
 
@@ -1464,7 +1464,7 @@
                                               types))
            (emf (get-effective-method-function generic-function smethods)))
       (invoke-emf emf args))))
-
+
 ;;; The value returned by compute-discriminating-function is a function
 ;;; object. It is called a discriminating function because it is called
 ;;; when the generic function is called and its role is to discriminate
@@ -1657,7 +1657,7 @@
 (defmethod compute-discriminating-function :around ((gf standard-generic-function))
   (maybe-encapsulate-discriminating-function
    gf (generic-function-encapsulations gf) (call-next-method)))
-
+
 (defmethod (setf class-name) (new-value class)
   (let ((classoid (layout-classoid (class-wrapper class))))
     (if (and new-value (symbolp new-value))
@@ -1669,7 +1669,7 @@
 (defmethod (setf generic-function-name) (new-value generic-function)
   (reinitialize-instance generic-function :name new-value)
   new-value)
-
+
 (defmethod function-keywords ((method standard-method))
   (multiple-value-bind (llks nreq nopt keywords)
       (analyze-lambda-list (if (consp method)
@@ -1677,7 +1677,7 @@
                                (method-lambda-list method)))
     (declare (ignore nreq nopt))
     (values keywords (ll-kwds-allowp llks))))
-
+
 ;;; This is based on the rules of method lambda list congruency
 ;;; defined in the spec. The lambda list it constructs is the pretty
 ;;; union of the lambda lists of the generic function and of all its

--- a/src/pcl/precom1.lisp
+++ b/src/pcl/precom1.lisp
@@ -22,6 +22,6 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;; (We used to pre-allocate generic function caches here, but we let
 ;;; the GC deal with that stuff these days)

--- a/src/pcl/print-object.lisp
+++ b/src/pcl/print-object.lisp
@@ -26,7 +26,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;;; the PRINT-OBJECT generic function
 
 ;;; Blow away the old non-generic function placeholder which was used
@@ -43,7 +43,7 @@
 (unless (sb-impl::!c-runtime-noinform-p)
   (write-string " done
 "))
-
+
 ;;;; PRINT-OBJECT methods for objects from PCL classes
 ;;;;
 

--- a/src/pcl/sequence.lisp
+++ b/src/pcl/sequence.lisp
@@ -8,7 +8,7 @@
 ;;;; more information.
 
 (in-package "SB-IMPL")
-
+
 ;;;; basic protocol
 (define-condition sequence:protocol-unimplemented (type-error
                                                    reference-condition)
@@ -152,7 +152,7 @@
    PROTOCOL-UNIMPLEMENTED error if the sequence protocol is not
    implemented for the class of SEQUENCE."))
 
-
+
 ;;;; iterator protocol
 
 ;;; The general protocol
@@ -448,7 +448,7 @@
 
 (defun sequence:canonize-key (key)
   (or (and key (if (functionp key) key (fdefinition key))) #'identity))
-
+
 ;;;; LOOP support.  (DOSEQUENCE support is present in the core SBCL
 ;;;; code).
 (defun sb-loop::loop-elements-iteration-path (variable data-type prep-phrases)
@@ -470,7 +470,7 @@
             (sb-loop::wrappers sb-loop::*loop*))
       `(((,variable nil ,data-type)) () () nil (funcall ,endp ,seq ,it ,lim ,f-e)
         (,variable (funcall ,elt ,seq ,it) ,it (funcall ,step ,seq ,it ,f-e))))))
-
+
 ;;;; generic implementations for sequence functions.
 
 (defgeneric sequence:map (result-prototype function sequence &rest sequences)

--- a/src/pcl/slot-name.lisp
+++ b/src/pcl/slot-name.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;; This choice of naming structure is perhaps unfortunate, because were the
 ;; names 2-lists, the globaldb hack to support this would instead be
 ;; a natural use of the (SETF <x>) style naming that globaldb favors.

--- a/src/pcl/slots-boot.lisp
+++ b/src/pcl/slots-boot.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 (defvar *!temporary-ensure-accessor-functions* nil)
 (defun ensure-accessor (fun-name)
   (when (member fun-name *!temporary-ensure-accessor-functions* :test 'equal)
@@ -408,7 +408,7 @@
        (boundp (lambda (instance)
                  (emf-funcall sdfun class instance slotd))))
      `(,name ,(class-name class) ,(slot-definition-name slotd)))))
-
+
 (defun maybe-class (class-or-name)
   (when (eq **boot-state** 'complete)
     (if (typep class-or-name 'class)
@@ -489,7 +489,7 @@
              (pv-binding1 ((bug "Please report this")
                            (instance) nil)
                (instance-boundp-custom .pv. 0 instance))))))))))
-
+
 ;;;; FINDING SLOT DEFINITIONS
 ;;;
 ;;; Historical PCL found slot definitions by iterating over

--- a/src/pcl/slots.lisp
+++ b/src/pcl/slots.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 ;;;; ANSI CL condition for unbound slots
 
 (define-condition unbound-slot (cell-error)
@@ -87,7 +87,7 @@
            (setf (fsc-instance-slots i2) s1)))
         (t
          (error "unrecognized instance type"))))
-
+
 ;;;; STANDARD-INSTANCE-ACCESS
 
 (declaim (inline standard-instance-access
@@ -116,7 +116,7 @@
 (defun (cas funcallable-standard-instance-access) (old-value new-value instance location)
   ;; FIXME: Maybe get rid of CLOS-SLOTS-REF entirely?
   (cas (svref (fsc-instance-slots instance) location) old-value new-value))
-
+
 ;;;; SLOT-VALUE, (SETF SLOT-VALUE), SLOT-BOUNDP, SLOT-MAKUNBOUND
 
 (declaim (ftype (sfunction (t symbol) t) slot-value))
@@ -422,7 +422,7 @@
             (object structure-object)
             (slotd structure-effective-slot-definition))
   (error "Structure slots can't be unbound."))
-
+
 (defmethod slot-missing
            ((class t) instance slot-name operation &optional new-value)
   (error "~@<When attempting to ~A, the slot ~S is missing from the ~
@@ -464,7 +464,7 @@
               :key #'slot-definition-location)))
       (cons
        (car position))))))
-
+
 ;;; FIXME: AMOP says that allocate-instance implies finalize-inheritance
 ;;; if the class is not yet finalized, but we don't seem to be taking
 ;;; care of this for non-standard-classes.

--- a/src/pcl/std-class.lisp
+++ b/src/pcl/std-class.lisp
@@ -22,7 +22,7 @@
 ;;;; specification.
 
 (in-package "SB-PCL")
-
+
 (defmethod slot-accessor-function ((slotd effective-slot-definition) type)
   (let ((info (the slot-info (slot-definition-info slotd))))
     (ecase type
@@ -133,7 +133,7 @@
 
 (defmethod slot-definition-allocation ((slotd structure-slot-definition))
   :instance)
-
+
 ;;;; various class accessors that are a little more complicated than can be
 ;;;; done with automatically generated reader methods
 
@@ -164,7 +164,7 @@
   (plist-value class 'class-slot-cells))
 (defmethod (setf class-slot-cells) (new-value (class std-class))
   (setf (plist-value class 'class-slot-cells) new-value))
-
+
 ;;;; class accessors that are even a little bit more complicated than those
 ;;;; above. These have a protocol for updating them, we must implement that
 ;;;; protocol.
@@ -257,7 +257,7 @@
                 ;; #'EQ to check for newness
                       (pushnew (method-generic-function m) collect
                                :test #'eq)))))))))
-
+
 (defmethod specializer-method-holder ((self specializer) &optional create)
   ;; CREATE can be ignored, because instances of SPECIALIZER
   ;; other than CLASS-EQ-SPECIALIZER have their DIRECT-METHODS slot
@@ -435,7 +435,7 @@
                     (typep value type))
           (error 'type-error :expected-type type :datum value))))
     value))
-
+
 (defmethod shared-initialize :after
     ((class std-class) slot-names &key
      (direct-superclasses nil direct-superclasses-p)
@@ -843,7 +843,7 @@
 
 (defmethod finalize-inheritance ((class structure-class))
   nil) ; always finalized
-
+
 (defun add-slot-accessors (class dslotds)
   (fix-slot-accessors class dslotds 'add))
 
@@ -876,7 +876,7 @@
           (fix r slot-name 'r slot-doc location))
         (dolist (w (slot-definition-writers dslotd))
           (fix w slot-name 'w slot-doc location))))))
-
+
 (defun add-direct-subclasses (class supers)
   (dolist (super supers)
     (unless (memq class (class-direct-subclasses class))
@@ -895,7 +895,7 @@
        ~2I~_~S~:>"
    class))
 
-
+
 (defun class-has-a-forward-referenced-superclass-p (class)
   (or (when (forward-referenced-class-p class)
         class)
@@ -1112,12 +1112,12 @@
                    (declare (ignore ignore))
                    (update-gf-dfun class gf))
                  gf-table)))))
-
+
 (defmethod compute-default-initargs ((class slot-class))
   (let ((initargs (loop for c in (class-precedence-list class)
                         append (class-direct-default-initargs c))))
     (delete-duplicates initargs :test #'eq :key #'car :from-end t)))
-
+
 ;;;; protocols for constructing direct and effective slot definitions
 
 (defmethod direct-slot-definition-class ((class std-class) &rest initargs)
@@ -1293,7 +1293,7 @@
            :internal-writer-function
            (slot-definition-internal-writer-function slotd)
            (call-next-method))))
-
+
 ;;; NOTE: For bootstrapping considerations, these can't use MAKE-INSTANCE
 ;;;       to make the method object. They have to use make-a-method which
 ;;;       is a specially bootstrapped mechanism for making standard methods.
@@ -1355,7 +1355,7 @@
 (defmethod remove-boundp-method ((class slot-class) generic-function)
   (let ((method (get-method generic-function () (list class) nil)))
     (when method (remove-method generic-function method))))
-
+
 ;;; MAKE-READER-METHOD-FUNCTION and MAKE-WRITER-METHOD-FUNCTION
 ;;; function are NOT part of the standard protocol. They are however
 ;;; useful; PCL makes use of them internally and documents them for
@@ -1378,7 +1378,7 @@
 
 (defmethod make-boundp-method-function ((class slot-class) slot-name)
   (make-std-boundp-method-function class slot-name))
-
+
 (defmethod compatible-meta-class-change-p (class proto-new-class)
   (eq (class-of class) (class-of proto-new-class)))
 
@@ -1388,7 +1388,7 @@
            (eq (class-of class) *the-class-funcallable-standard-class*))
       (and (eq (class-of superclass) *the-class-funcallable-standard-class*)
            (eq (class-of class) *the-class-standard-class*))))
-
+
 ;;; What this does depends on which of the four possible values of
 ;;; LAYOUT-INVALID the PCL wrapper has; the simplest case is when it
 ;;; is (:FLUSH <wrapper>) or (:OBSOLETE <wrapper>), when there is
@@ -1437,7 +1437,7 @@
               (%invalidate-wrapper owrapper :obsolete nwrapper)
               (%invalidate-wrapper owrapper :flush nwrapper))))))
   nil)
-
+
 ;;; MAKE-INSTANCES-OBSOLETE can be called by user code. It will cause
 ;;; the next access to the instance (as defined in 88-002R) to trap
 ;;; through the UPDATE-INSTANCE-FOR-REDEFINED-CLASS mechanism.
@@ -1621,7 +1621,7 @@
      (let ((*in-obsolete-instance-trap* t))
        (error 'obsolete-structure :datum instance)))))
 
-
+
 (defun %change-class (instance new-class initargs)
   (declare (notinline allocate-instance))
   (binding* ((old-wrapper (layout-of instance))
@@ -1735,7 +1735,7 @@
 
 (defmethod change-class ((instance t) (new-class-name symbol) &rest initargs)
   (apply #'change-class instance (find-class new-class-name) initargs))
-
+
 ;;;; The metaclasses SYSTEM-CLASS and BUILT-IN-CLASS
 ;;;;
 ;;;; These metaclasses are something of a weird creature. By this
@@ -1771,7 +1771,7 @@
   t)
 (defmethod validate-superclass ((c class) (s built-in-class))
   nil)
-
+
 ;;; Some necessary methods for FORWARD-REFERENCED-CLASS
 (defmethod class-direct-slots ((class forward-referenced-class)) ())
 (defmethod class-direct-default-initargs ((class forward-referenced-class)) ())
@@ -1785,7 +1785,7 @@
 
 (defmethod validate-superclass ((c slot-class) (f forward-referenced-class))
   t)
-
+
 (defmethod add-dependent ((metaobject dependent-update-mixin) dependent)
   (pushnew dependent (plist-value metaobject 'dependents) :test #'eq))
 

--- a/src/pcl/vector.lisp
+++ b/src/pcl/vector.lisp
@@ -36,7 +36,7 @@
 ;;;; GF are specializers parameters, we can assign a permutation index
 ;;;; to each such (GF . ARGS) tuple inside a method body, and use this
 ;;;; to cache effective method functions.
-
+
 (declaim (inline make-pv-table))
 (defstruct (pv-table (:predicate pv-tablep)
                      (:copier nil))
@@ -71,7 +71,7 @@
                            :pv-size (* 2 (reduce #'+ snl :key #'length))))))
     (sb-thread:with-mutex (*pv-lock*)
       (%intern-pv-table (mapcar #'intern-slot-names slot-name-lists)))))
-
+
 (defun use-standard-slot-access-p (class slot-name type)
   (or (not (eq **boot-state** 'complete))
       (and (standard-class-p class)
@@ -129,7 +129,7 @@
 
 (defun make-pv-type-declaration (var)
   `(type simple-vector ,var))
-
+
 ;;; Sometimes we want to finalize if we can, but it's OK if
 ;;; we can't.
 (defun try-finalize-inheritance (class)
@@ -552,7 +552,7 @@
                                       :key #'car))))
           slots))
 
-
+
 ;;;; This needs to work in terms of metatypes and also needs to work
 ;;;; for automatically generated reader and writer functions.
 ;;;; Automatically generated reader and writer functions use this

--- a/src/pcl/walk.lisp
+++ b/src/pcl/walk.lisp
@@ -37,11 +37,11 @@
            "VAR-GLOBALLY-SPECIAL-P"
            "VAR-DECLARATION"))
 (in-package "SB-WALKER")
-
+
 ;;;; forward references
 
 (defvar *key-to-walker-environment*)
-
+
 ;;;; environment hacking stuff, necessarily SBCL-specific
 
 ;;; Here in the original PCL were implementations of the
@@ -205,7 +205,7 @@
            (if (eq macro *key-to-walker-environment*)
                (values (bogo-fun-to-walker-info (cddr entry)))
                (values (function-lambda-expression (cddr entry))))))))
-
+
 ;;;; other environment hacking, not so SBCL-specific as the
 ;;;; environment hacking in the previous section
 
@@ -239,7 +239,7 @@
     (eval-in-lexenv `(defmacro ,gensym ,llist ,@body)
                     (sb-c::make-restricted-lexenv env))
     (macro-function gensym)))
-
+
 ;;;; the actual walker
 
 ;;; As the walker walks over the code, it communicates information to
@@ -356,7 +356,7 @@
 (defun var-globally-special-p (symbol)
   (eq (info :variable :kind symbol) :special))
 
-
+
 ;;;; handling of special forms
 
 ;;; Here are some comments from the original PCL on the difficulty of
@@ -433,7 +433,7 @@
          ;; good, etc.
          (error "Illegal function call in method body:~%  ~S"
                 context))))
-
+
 ;;;; the actual templates
 
 ;;; ANSI special forms
@@ -473,7 +473,7 @@
 ;;; FIXME: maybe we don't need this one any more, given that
 ;;; NAMED-LAMBDA now expands into (FUNCTION (NAMED-LAMBDA ...))?
 (define-walker-template named-lambda walk-named-lambda)
-
+
 (defvar *walk-form-expand-macros-p* nil)
 
 #+sb-fasteval
@@ -666,7 +666,7 @@
       (recons x
               (car args)
               (relist-internal (cdr x) (cdr args) *p))))
-
+
 ;;;; special walkers
 
 (defun walk-declarations (body fn env
@@ -1050,7 +1050,7 @@
             (walk-form-internal predicate context env)
             (walk-form-internal arm1 context env)
             (walk-form-internal arm2 context env))))
-
+
 ;;;; examples
 
 #|

--- a/src/pcl/wrapper.lisp
+++ b/src/pcl/wrapper.lisp
@@ -297,7 +297,7 @@
     (if (invalid-wrapper-p wrapper)
         (check-wrapper-validity instance)
         wrapper)))
-
+
 ;;;  NIL: means nothing so far, no actual arg info has NILs in the
 ;;;  metatype.
 ;;;

--- a/tests/arith.impure.lisp
+++ b/tests/arith.impure.lisp
@@ -67,7 +67,7 @@
       ()
       '(lambda (n) (coerce n 'single-float))
     (((expt 10 1000)) (condition 'floating-point-overflow))))
-
+
 (defun are-we-getting-ash-right (x y)
   (declare (optimize speed)
            (type (unsigned-byte 32) x)
@@ -143,7 +143,7 @@
     (loop for x in neg-values do
          (test x 'nc-ash 'c-ash))))
 
-
+
 (declaim (inline ppc-ldb-2))
 
 (defun ppc-ldb-2 (fun value)
@@ -169,4 +169,4 @@
    (ppc-ldb-1 (lambda (x)
                 (push x acc)))
    (assert (equal acc '(#xff #xff #xff #xff)))))
-
+

--- a/tests/clos-1.impure.lisp
+++ b/tests/clos-1.impure.lisp
@@ -96,7 +96,7 @@
   (assert (string= (doc (find-method #'set-b-of nil '(t foo))) "docstring for B"))
   (assert (string= (doc (find-method #'c nil '(foo))) "docstring for C"))
   (assert (string= (doc (find-method #'(setf c) nil '(t foo))) "docstring for C")))
-
+
 ;;; some nasty tests of NO-NEXT-METHOD.
 (defvar *method-with-no-next-method*)
 (defvar *nnm-count* 0)
@@ -116,7 +116,7 @@
 (with-test (:name (no-next-method :gf-name-changed))
   (new-nnm-tester 1)
   (assert (= *nnm-count* 2)))
-
+
 ;;; Tests the compiler's incremental rejiggering of GF types.
 (fmakunbound 'foo)
 (with-test (:name :keywords-supplied-in-methods-ok-1)

--- a/tests/clos-method-combination-redefinition.impure.lisp
+++ b/tests/clos-method-combination-redefinition.impure.lisp
@@ -15,7 +15,7 @@
   (:use "COMMON-LISP" "TEST-UTIL"))
 
 (in-package "CLOS-METHOD-COMBINATION-REDEFINITION")
-
+
 ;;;; long-form method combination redefinition
 
 ;;; first, define a method combination
@@ -55,7 +55,7 @@
   (assert (eql (long-or-test 3) 'fixnum))
   (assert (eql (long-or-test (1+ most-positive-fixnum)) 'integer))
   (assert (eql (long-or-test 3.2) 'number)))
-
+
 ;;;; short-form method-combination redefiniton
 
 ;;; define a method-combination
@@ -104,7 +104,7 @@
   (assert (= (short-div 3) 4))
   (assert (= (short-div 3.0) -4)))
 
-
+
 ;;;; modifying the need for args-lambda-list
 
 ;;; define a fancy method combination.  (Happens to implement a finite state machine)
@@ -167,7 +167,7 @@
   (assert (not (even-as (make-instance 'parse-state :string "abcbab") :start 'no)))
   (assert (not (even-as (make-instance 'parse-state :string "abcbabab"))))
   (assert (even-as (make-instance 'parse-state :string "abcbabab") :start 'no)))
-
+
 ;;;; changing between short- and long-form method combination
 (define-method-combination maximum :operator max)
 

--- a/tests/clos-typechecking.impure.lisp
+++ b/tests/clos-typechecking.impure.lisp
@@ -21,7 +21,7 @@
 
 (defvar *t* t)
 (defvar *one* 1)
-
+
 ;;;; Slot type checking for standard instances
 
 (defclass foo ()
@@ -115,7 +115,7 @@
   (checked-compile-and-assert (:optimize :maximally-safe)
       '(lambda () (make-instance 'foo :slot *t*))
     (() (condition 'type-error))))
-
+
 ;;;; Slot type checking for funcallable instances
 
 (defclass foo/gf (sb-mop:standard-generic-function)
@@ -205,7 +205,7 @@
   (checked-compile-and-assert (:optimize :maximally-safe)
       '(lambda () (make-instance 'foo/gf :slot/gf *t*))
     (() (condition 'type-error))))
-
+
 ;;;; Type checking for inherited slots
 
 (defclass inheritance-a/slot-value/float ()

--- a/tests/clos.impure-cload.lisp
+++ b/tests/clos.impure-cload.lisp
@@ -27,7 +27,7 @@
   (mio-demo))
 
 (mio-test)
-
+
 ;;; Some tests of bits of optimized MAKE-INSTANCE that were hopelessly
 ;;; wrong until Gerd's ctor MAKE-INSTANCE optimization was ported.
 (defvar *d-i-s-e-count* 0)
@@ -53,7 +53,7 @@
 (assert (= (class-allocation-reader) 3))
 (class-allocation-writer 4)
 (assert (= (class-allocation-reader) 4))
-
+
 ;;; from James Anderson via Gerd Moellmann: defining methods with
 ;;; specializers with forward-referenced superclasses used not to
 ;;; work.
@@ -76,7 +76,7 @@
 (defmethod method-on-unknown ((x unknown-type)) x)
 ;;; (we can't call it without defining methods on allocate-instance
 ;;; etc., but we should be able to define it).
-
+
 ;;; the ctor MAKE-INSTANCE optimizer used not to handle duplicate
 ;;; initargs...
 (defclass dinitargs-class1 ()
@@ -104,7 +104,7 @@
 (assert (slot-boundp (make-instance 'shared-to-local-initform-sub) 'redefined))
 (assert (eq 'orig-initform
             (slot-value (make-instance 'shared-to-local-initform-sub) 'redefined)))
-
+
 (defgeneric no-ignored-warnings (x y))
 (handler-case
     (eval '(defmethod no-ignored-warnings ((x t) (y t))
@@ -118,7 +118,7 @@
     (eval '(defmethod no-ignored-warnings ((x fixnum) (y t))
             (declare (ignore x)) (setq y 'foo)))
   (style-warning (c) (error c)))
-
+
 ;;; ctor optimization bugs:
 ;;;
 ;;; :DEFAULT-INITARGS not checked for validity
@@ -148,7 +148,7 @@
   (assert (= valid-initarg 1)))
 (make-instance 'default-initargs-with-method2)
 (assert (= *d-i-w-m-2* 1))
-
+
 ;;; from Axel Schairer on cmucl-imp 2004-08-05
 (defclass class-with-symbol-initarg ()
   ((slot :initarg slot)))
@@ -164,7 +164,7 @@
   (make-instance 'class-with-symbol-initarg slot arg))
 (assert (eql (slot-value (make-thing 1) 'slot) 1))
 (assert (eql (slot-value (make-other-thing 'slot 2) 'slot) 2))
-
+
 ;;; test that ctors can be used with the literal class
 (eval-when (:compile-toplevel)
   (defclass ctor-literal-class () ())
@@ -177,7 +177,7 @@
   (assert (typep (ctor-literal-class) 'ctor-literal-class)))
 (with-test (:name (:ctor :literal-class-quoted))
   (assert (typep (ctor-literal-class2) 'ctor-literal-class2)))
-
+
 ;;; test that call-next-method and eval-when doesn't cause an
 ;;; undumpable method object to arise in the effective source code.
 ;;; (from Sascha Wilde sbcl-devel 2007-07-15)

--- a/tests/clos.impure.lisp
+++ b/tests/clos.impure.lisp
@@ -17,7 +17,7 @@
 (defpackage "CLOS-IMPURE"
   (:use "CL" "SB-EXT" "ASSERTOID" "TEST-UTIL" "COMPILER-TEST-UTIL"))
 (in-package "CLOS-IMPURE")
-
+
 ;;; It should be possible to do DEFGENERIC and DEFMETHOD referring to
 ;;; structure types defined earlier in the file.
 (defstruct struct-a x y)
@@ -196,7 +196,7 @@
        (((pi t))
         t nil "COMMON-LISP:PI names a defined constant")))))
 
-
+
 ;;; Explicit :metaclass option with structure-class and
 ;;; standard-class.
 
@@ -240,7 +240,7 @@
 (assert (eq (born-to-be-redefined 1) 'int))
 (defgeneric born-to-be-redefined (x))
 (assert (eq (born-to-be-redefined 1) 'int))
-
+
 ;;; In the removal of ITERATE from SB-PCL, a bug was introduced
 ;;; preventing forward-references and also CHANGE-CLASS (which
 ;;; forward-references used interally) from working properly.
@@ -500,7 +500,7 @@
 (defmethod bug180 list ((x fixnum))
   'fixnum)
 (assert (equal (bug180 14) '(number fixnum)))
-
+
 ;;; printing a structure class should not loop indefinitely (or cause
 ;;; a stack overflow):
 (defclass test-printing-structure-class ()
@@ -525,7 +525,7 @@
   (c-writer 5 foo)
   (assert (= (a-accessor foo) 4))
   (assert (= (c-accessor foo) 5)))
-
+
 ;;; At least as of sbcl-0.7.4, PCL has code to support a special
 ;;; encoding of effective method functions for slot accessors as
 ;;; FIXNUMs. Given this special casing, it'd be easy for slot accessor
@@ -554,7 +554,7 @@
 (ffin! 'almost-triang-fin *cod*)
 (assert (eq (ffin *cod*) 'almost-triang-fin))
 (assert (equalp #((:before cod) (cod)) *clos-dispatch-side-fx*))
-
+
 ;;; Until sbcl-0.7.6.21, the long form of DEFINE-METHOD-COMBINATION
 ;;; ignored its options; Gerd Moellmann found and fixed the problem
 ;;; for cmucl (cmucl-imp 2002-06-18).
@@ -569,7 +569,7 @@
 
 (defmethod gf (obj)
   obj)
-
+
 ;;; Until sbcl-0.7.7.20, some conditions weren't being signalled, and
 ;;; some others were of the wrong type:
 (macrolet ((assert-program-error (form)
@@ -629,7 +629,7 @@
   (assert-program-error (defmethod foo019 ((foo t) &rest x &optional y) nil))
   (assert-program-error (defmethod foo020 ((foo t) &key x &optional y) nil))
   (assert-program-error (defmethod foo021 ((foo t) &key x &rest y) nil)))
-
+
 ;;; DOCUMENTATION's argument-precedence-order wasn't being faithfully
 ;;; preserved through the bootstrap process until sbcl-0.7.8.39.
 ;;; (thanks to Gerd Moellmann)
@@ -641,7 +641,7 @@
     (assert (stringp answer))
     (defmethod documentation ((x (eql 'foo022)) y) "WRONG")
     (assert (string= (documentation 'foo022 'function) answer))))
-
+
 ;;; only certain declarations are permitted in DEFGENERIC
 (macrolet ((assert-program-error (form)
              `(multiple-value-bind (value error)
@@ -662,7 +662,7 @@
   'success)
 (assert (eq (no-next-method-test 1) 'success))
 (assert-error (no-next-method-test 'foo) sb-pcl::no-applicable-method-error)
-
+
 ;;; regression test for bug 176, following a fix that seems
 ;;; simultaneously to fix 140 while not exposing 176 (by Gerd
 ;;; Moellmann, merged in sbcl-0.7.9.12).
@@ -677,7 +677,7 @@
 (defclass b176 () (aslot-176))
 (defclass c176-0 (b176) ())
 (assert (= 1 (setf (slot-value (make-instance 'c176-9) 'aslot-176) 1)))
-
+
 ;;; DEFINE-METHOD-COMBINATION was over-eager at checking for duplicate
 ;;; primary methods:
 (define-method-combination dmc-test-mc (&optional (order :most-specific-first))
@@ -722,7 +722,7 @@
                        (make-method ,form)))
                     form)))
             'dmc-test-return))
-
+
 ;;; DEFINE-METHOD-COMBINATION should, according to the description in 7.7,
 ;;; allow you to do everything in the body forms yourself if you specify
 ;;; exactly one method group whose qualifier-pattern is *
@@ -870,7 +870,7 @@
                             (list (find-class 'integer))))
 (assert-error (defmethod incompatible-ll-test-3 (x y) (list x y)))
 
-
+
 ;;; Attempting to instantiate classes with forward references in their
 ;;; CPL should signal errors (FIXME: of what type?)
 (defclass never-finished-class (this-one-unfinished-too) ())
@@ -882,14 +882,14 @@
     (ignore-errors (make-instance 'this-one-unfinished-too))
   (assert (null result))
   (assert (typep error 'error)))
-
+
 ;;; Classes with :ALLOCATION :CLASS slots should be subclassable (and
 ;;; weren't for a while in sbcl-0.7.9.xx)
 (defclass superclass-with-slot ()
   ((a :allocation :class)))
 (defclass subclass-for-class-allocation (superclass-with-slot) ())
 (make-instance 'subclass-for-class-allocation)
-
+
 ;;; bug #136: CALL-NEXT-METHOD was being a little too lexical,
 ;;; resulting in failure in the following:
 (defmethod call-next-method-lexical-args ((x integer))
@@ -899,7 +899,7 @@
     (declare (ignorable x))
     (call-next-method)))
 (assert (= (call-next-method-lexical-args 3) 3))
-
+
 ;;; DEFINE-METHOD-COMBINATION with arguments was hopelessly broken
 ;;; until 0.7.9.5x
 (defvar *d-m-c-args-test* nil)
@@ -934,7 +934,7 @@
 (ignore-errors (d-m-c-args-test 1))
 (assert (equal *d-m-c-args-test*
                '("unlock" "object-lock" "lock" "object-lock")))
-
+
 ;;; The walker (on which DEFMETHOD depended) didn't know how to handle
 ;;; SYMBOL-MACROLET properly.  In fact, as of sbcl-0.7.10.20 it still
 ;;; doesn't, but it does well enough to compile the following without
@@ -971,7 +971,7 @@
     (assert (= value 3)))
   ;; specified.
   (assert (char= (char (get-output-stream-string x) 0) #\1)))
-
+
 ;;; REINITIALIZE-INSTANCE, in the ctor optimization, wasn't checking
 ;;; for invalid initargs where it should:
 (defclass class234 () ())
@@ -1005,10 +1005,10 @@
   (incf *bug234-b*))
 (bug234-b)
 (assert (= *bug234-b* 1))
-
+
 ;;; we should be able to make classes with uninterned names:
 (defclass #:class-with-uninterned-name () ())
-
+
 ;;; SLOT-MISSING should be called when there are missing slots.
 (defclass class-with-all-slots-missing () ())
 (defmethod slot-missing (class (o class-with-all-slots-missing)
@@ -1054,7 +1054,7 @@
                           'baz))))
   (try inline)
   (try notinline))
-
+
 ;;; we should be able to specialize on anything that names a class.
 (defclass name-for-class () ())
 (defmethod something-that-specializes ((x name-for-class)) 1)
@@ -1063,7 +1063,7 @@
 (assert (= (something-that-specializes (make-instance 'name-for-class)) 2))
 (assert (= (something-that-specializes (make-instance 'other-name-for-class))
            2))
-
+
 ;;; more forward referenced classes stuff
 (defclass frc-1 (frc-2) ())
 (assert (subtypep 'frc-1 (find-class 'frc-2)))
@@ -1074,7 +1074,7 @@
 (defclass frc-3 () ())
 (assert (typep (make-instance 'frc-1 :a 2) (find-class 'frc-1)))
 (assert (typep (make-instance 'frc-2 :a 3) (find-class 'frc-2)))
-
+
 ;;; check that we can define classes with two slots of different names
 ;;; (even if it STYLE-WARNs).
 (defclass odd-name-class ()
@@ -1084,13 +1084,13 @@
 (let ((x (make-instance 'odd-name-class :name 1 :name2 2)))
   (assert (= (slot-value x 'name) 1))
   (assert (= (slot-value x 'cl-user::name) 2))))
-
+
 ;;; ALLOCATE-INSTANCE should work on structures, even if defined by
 ;;; DEFSTRUCT (and not DEFCLASS :METACLASS STRUCTURE-CLASS).
 (defstruct allocatable-structure a)
 (assert (typep (allocate-instance (find-class 'allocatable-structure))
                'allocatable-structure))
-
+
 ;;; Bug found by Paul Dietz when devising CPL tests: somewhat
 ;;; amazingly, calls to CPL would work a couple of times, and then
 ;;; start returning NIL.  A fix was found (relating to the
@@ -1113,7 +1113,7 @@
                '(broadcast-stream stream structure-object)))
 (assert (equal (cpl (make-broadcast-stream))
                '(broadcast-stream stream structure-object)))
-
+
 ;;; Bug in CALL-NEXT-METHOD: assignment to the method's formal
 ;;; parameters shouldn't affect the arguments to the next method for a
 ;;; no-argument call to CALL-NEXT-METHOD
@@ -1157,7 +1157,7 @@
   (assert (equal (bug-1734771-2 2 0) '(2 0 t))))
 (with-test (:name (:cnm-assignment :bug-1734771 6))
   (assert (equal (bug-1734771-2 t) '(t nil nil))))
-
+
 ;;; Bug reported by Istvan Marko 2003-07-09
 (let ((class-name (gentemp)))
   (loop for i from 1 to 9
@@ -1484,7 +1484,7 @@
                    "3")))
 
 
-
+
 ;;; When class definition does not complete due to a bad accessor
 ;;; name, do not cause an error when a new accessor name is provided
 ;;; during class redefinition
@@ -1498,7 +1498,7 @@
 (defclass redefinition-of-accessor-class ()
   ((slot :accessor new-name)))
 
-
+
 
 (load "package-ctor-bug.lisp")
 (assert (= (package-ctor-bug:test) 3))
@@ -1534,7 +1534,7 @@
   (multiple-value-bind (val err) (ignore-errors (funcall 'bug-281 'symbol))
     (assert (not val))
     (assert (typep err 'error))))
-
+
 ;;; RESTART-CASE and CALL-METHOD
 
 ;;; from Bruno Haible
@@ -1648,7 +1648,7 @@
           (assert (equal (list (slot-value c1 'class-slot)
                                (slot-value c2 'class-slot))
                    (list 1 1))))))
-
+
 ;;; tests of ctors on anonymous classes
 (defparameter *unnamed* (defclass ctor-unnamed-literal-class () ()))
 (setf (class-name *unnamed*) nil)
@@ -1671,7 +1671,7 @@
   (assert (typep (ctor-unnamed-literal-class2) *unnamed2*)))
 (with-test (:name (:ctor :unnamed-after/symbol))
   (assert-error (ctor-unnamed-literal-class2/symbol)))
-
+
 ;;; classes with slot types shouldn't break if the types don't name
 ;;; classes (bug #391)
 (defclass slot-type-superclass () ((slot :type fixnum)))
@@ -1679,7 +1679,7 @@
   ((slot :type (integer 1 5))))
 (let ((instance (make-instance 'slot-type-subclass)))
   (setf (slot-value instance 'slot) 3))
-
+
 ;;; ctors where there's a non-standard SHARED-INITIALIZE method and an
 ;;; initarg which isn't self-evaluating (kpreid on #lisp 2006-01-29)
 (defclass kpreid-enode ()
@@ -1692,7 +1692,7 @@
   (let ((x (make-kpreid-enode))
         (y (make-kpreid-enode)))
     (= (slot-value x 'slot) (slot-value y 'slot))))
-
+
 ;;; defining a class hierarchy shouldn't lead to spurious classoid
 ;;; errors on TYPEP questions (reported by Tim Moore on #lisp
 ;;; 2006-03-10)
@@ -1704,7 +1704,7 @@
 (assert (not (typep-backwards-3 1)))
 (assert (not (typep-backwards-3 (make-instance 'backwards-2))))
 (assert (typep-backwards-3 (make-instance 'backwards-3)))
-
+
 (defgeneric remove-method-1 (x)
   (:method ((x integer)) (1+ x)))
 (defgeneric remove-method-2 (x)
@@ -1738,7 +1738,7 @@
                              (defmethod class-as-specializer-test2 ((x ,(find-class 'class-as-specializer-test)))
                                'bar))))
 (assert (eq 'bar (class-as-specializer-test2 (make-instance 'class-as-specializer-test))))
-
+
 ;;; CHANGE-CLASS and tricky allocation.
 (defclass foo-to-be-changed ()
   ((a :allocation :class :initform 1)))
@@ -1748,7 +1748,7 @@
   ((a :allocation :instance :initform 2)))
 (change-class *bar-to-be-changed* 'baz-to-be-changed)
 (assert (= (slot-value *bar-to-be-changed* 'a) 1))
-
+
 ;;; proper name and class redefinition
 (defvar *to-be-renamed1* (defclass to-be-renamed1 () ()))
 (defvar *to-be-renamed2* (defclass to-be-renamed2 () ()))
@@ -1757,13 +1757,13 @@
 (assert (not (eq *to-be-renamed1* *to-be-renamed2*)))
 (assert (not (eq *to-be-renamed1* *renamed1*)))
 (assert (not (eq *to-be-renamed2* *renamed1*)))
-
+
 ;;; CLASS-NAME (and various other standardized generic functions) have
 ;;; their effective methods precomputed; in the process of rearranging
 ;;; (SETF FIND-CLASS) and FINALIZE-INHERITANCE, this broke.
 (defclass class-with-odd-class-name-method ()
   ((a :accessor class-name)))
-
+
 ;;; another case where precomputing (this time on PRINT-OBJECT) and
 ;;; lazily-finalized classes caused problems.  (report from James Y
 ;;; Knight sbcl-devel 20-07-2006)
@@ -1790,7 +1790,7 @@
 ;;; SUBSUB-PRINT-OBJECT wrapper; if an invalid wrapper gets into a
 ;;; cache with more than one key, then failure ensues.
 (reinitialize-instance #'print-object)
-
+
 ;;; bug in long-form method combination: if there's an applicable
 ;;; method not part of any method group, we need to call
 ;;; INVALID-METHOD-ERROR.  (MC27 test case from Bruno Haible)
@@ -1815,7 +1815,7 @@
 (handler-bind ((style-warning #'muffle-warning))
 (assert (equal '(result) (test-mc27prime 3))))
 (assert-error (test-mc27 t) sb-pcl::no-applicable-method-error) ; still no-applicable-method
-
+
 ;;; more invalid wrappers.  This time for a long-standing bug in the
 ;;; compiler's expansion for TYPEP on various class-like things, with
 ;;; user-visible consequences.
@@ -1829,7 +1829,7 @@
 (compile (defun is-a-structure-object-p (x) (typep x 'structure-object)))
 (make-instances-obsolete (find-class 'obsolete-again))
 (assert (not (is-a-structure-object-p *obsolete-again*)))
-
+
 ;;; overeager optimization of slot-valuish things
 (defclass listoid ()
   ((caroid :initarg :caroid)
@@ -1847,7 +1847,7 @@
                                             (make-instance 'listoid))))
              3)))
 
-
+
 
 ;;;; Tests for argument parsing in fast-method-functions.
 
@@ -2195,7 +2195,7 @@
 (with-test (:name :remove-default-initargs)
   (assert (= 42 (slot-value (make-instance 'remove-default-initargs-test)
                             'x))))
-
+
 ;; putting this inside WITH-TEST interferes with recognition of the class name
 ;; as a specializer
 (defclass bug-485019 ()
@@ -2256,7 +2256,7 @@
                                                 "ok!"))
                                        (invoke-restart r))))))
                    (no-primary-method/retry (cons t t))))))
-
+
 ;;; test that a cacheing strategy for make-instance initargs checking
 ;;; can handle class redefinitions
 
@@ -2296,7 +2296,7 @@
   (let ((thing (cacheing-initargs-redefinitions-make-instances :slot)))
     (assert (not (slot-boundp thing 'slot)))))
 
-
+
 ;;; defmethod tests
 
 (with-test (:name (defmethod :specializer-builtin-class-alias :bug-618387))
@@ -2574,7 +2574,7 @@
     (declare (ignore foo bar))
     (assert (= count0 count1 count2))))
 
-
+
 ;;; Classes shouldn't be their own direct or indirect superclasses or
 ;;; metaclasses.
 

--- a/tests/compiler.impure.lisp
+++ b/tests/compiler.impure.lisp
@@ -339,7 +339,7 @@
 (with-test (:name (the :bug-194d))
   (assert (eq (bug194d) t)))
 
-
+
 ;;; BUG 48a. and b. (symbol-macrolet handling), fixed by Eric Marsden
 ;;; and Raymond Toy for CMUCL, fix ported for sbcl-0.7.6.18.
 (flet ((test (form)
@@ -365,7 +365,7 @@
     (test `(lambda ()
              (symbol-macrolet ((s nil)) (declare (special s)) s)))))
 
-
+
 ;;; bug 120a: Turned out to be constraining code looking like (if foo
 ;;; <X> <X>) where <X> was optimized by the compiler to be the exact
 ;;; same block in both cases, but not turned into (PROGN FOO <X>).
@@ -615,7 +615,7 @@
 (declaim (ftype (function (t) (values package boolean)) bug221f2))
 (defun bug221 (b x)
   (funcall (if b #'bug221f1 #'bug221f2) x))
-
+
 ;;; bug 172: macro lambda lists were too permissive until 0.7.9.28
 ;;; (fix provided by Matthew Danish) on sbcl-devel
 (with-test (:name (defmacro :lambda-list :bug-172))
@@ -655,7 +655,7 @@
     (assert (typep (check-embedded-thes 3 3  0 2.5f0) 'type-error))
     (assert (typep (check-embedded-thes 3 3  2 3.5f0) 'type-error))))
 
-
+
 ;;; INLINE inside MACROLET
 (declaim (inline to-be-inlined))
 (macrolet ((def (x) `(defun ,x (y) (+ y 1))))
@@ -677,7 +677,7 @@
 (defun to-be-inlined (y)
   (+ y 5))
 #-interpreter (assert (= (call-inlined 3) 6))
-
+
 ;;; DEFINE-COMPILER-MACRO to work as expected, not via weird magical
 ;;; IR1 pseudo-:COMPILE-TOPLEVEL handling
 (defvar *bug219-a-expanded-p* nil)
@@ -769,7 +769,7 @@
   (assert (equal (bug223-int 4) '(ext int 3)))
   (bug223-wrap)
   (assert (equal (bug223-int 4) '(ext ext int 2))))
-
+
 ;;; COERCE got its own DEFOPTIMIZER which has to reimplement most of
 ;;; SPECIFIER-TYPE-NTH-ARG.  For a while, an illegal type would throw
 ;;; you into the debugger on compilation.
@@ -782,7 +782,7 @@
 (with-test (:name (coerce :optimizer))
   (assert-error (coerce-defopt1 3))
   (assert-error (coerce-defopt2 3)))
-
+
 ;;; Oops.  In part of the (CATCH ..) implementation of DEBUG-RETURN,
 ;;; it was possible to confuse the type deriver of the compiler
 ;;; sufficiently that compiler invariants were broken (explained by
@@ -805,7 +805,7 @@
 (defun debug-return-catch-break2 (x)
   (declare (type (vector (unsigned-byte 8)) x))
   (setq *y* (the (unsigned-byte 8) (aref x 4))))
-
+
 ;;; FUNCTION-LAMBDA-EXPRESSION should return something that COMPILE
 ;;; can understand.  Here's a simple test for that on a function
 ;;; that's likely to return a hairier list than just a lambda:
@@ -923,7 +923,7 @@
       (load source)
       (full-check)
       (delete-file fasl))))
-
+
 (defun expt-derive-type-bug (a b)
   (unless (< a b)
     (truncate (expt a b))))
@@ -952,7 +952,7 @@
                      c
                      (return-from return :good))))
                :good)))
-
+
 ;;;; MUFFLE-CONDITIONS test (corresponds to the test in the manual)
 ; FIXME: make a better test!
 (with-test (:name muffle-conditions :skipped-on (or :alpha :x86-64))
@@ -969,7 +969,7 @@
     (declare (ignore failure-p warnings style-warnings))
     (assert (= (length notes) 1))
     (assert (equal (multiple-value-list (funcall fun 1)) '(5 -5)))))
-
+
 (with-test (:name (flet labels &key))
   (assert-error (eval '(flet ((%f (&key) nil)) (%f nil nil))))
   (assert-error (eval '(labels ((%f (&key x) x)) (%f nil nil)))))
@@ -1519,7 +1519,7 @@
     ;; remove the DEBUG restriction
     (let ((res (sb-ext:restrict-compiler-policy 'debug 0)))
       (assert (null res)))))
-
+
 ;;;; tests not in the problem domain, but of the consistency of the
 ;;;; compiler machinery itself
 
@@ -1587,7 +1587,7 @@
                   (nil (fun-info-templates info) :exit-if-null))
          ;; ... it has translators
          (grovel-results name))))))
-
+
 ;;;; bug 305: INLINE/NOTINLINE causing local ftype to be lost
 
 (test-util:with-test (:name (compile inline notinline))

--- a/tests/compiler.pure.lisp
+++ b/tests/compiler.pure.lisp
@@ -1269,7 +1269,7 @@
          (logand a (* a 438810)))
     ((215067723) 13739018)))
 
-
+
 ;;;; Bugs in stack analysis
 ;;; bug 299 (reported by PFD)
 (with-test (:name (compile :stack-analysis :bug-299))
@@ -1489,7 +1489,7 @@
                    1 2 3))
                  '(0))))
 
-
+
 ;;; MISC.275
 (with-test (:name (compile :misc.275))
   (assert

--- a/tests/ctor.impure.lisp
+++ b/tests/ctor.impure.lisp
@@ -17,7 +17,7 @@
   (:use "CL" "TEST-UTIL" "COMPILER-TEST-UTIL"))
 
 (in-package "CTOR-TEST")
-
+
 (defclass no-slots () ())
 
 (defun make-no-slots ()
@@ -49,7 +49,7 @@
 
 (assert (typep (make-no-slots) 'no-slots))
 (assert (typep (funcall (gethash '(sb-pcl::ctor no-slots nil) sb-pcl::*all-ctors*)) 'no-slots))
-
+
 (defclass one-slot ()
   ((a :initarg :a)))
 
@@ -75,7 +75,7 @@
                                 4) 'a) 4))
 (assert (not (slot-boundp (make-one-slot-noa) 'a)))
 (assert (not (slot-boundp (funcall (gethash '(sb-pcl::ctor one-slot nil) sb-pcl::*all-ctors*)) 'a)))
-
+
 (defclass one-slot-superclass ()
   ((b :initarg :b)))
 (defclass one-slot-subclass (one-slot-superclass)

--- a/tests/data/wonky1.lisp
+++ b/tests/data/wonky1.lisp
@@ -2,7 +2,7 @@
 #|
  More randomness
 |#
-
+
 
 ;;;
 (progn (defvar *foo* #[ hi ]) x)

--- a/tests/data/wonky2.lisp
+++ b/tests/data/wonky2.lisp
@@ -3,7 +3,7 @@
 #|
  More randomness
 |#
-
+
 
 ;; It would be really nice if this reported that the
 ;; error occurred at the "#." but it's better than before,

--- a/tests/data/wonky3.lisp
+++ b/tests/data/wonky3.lisp
@@ -2,7 +2,7 @@
 #|
  More randomness
 |#
-
+
 
 #+no-such-feature (defun foo
                    (hooey))

--- a/tests/deadline.impure.lisp
+++ b/tests/deadline.impure.lisp
@@ -147,7 +147,7 @@
       (sb-thread:interrupt-thread thread (lambda () 42))
       (let ((seconds-passed (sb-thread:join-thread thread)))
         (assert (< seconds-passed 1.2))))))
-
+
 ;;;; Sleep
 
 (with-test (:name (sb-sys:with-deadline sleep :smoke))

--- a/tests/debug.impure.lisp
+++ b/tests/debug.impure.lisp
@@ -19,7 +19,7 @@
 (when (eq sb-ext:*evaluator-mode* :interpret)
   (sb-ext:exit :code 104))
 
-
+
 ;;;; Check that we get debug arglists right.
 
 (defun zoop (zeep &key beep)
@@ -236,7 +236,7 @@
 
 ;; unconditional, in case either previous left it enabled
 (disable-debugger)
-
+
 ;;;; test some limitations of MAKE-LISP-OBJ
 
 ;;; Older GENCGC systems had a bug in the pointer validation used by

--- a/tests/defstruct.impure.lisp
+++ b/tests/defstruct.impure.lisp
@@ -10,7 +10,7 @@
 ;;;; more information.
 
 (load "compiler-test-util.lisp")
-
+
 ;;;; examples from, or close to, the Common Lisp DEFSTRUCT spec
 
 ;;; Type mismatch of slot default init value isn't an error until the
@@ -182,7 +182,7 @@
   frizzy-hair-p
   polkadots)
 (assert (is-a-bozo-p (make-up-klown)))
-
+
 ;;;; systematically testing variants of DEFSTRUCT:
 ;;;;   * native, :TYPE LIST, and :TYPE VECTOR
 
@@ -371,7 +371,7 @@
 (test-variant vector-struct :colontype vector :boa-constructor-p t)
 (test-variant list-struct :colontype list :boa-constructor-p t)
 
-
+
 ;;;; testing raw slots harder
 ;;;;
 ;;;; The offsets of raw slots need to be rescaled during the punning
@@ -427,7 +427,7 @@
   (assert (eql (manyraw-dd copy) #c(0.33 0.33)))
   (assert (eql (manyraw-ee copy) #c(0.44d0 0.44d0))))
 
-
+
 ;;;; Since GC treats raw slots specially now, let's try this with more objects
 ;;;; and random values as a stress test.
 
@@ -581,7 +581,7 @@
   ;; make-load-form omits slot A. it reads as 0
   (assert (equalp (make-hugest-manyraw :a 0) (dumped-hugest-manyraw))))
 
-
+
 ;;;; miscellaneous old bugs
 
 (defstruct ya-struct)
@@ -617,7 +617,7 @@
 (let ((foo-0-7-8-53 (make-foo-0-7-8-53 :x :s)))
   (assert (eq (foo-0-7-8-53-x foo-0-7-8-53) :s))
   (assert (eq (foo-0-7-8-53-y foo-0-7-8-53) :not)))
-
+
 ;;; tests of behaviour of colliding accessors.
 (defstruct (bug127-foo (:conc-name bug127-baz-)) a)
 (assert (= (bug127-baz-a (make-bug127-foo :a 1)) 1))
@@ -644,7 +644,7 @@
 (assert-error (bug127--foo (make-bug127-e :foo 3)) type-error)
 
 ;;; FIXME: should probably do the same tests on DEFSTRUCT :TYPE
-
+
 ;;; As noted by Paul Dietz for CMUCL, :CONC-NAME handling was a little
 ;;; too fragile:
 (defstruct (conc-name-syntax :conc-name) a-conc-name-slot)
@@ -658,7 +658,7 @@
             (make-conc-name-nil :conc-name-nil-slot 1)) 1))
 (assert-error (conc-name-nil-slot (make-conc-name-nil))
               undefined-function)
-
+
 ;;; The named/typed predicates were a little fragile, in that they
 ;;; could throw errors on innocuous input:
 (defstruct (list-struct (:type list) :named) a-slot)
@@ -675,7 +675,7 @@
 (assert (vector-struct-p (make-vector-struct)))
 (assert (not (vector-struct-p nil)))
 (assert (not (vector-struct-p #())))
-
+
 
 ;;; bug 3d: type safety with redefined type constraints on slots
 #+#.(cl:if (assertoid:legacy-eval-p) '(or) '(and))
@@ -848,7 +848,7 @@
 ;;; bug reported by John Morrison, 2008-07-22 on sbcl-devel
 (defstruct (raw-slot-struct-with-unknown-init (:constructor make-raw-slot-struct-with-unknown-init ()))
  (x (#:unknown-function) :type double-float))
-
+
 ;;; Some checks for the behavior of incompatibly redefining structure
 ;;; classes.  We don't actually check that our detection of
 ;;; "incompatible" is comprehensive, only that if an incompatible
@@ -956,7 +956,7 @@ redefinition."
 ;; When eyeballing these, it's helpful to see when various things are
 ;; happening.
 (setq *compile-verbose* t *load-verbose* t)
-
+
 ;;; Tests begin.
 ;; Base case: recklessly-continue.
 (with-defstruct-redefinition-test :defstruct/recklessly
@@ -1018,7 +1018,7 @@ redefinition."
   (let ((instance (funcall ctor)))
     (load (compile-file-assert path2))
     (assert-invalid instance)))
-
+
 ;;; Subclasses.
 ;; Ensure that recklessly continuing DT(expected)T to instances of
 ;; subclasses.  (This is a case where recklessly continuing is

--- a/tests/deprecation.impure.lisp
+++ b/tests/deprecation.impure.lisp
@@ -9,7 +9,7 @@
 ;;;; absolutely no warranty. See the COPYING and CREDITS files for
 ;;;; more information.
 
-
+
 ;;;; Helpers
 
 (defun test (namespace name state make-body
@@ -65,7 +65,7 @@
                                 (describe name stream))))
     ;; Check DOCUMENTATION.
     (search-string/documentation (documentation name namespace))))
-
+
 ;;;; DEPRECATED declaration syntax
 
 (with-test (:name (deprecated :declaration :syntax))
@@ -99,7 +99,7 @@
           (deprecated :early "1" (variable deprecated.declaration.replacement
                                   :replacement (deprecated.declaration.replacement1
                                                 deprecated.declaration.replacement2))))))
-
+
 ;;;; Deprecated variables
 
 (macrolet
@@ -166,7 +166,7 @@
   (define-variable-tests defconstant         definition.defconstant)
   (define-variable-tests define-symbol-macro definition.define-symbol-macro
     :symbol-value nil))
-  
+  
 ;;;; Deprecated functions
 
 (macrolet
@@ -213,7 +213,7 @@
     :call nil :check-describe nil)
   (define-function-tests defun            definition.defun)
   (define-function-tests defmacro         definition.defmacro))
-
+
 ;;;; Deprecated types
 
 (macrolet
@@ -300,7 +300,7 @@
      :call                   nil
      :expected-warning-count '(eql 0))))
 
-
+
 ;;;; Loader deprecation warnings
 
 (defun please-dont-use-this (x)

--- a/tests/deprecation.internal.impure.lisp
+++ b/tests/deprecation.internal.impure.lisp
@@ -9,7 +9,7 @@
 ;;;; absolutely no warranty. See the COPYING and CREDITS files for
 ;;;; more information.
 
-
+
 ;;;; Helpers
 
 (defun test (kind name state make-body
@@ -50,7 +50,7 @@
     ;; Check the documentation.
     #+sb-doc
     (search-string (documentation name kind))))
-
+
 ;;;; Deprecated variables
 
 (sb-int:define-deprecated-variable :early "1.2.10"
@@ -92,7 +92,7 @@
   (test 'variable 'deprecated-variable.final :final
                           (lambda (name) `((symbol-global-value ',name)))))
 
-
+
 ;;;; Deprecated functions
 
 (sb-int:define-deprecated-function :early "1.2.10"

--- a/tests/dump.impure-cload.lisp
+++ b/tests/dump.impure-cload.lisp
@@ -73,7 +73,7 @@
 (defparameter *numbers*
   '(-1s0 -1f0 -1d0 -1l0
     #c(-1s0 -1s0) #c(-1f0 -1f0) #c(-1d0 -1d0) #c(-1l0 -1l0)))
-
+
 ;;; tests for MAKE-LOAD-FORM-SAVING-SLOTS
 (eval-when (:compile-toplevel :load-toplevel :execute)
   (defstruct savable-structure
@@ -102,7 +102,7 @@
   #.(make-instance 'savable-class :a 3))
 (assert (not (slot-boundp *savable-class* 'a)))
 
-
+
 ;;; ensure that we can dump and reload specialized arrays whose element
 ;;; size is smaller than a byte (caused a few problems circa SBCL
 ;;; 0.8.14.4)
@@ -110,7 +110,7 @@
 (defvar *1-bit* #.(make-array 5 :element-type 'bit :initial-element 0))
 (defvar *2-bit* #.(make-array 5 :element-type '(unsigned-byte 2) :initial-element 0))
 (defvar *4-bit* #.(make-array 5 :element-type '(unsigned-byte 4) :initial-element 1))
-
+
 ;;; tests for constant coalescing (and absence of such) in the
 ;;; presence of strings.
 (progn

--- a/tests/dynamic-extent.impure.lisp
+++ b/tests/dynamic-extent.impure.lisp
@@ -137,7 +137,7 @@
       (declare (dynamic-extent z))
       (opaque-identity :bar)
       z)))
-
+
 ;;; alignment
 
 (defvar *x*)
@@ -802,7 +802,7 @@
 
 (with-test (:name (:no-consing :mutex) :skipped-on (not :sb-thread))
   (assert-no-consing (test-mutex)))
-
+
 
 ;;; Bugs found by Paul F. Dietz
 
@@ -1143,7 +1143,7 @@
              (assert (eql x (car (aref vec3 0))))
              (assert (eql x (elt (aref vec4 0) 0))))))
     (assert-no-consing (test 42))))
-
+
 (defun bug-681092 ()
   (declare (optimize speed))
   (let ((c 0))
@@ -1154,7 +1154,7 @@
         (return (bar))))))
 (with-test (:name :bug-681092)
   (assert (= 10 (bug-681092))))
-
+
 ;;;; Including a loop in the flow graph between a DX-allocation and
 ;;;; the start of its environment would, for a while, cause executing
 ;;;; any of the code in the loop to discard the value.  Found via
@@ -1175,7 +1175,7 @@
     (eq y w)))
 (with-test (:name :bug-1472785)
   (assert (null (bug-1472785 1))))
-
+
 ;;;; &REST lists should stop DX propagation -- not required by ANSI,
 ;;;; but required by sanity.
 

--- a/tests/error-source-path.impure.lisp
+++ b/tests/error-source-path.impure.lisp
@@ -9,7 +9,7 @@
 ;;;; absolutely no warranty. See the COPYING and CREDITS files for
 ;;;; more information.
 
-
+
 ;;; Utilities
 
 (defmacro assert-condition-source-paths (form &rest source-paths)
@@ -27,7 +27,7 @@
   (declare (ignore body))
   (error "error from macro"))
 
-
+
 ;;; Tests
 
 (with-test (:name (:source-path multiple-value-bind))

--- a/tests/exhaust.impure.lisp
+++ b/tests/exhaust.impure.lisp
@@ -13,7 +13,7 @@
 
 #+interpreter (sb-ext:exit :code 104)
 
-
+
 ;;; Prior to sbcl-0.7.1.38, doing something like (RECURSE), even in
 ;;; safe code, would crash the entire Lisp process. Then the soft
 ;;; stack checking was introduced, which checked (in safe code) for

--- a/tests/external-format.impure.lisp
+++ b/tests/external-format.impure.lisp
@@ -220,7 +220,7 @@
       (when p
         (delete-file p)))))
 
-
+
 ;;;; KOI8-R external format
 (with-open-file (s *test-path* :direction :output
                  :if-exists :supersede :external-format :koi8-r)
@@ -253,7 +253,7 @@
                   uni-codes))
   (assert (equalp (string-to-octets (map 'string #'code-char uni-codes) :external-format :koi8-r)
                   koi8-r-codes)))
-
+
 ;;; tests of FILE-STRING-LENGTH
 (let ((standard-characters "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!$\"'(),_-./:;?+<=>#%&*@[\\]{|}`^~"))
   (do-external-formats (xf)
@@ -286,7 +286,7 @@
            (string-length (file-string-length s string)))
       (write-string string s)
       (assert (= (file-position s) (+ position string-length))))))
-
+
 
 ;;; See sbcl-devel "Subject: Bug in FILE-POSITION on UTF-8-encoded files"
 ;;; by Lutz Euler on 2006-03-05 for more details.
@@ -473,7 +473,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (char= #\? (char string 256))))))
 (delete-file *test-path*)
-
+
 ;;; latin-2 tests
 (with-test (:name (:unibyte-input-replacement :latin-2))
   (dotimes (i 256)
@@ -498,7 +498,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 57 (count #\? string :start #xa1))))))
 (delete-file *test-path*)
-
+
 ;;; latin-3 tests
 (with-test (:name (:unibyte-input-replacement :latin-3))
   (dotimes (i 256)
@@ -524,7 +524,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 35 (count #\? string :start #xa1))))))
 (delete-file *test-path*)
-
+
 ;;; latin-4 tests
 (with-test (:name (:unibyte-input-replacement :latin-4))
   (dotimes (i 256)
@@ -549,7 +549,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 50 (count #\? string :start #xa1))))))
 (delete-file *test-path*)
-
+
 ;;; iso-8859-5 tests
 (with-test (:name (:unibyte-input-replacement :iso-8859-5))
   (dotimes (i 256)
@@ -574,7 +574,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 93 (count #\? string :start #xa1))))))
 (delete-file *test-path*)
-
+
 ;;; iso-8859-6 tests
 (with-test (:name (:unibyte-input-replacement :iso-8859-6))
   (dotimes (i 256)
@@ -602,7 +602,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 93 (count #\? string :start #xa1))))))
 (delete-file *test-path*)
-
+
 ;;; iso-8859-7 tests
 (with-test (:name (:unibyte-input-replacement :iso-8859-7))
   (dotimes (i 256)
@@ -628,7 +628,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 80 (count #\? string :start #xa1))))))
 (delete-file *test-path*)
-
+
 ;;; iso-8859-8 tests
 (with-test (:name (:unibyte-input-replacement :iso-8859-8))
   (dotimes (i 256)
@@ -654,7 +654,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 67 (count #\? string :start #xa1))))))
 (delete-file *test-path*)
-
+
 ;;; latin-5 tests
 (with-test (:name (:unibyte-input-replacement :latin-5))
   (dotimes (i 256)
@@ -679,7 +679,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 6 (count #\? string :start #xd0))))))
 (delete-file *test-path*)
-
+
 ;;; latin-6 tests
 (with-test (:name (:unibyte-input-replacement :latin-6))
   (dotimes (i 256)
@@ -703,7 +703,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 46 (count #\? string :start #xa1))))))
 (delete-file *test-path*)
-
+
 ;;; iso-8859-11 tests
 (with-test (:name (:unibyte-input-replacement :iso-8859-11))
   (dotimes (i 256)
@@ -728,7 +728,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 95 (count #\? string :start #xa1))))))
 (delete-file *test-path*)
-
+
 ;;; latin-7 tests
 (with-test (:name (:unibyte-input-replacement :latin-7))
   (dotimes (i 256)
@@ -754,7 +754,7 @@
         (assert (char/= (char string i) #\?)))
       (assert (= 52 (count #\? string :start #xa1))))))
 (delete-file *test-path*)
-
+
 ;;; latin-8 tests
 (with-test (:name (:unibyte-input-replacement :latin-8))
   (dotimes (i 256)
@@ -778,7 +778,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 31 (count #\? string :start #xa1))))))
 (delete-file *test-path*)
-
+
 ;;; latin-9 tests
 (with-test (:name (:unibyte-input-replacement :latin-9))
   (dotimes (i 256)
@@ -803,7 +803,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 8 (count #\? string :start #xa4))))))
 (delete-file *test-path*)
-
+
 ;;; koi8-r tests
 (with-test (:name (:unibyte-input-replacement :koi8-r))
   (dotimes (i 256)
@@ -827,7 +827,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 122 (count #\? string :start #x80))))))
 (delete-file *test-path*)
-
+
 ;;; koi8-u tests
 (with-test (:name (:unibyte-input-replacement :koi8-u))
   (dotimes (i 256)
@@ -851,7 +851,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 122 (count #\? string :start #x80))))))
 (delete-file *test-path*)
-
+
 ;;; x-mac-cyrillic tests
 (with-test (:name (:unibyte-input-replacement :x-mac-cyrillic))
   (dotimes (i 256)
@@ -876,7 +876,7 @@
         (assert (= (char-code (char string i)) i)))
       (assert (= 113 (count #\? string :start #x80))))))
 (delete-file *test-path*)
-
+
 ;;; ucs-2 tests
 (with-test (:name (:multibyte :ucs2le))
   (let* ((size 120)
@@ -953,7 +953,7 @@
       (let ((string (read-line s)))
         (assert (char= (char string 0) (code-char #x10100)))
         (assert (char= (char string 1) #\replacement_character))))))
-
+
 ;;; utf tests
 (with-test (:name (:utf-16le :roundtrip))
   (let ((string (map 'string 'code-char '(#x20 #x200 #x2000 #xfffd #x10fffd))))
@@ -1054,5 +1054,5 @@
                                     :external-format :euc-jp)
                    (read-line f))))
   (delete-file *test-path*))
-
+
 ;;;; success

--- a/tests/filesys.pure.lisp
+++ b/tests/filesys.pure.lisp
@@ -105,7 +105,7 @@
              (assert (equal (directory* "" :name :wild :type :wild)
                             expected-wild))))
       (delete-directory test-directory :recursive t))))
-
+
 ;;;; OPEN
 
 ;;; In sbcl-0.6.9 FOO-NAMESTRING functions  returned "" instead of NIL.
@@ -336,7 +336,7 @@
   (let ((pathname (parse-native-namestring "foo/bar//baz")))
     (assert (string= (car (last (pathname-directory pathname))) "bar"))))
 
-
+
 ;;;; DELETE-DIRECTORY
 
 (with-test (:name (delete-directory :as-file :complicated-name-or-type :bug-1740624))

--- a/tests/gray-streams.impure.lisp
+++ b/tests/gray-streams.impure.lisp
@@ -12,7 +12,7 @@
 ;;;; more information.
 
 (cl:in-package :cl-user)
-
+
 ;;;; class precedence tests
 
 (with-test (:name (:class-precedence))
@@ -57,7 +57,7 @@
   (assert (eql (stream-element-type
                 *fundamental-character-stream-instance*)
                'character)))
-
+
 ;;;; example character input and output streams
 
 (defclass character-output-stream (fundamental-character-output-stream)
@@ -68,7 +68,7 @@
 (defclass character-input-stream (fundamental-character-input-stream)
   ((lisp-stream :initarg :lisp-stream
                 :accessor character-input-stream-lisp-stream)))
-
+
 ;;;; example character output stream encapsulating a lisp-stream
 
 (defun make-character-output-stream (lisp-stream)
@@ -108,7 +108,7 @@
   (if new-value
       (setf (character-output-stream-position stream) new-value)
       (character-output-stream-position stream)))
-
+
 ;;;; example character input stream encapsulating a lisp-stream
 
 (defun make-character-input-stream (lisp-stream)
@@ -137,7 +137,7 @@
 
 (defmethod stream-clear-input ((stream character-input-stream))
   (clear-input (character-input-stream-lisp-stream stream)))
-
+
 ;;;; tests for character i/o, using the above:
 
 (with-test (:name (:character-input-stream :character-output-stream))
@@ -227,7 +227,7 @@
                      (write-sequence output-test-list our-char-output)
                      (assert (null (peek-char nil our-char-input nil nil nil)))))
                  test-string))))))
-
+
 ;;;; example classes for binary output
 
 (defclass binary-to-char-output-stream (fundamental-binary-output-stream)
@@ -262,7 +262,7 @@
   (let ((char (code-char integer)))
     (write-char char
                 (binary-to-char-output-stream-lisp-stream stream))))
-
+
 ;;;; tests using binary i/o, using the above
 
 (with-test (:name (fundamental-binary-input-stream
@@ -286,7 +286,7 @@
                      (write-byte byte our-bin-to-char-output))))
                test-string)))))
 
-
+
 
 ;;; Minimal test of file-position
 (with-test (:name file-position)

--- a/tests/interface.impure.lisp
+++ b/tests/interface.impure.lisp
@@ -13,7 +13,7 @@
 
 (defmacro silently (&rest things)
   `(let ((*standard-output* (make-broadcast-stream))) ,@things))
-
+
 ;; Interpreted closure is a problem for COMPILE
 (with-test (:name (disassemble function) :skipped-on :interpreter)
   ;; DISASSEMBLE shouldn't fail on closures or unpurified functions
@@ -93,7 +93,7 @@
     (assert (equal (function-lambda-expression
                     (nth-value 1 (funcall f)))
                    '(lambda (w) (block f2 (* w 0.3)))))))
-
+
 ;;; Tests of documentation on types and classes
 
 (defun assert-documentation (thing doc-type expected)
@@ -377,7 +377,7 @@
   (assert
    (or (member :big-endian *features*)
        (member :little-endian *features*))))
-
+
 (with-test (:name (apropos :inherited :bug-1364413))
   (let* ((package (make-package "BUGGALO" :use nil))
          (symbol (intern "BUGGALO" package)))
@@ -433,7 +433,7 @@
 (with-test (:name (:generic-function-pretty-arglist 5))
   (assert (equal (sb-pcl::generic-function-pretty-arglist #'gf-arglist-5)
                  '(x &key y z &allow-other-keys))))
-
+
 (defgeneric traced-gf (x))
 (defmethod traced-gf (x) (1+ x))
 

--- a/tests/interface.pure.lisp
+++ b/tests/interface.pure.lisp
@@ -11,7 +11,7 @@
 ;;;; absolutely no warranty. See the COPYING and CREDITS files for
 ;;;; more information.
 
-
+
 ;;;; properties of symbols, e.g. presence of doc strings for public symbols
 
 (enable-test-parallelism)

--- a/tests/load.impure.lisp
+++ b/tests/load.impure.lisp
@@ -116,7 +116,7 @@
          (load *tmp-filename*)
          (assert (equal (merge-pathnames *tmp-filename*) *saved-load-pathname*)))
     (delete-file *tmp-filename*)))
-
+
 ;;; Test many, many variations on LOAD.
 (defparameter *counter* 0)
 (defparameter *loaded-pathname* nil)

--- a/tests/macroexpand.impure.lisp
+++ b/tests/macroexpand.impure.lisp
@@ -240,7 +240,7 @@
   (assert (equal-mod-gensyms
            (macroexpand-1 '(setf (bar-a x) 3))
            '(let* ((#2=#:x x) (new 3)) (funcall #'(setf bar-a) new #2#)))))
-
+
 ;;; WITH-CURRENT-SOURCE-FORM tests
 
 (defmacro warnings-in-subforms (a b)

--- a/tests/mop-18.impure-cload.lisp
+++ b/tests/mop-18.impure-cload.lisp
@@ -44,7 +44,7 @@
   (reinitialize-instance (find-class 'test-standard-object) :direct-slots nil)
   (assert (eq *finalized-class* (find-class 'test-standard-object)))
   (assert (null (sb-mop:class-slots (find-class 'test-standard-object)))))
-
+
 (defclass test-funcallable-standard-class (sb-mop:funcallable-standard-class)
   ())
 

--- a/tests/mop-19.impure-cload.lisp
+++ b/tests/mop-19.impure-cload.lisp
@@ -48,7 +48,7 @@
     (assert (eq (class-of method) (find-class 'my-reader))))
   (let ((method (find-method #'b nil (list (find-class t) (find-class 'foo)))))
     (assert (eq (class-of method) (find-class 'my-writer)))))
-
+
 (defclass my-other-class (my-class) ())
 (defmethod sb-mop:validate-superclass ((a my-other-class) (b standard-class)) t)
 

--- a/tests/mop-20.impure-cload.lisp
+++ b/tests/mop-20.impure-cload.lisp
@@ -41,7 +41,7 @@
   (assert (string= (with-output-to-string (*standard-output*)
                      (assert (= (run-test) 42)))
                    "42")))
-
+
 ;;; Slightly more complex test cases, from Bruno Haible (sbcl-devel
 ;;; 2004-06-11).  First the setup.
 (defclass user-method (standard-method) (myslot))

--- a/tests/mop-21.impure-cload.lisp
+++ b/tests/mop-21.impure-cload.lisp
@@ -107,7 +107,7 @@
      ,@(unless (member :method-combination options :key #'car)
          '((:method-combination beta)))
      ,@options))
-
+
 (defclass top () ())
 (defclass middle (top) ())
 (defclass bottom (middle) ())

--- a/tests/mop-27.impure.lisp
+++ b/tests/mop-27.impure.lisp
@@ -79,7 +79,7 @@
 (defmethod sb-mop:remove-direct-method ((specializer pattern-specializer) method)
   (setf (slot-value specializer 'direct-methods)
         (remove method (slot-value specializer 'direct-methods))))
-
+
 (defgeneric simplify (x)
   (:generic-function-class pattern-gf/1))
 ;;; KLUDGE: order of definition matters, as we simply traverse

--- a/tests/mop.impure.lisp
+++ b/tests/mop.impure.lisp
@@ -19,14 +19,14 @@
   (:use "CL" "SB-MOP" "ASSERTOID" "TEST-UTIL"))
 
 (in-package "MOP-TEST")
-
+
 ;;; Readers for Class Metaobjects (pp. 212--214 of AMOP)
 (defclass red-herring (forward-ref) ())
 
 (assert (null (class-direct-slots (find-class 'forward-ref))))
 (assert (null (class-direct-default-initargs
                (find-class 'forward-ref))))
-
+
 ;;; Readers for Generic Function Metaobjects (pp. 216--218 of AMOP)
 (defgeneric fn-with-odd-arg-precedence (a b c)
   (:argument-precedence-order b c a))
@@ -52,7 +52,7 @@
   (assert (= (length decls) 2))
   (assert (member '(optimize (speed 3)) decls :test #'equal))
   (assert (member '(optimize (safety 0)) decls :test #'equal)))
-
+
 ;;; Readers for Slot Definition Metaobjects (pp. 221--224 of AMOP)
 
 ;;; Ensure that SLOT-DEFINITION-ALLOCATION returns :INSTANCE/:CLASS as
@@ -68,7 +68,7 @@
                  (accessor-method-slot-definition
                   (car methods)))
                 (cadr m)))))
-
+
 ;;; Class Finalization Protocol (see section 5.5.2 of AMOP)
 (let ((finalized-count 0))
   (defmethod finalize-inheritance :after ((x standard-class))
@@ -84,7 +84,7 @@
 (assert (or (= (get-count) 2) (= (get-count) 3)))
 (make-instance 'finalization-test-2)
 (assert (= (get-count) 3))
-
+
 ;;; Bits of FUNCALLABLE-STANDARD-CLASS are easy to break; make sure
 ;;; that it is at least possible to define classes with that as a
 ;;; metaclass.
@@ -92,7 +92,7 @@
   (:metaclass funcallable-standard-class))
 (defgeneric g (a b c)
   (:generic-function-class gf-class))
-
+
 ;;; until sbcl-0.7.12.47, PCL wasn't aware of some direct class
 ;;; relationships.  These aren't necessarily true, but are probably
 ;;; not going to change often.
@@ -101,14 +101,14 @@
               (find-class t)))
   (assert (member (find-class x)
                   (class-direct-subclasses (find-class t)))))
-
+
 ;;; the class-prototype of the NULL class used to be some weird
 ;;; standard-instance-like thing.  Make sure it's actually NIL.
 ;;;
 ;;; (and FIXME: eventually turn this into asserting that the prototype
 ;;; of all built-in-classes is of the relevant type)
 (assert (null (class-prototype (find-class 'null))))
-
+
 ;;; simple consistency checks for the SB-MOP package: all of the
 ;;; functionality specified in AMOP is in functions and classes:
 (assert (null (loop for x being each external-symbol in "SB-MOP"
@@ -123,7 +123,7 @@
                                            (fdefinition x)))
                                   0))
                     collect x)))
-
+
 ;;; make sure that ENSURE-CLASS-USING-CLASS's arguments are the right
 ;;; way round (!)
 (defvar *e-c-u-c-arg-order* nil)
@@ -134,7 +134,7 @@
 (assert (null *e-c-u-c-arg-order*))
 (defclass e-c-u-c-arg-order () ())
 (assert (eq *e-c-u-c-arg-order* t))
-
+
 ;;; verify that FIND-CLASS works after FINALIZE-INHERITANCE
 (defclass automethod-class (standard-class) ())
 (defmethod validate-superclass ((c1 automethod-class) (c2 standard-class))
@@ -145,7 +145,7 @@
   (:metaclass automethod-class))
 (defvar *automethod-object* (make-instance 'automethod-object))
 (assert (typep *automethod-object* 'automethod-object))
-
+
 ;;; COMPUTE-EFFECTIVE-SLOT-DEFINITION should take three arguments, one
 ;;; of which is the name of the slot.
 (defvar *compute-effective-slot-definition-count* 0)
@@ -160,7 +160,7 @@
 ;;; sequence, nor whether that's compliant with AMOP.  -- CSR,
 ;;; 2003-04-17
 (assert (> *compute-effective-slot-definition-count* 0))
-
+
 ;;; this used to cause a nasty uncaught metacircularity in PCL.
 (defclass substandard-method (standard-method) ())
 (defgeneric substandard-defgeneric (x y)
@@ -169,7 +169,7 @@
   (:method ((x string) (y string)) (concatenate 'string x y)))
 (assert (= (substandard-defgeneric 1 2) 3))
 (assert (string= (substandard-defgeneric "1" "2") "12"))
-
+
 (let* ((x (find-class 'pathname))
        (xs (class-direct-subclasses x)))
   (assert (>= (length xs) 1))
@@ -181,7 +181,7 @@
        (spec (first (sb-mop:method-specializers m))))
   (assert (not (typep 1 spec)))
   (assert (typep 4.0 spec)))
-
+
 ;;; BUG #334, relating to programmatic addition of slots to a class
 ;;; with COMPUTE-SLOTS.
 ;;;
@@ -246,7 +246,7 @@
   (assert (slot-boundp x 'x))
   (assert (eq t (slot-value x 'x)))
   (assert (not (slot-boundp x 'y))))
-
+
 ;;;; the CTOR optimization was insufficiently careful about its
 ;;;; assumptions: firstly, it failed with a failed AVER for
 ;;;; non-standard-allocation slots:
@@ -287,7 +287,7 @@
     (incf *special-ssvuc-counter-2*))
   (funcall fun)
   (assert (= *special-ssvuc-counter-2* 1)))
-
+
 ;;; vicious metacycle detection and resolution wasn't good enough: it
 ;;; didn't take account that the slots (and hence the slot readers)
 ;;; might be inherited from superclasses.  This example, due to Bruno
@@ -429,7 +429,7 @@
           :name 'class-as-metaclass-test
           :direct-superclasses (list (find-class 'standard-object)))
          'class))
-
+
 ;;; COMPUTE-DEFAULT-INITARGS protocol mismatch reported by Bruno
 ;;; Haible
 (defparameter *extra-initarg-value* 'extra)
@@ -452,7 +452,7 @@
   ((slot :initarg :extra))
   (:metaclass custom-default-initargs-class))
 (assert (eq (slot-value (make-instance 'extra-initarg) 'slot) 'extra))
-
+
 ;;; STANDARD-CLASS valid as a superclass for FUNCALLABLE-STANDARD-CLASS
 (defclass standard-class-for-fsc ()
   ((scforfsc-slot :initarg :scforfsc-slot :accessor scforfsc-slot)))
@@ -485,12 +485,12 @@
      ()
      (:metaclass funcallable-standard-class))
    (make-instance 'bad-funcallable-standard-class)))
-
+
 ;;; we should be able to make classes with silly names
 (make-instance 'standard-class :name 3)
 (defclass foo () ())
 (reinitialize-instance (find-class 'foo) :name '(a b))
-
+
 ;;; classes (including anonymous ones) and eql-specializers should be
 ;;; allowed to be specializers.
 (defvar *anonymous-class*
@@ -504,20 +504,20 @@
         ((obj ,(intern-eql-specializer *object-of-anonymous-class*)))
         42))
 (assert (eql (method-on-anonymous-class *object-of-anonymous-class*) 42))
-
+
 ;;; accessors can cause early finalization, which caused confusion in
 ;;; the system, leading to uncompileable TYPEP problems.
 (defclass funcallable-class-for-typep ()
   ((some-slot-with-accessor :accessor some-slot-with-accessor))
   (:metaclass funcallable-standard-class))
 (compile nil '(lambda (x) (typep x 'funcallable-class-for-typep)))
-
+
 ;;; even anonymous classes should be valid types
 (let* ((class1 (make-instance 'standard-class :direct-superclasses (list (find-class 'standard-object))))
        (class2 (make-instance 'standard-class :direct-superclasses (list class1))))
   (assert (subtypep class2 class1))
   (assert (typep (make-instance class2) class1)))
-
+
 ;;; ensure-class got its treatment of :metaclass wrong.
 (ensure-class 'better-be-standard-class :direct-superclasses '(standard-object)
               :metaclass 'standard-class
@@ -713,7 +713,7 @@
          (slot (first (class-slots class))))
     (assert (equal (slot-definition-initargs slot) '(:a)))))
 
-
+
 (defclass change-class-test-m (standard-class) ())
 (defmethod validate-superclass ((c1 change-class-test-m) (c2 standard-class))
   t)

--- a/tests/pathnames.impure.lisp
+++ b/tests/pathnames.impure.lisp
@@ -14,7 +14,7 @@
 ;;;; absolutely no warranty. See the COPYING and CREDITS files for
 ;;;; more information.
 
-
+
 ;;;; Pathname accessors
 
 (with-test (:name (pathname :accessors :stream-not-associated-to-file type-error))
@@ -128,7 +128,7 @@
        (,#P"n.Foo" :common "Foo")
        (,#P"n.a*b" :common ("A" :multi-char-wild "B"))))))
 
-
+
 ;;;; Logical pathnames
 
 (setf (logical-pathname-translations "demo0")
@@ -298,7 +298,7 @@
                               "test0:foo;bar;baz;mum.quux.3"))
                  "/library/foo/foo/bar/baz/mum.quux")))
 
-
+
 ;;;; MERGE-PATHNAME tests
 ;;;;
 ;;;; There are some things we don't bother testing, just because they're
@@ -407,7 +407,7 @@
                (frob pathname-directory)
                (frob pathname-name)
                (frob pathname-type)))))
-
+
 ;;; host-namestring testing
 (with-test (:name host-namestring)
   (assert (string=
@@ -419,14 +419,14 @@
   (assert-error
    (setf (logical-pathname-translations "")
          (list '("**;*.*.*" "/**/*.*")))))
-
+
 ;;; Bug 200: translate-logical-pathname is according to the spec supposed
 ;;; not to give errors if asked to translate a namestring for a valid
 ;;; physical pathname.  Failed in 0.7.7.28 and before
 (with-test (:name (:logical-pathname 16))
   (assert (string= (namestring (translate-logical-pathname "/")) "/")))
 
-
+
 ;;; Not strictly pathname logic testing, but until sbcl-0.7.6.19 we
 ;;; had difficulty with non-FILE-STREAM stream arguments to pathname
 ;;; functions (they would cause memory protection errors).  Make sure
@@ -441,7 +441,7 @@
              (assert-error (funcall fun) type-error))))
     (test '(pathname (make-string-input-stream "FOO")))
     (test '(merge-pathnames (make-string-output-stream)))))
-
+
 ;;; ensure print-read consistency (or print-not-readable-error) on
 ;;; pathnames:
 (with-test (:name :print/read-consistency)
@@ -473,7 +473,7 @@
                  (pathname-host new) (pathname-device new)
                  (pathname-directory new) (pathname-name new)
                  (pathname-type new) (pathname-version new)))))))
-
+
 ;;; BUG 330: "PARSE-NAMESTRING should accept namestrings as the
 ;;; default argument" ...and streams as well
 (with-test (:name (parse-namestring stream))
@@ -488,12 +488,12 @@
           ;; opposed to eg. #P"/path/to/current/foo"), which is
           ;; possibly mildly surprising but probably conformant.
           (assert (parse-namestring "foo" nil f)))))
-
+
 ;;; ENOUGH-NAMESTRING should probably not fail when the namestring in
 ;;; question has a :RELATIVE pathname.
 (with-test (:name enough-namestring)
   (assert (equal (enough-namestring #p"foo" #p"./") "foo")))
-
+
 ;;;; NAMESTRING
 
 ;;; bug reported by Artem V. Andreev: :WILD not handled in unparsing
@@ -602,14 +602,14 @@
                    (list* 'write-to-string pathname vars)
                    expected
                    actual)))
-
+
 ;;; we got (truename "/") wrong for about 6 months.  Check that it's
 ;;; still right.
 (with-test (:name :root-truename)
   (let ((pathname (truename "/")))
     (assert (equalp pathname (merge-pathnames #p"/")))
     (assert (equal (pathname-directory pathname) '(:absolute)))))
-
+
 ;;; we failed to unparse logical pathnames with :NAME :WILD :TYPE NIL.
 ;;; (Reported by Pascal Bourguignon.
 (with-test (:name (namestring :unparse-logical-wild))
@@ -624,7 +624,7 @@
              (assert-error (namestring pathname) file-error))))
     (test :name "")
     (test :type "foo")))
-
+
 ;;; reported by James Y Knight on sbcl-devel 2006-05-17
 (with-test (:name :merge-back)
   (let ((p1 (make-pathname :directory '(:relative "bar")))
@@ -676,10 +676,10 @@
   (assert (equal #p"quux/bar.fasl"
                  (let ((*default-pathname-defaults* #p"quux/"))
                    (compile-file-pathname "bar.lisp")))))
-
+
 (with-test (:name :wild-enough)
   (enough-namestring #p".a*"))
-
+
 
 (with-test (:name :translated-wild-version)
   (assert (eq 99
@@ -699,7 +699,7 @@
 ;;; enough-namestring relative to root
 (with-test (:name :enough-relative-to-root)
   (assert (equal "foo" (enough-namestring "/foo" "/"))))
-
+
 ;;; Check the handling of NIL, :UNSPECIFIC, the empty string, and
 ;;; non-NIL strings in NATIVE-NAMESTRING implementations.  Revised by
 ;;; RMK 2007-11-28, attempting to preserve the apparent intended

--- a/tests/pprint.impure.lisp
+++ b/tests/pprint.impure.lisp
@@ -198,7 +198,7 @@
     (try '(lambda `(,x ,y) :forms) "(LAMBDA `(,X ,Y) :FORMS)")
     (try '(defun f `(,x ,y) :forms) "(DEFUN F `(,X ,Y) :FORMS)")))
 
-
+
 ;;; SET-PPRINT-DISPATCH should accept function name arguments, and not
 ;;; rush to coerce them to functions.
 (set-pprint-dispatch '(cons (eql frob)) 'ppd-function-name)
@@ -209,7 +209,7 @@
 (let ((s (with-output-to-string (s)
            (pprint '(frob a b) s))))
   (assert (position #\3 s)))
-
+
 ;; Test that circularity detection works with pprint-logical-block
 ;; (including when called through pprint-dispatch).
 (with-test (:name :pprint-circular-detection)
@@ -400,7 +400,7 @@
   (defun thing (x) x)
   (assert (string= (write-to-string (make-weasel) :pretty t)
                    "hi WEASEL!")))
-
+
 (deftype known-cons ()
   '(cons (member known-cons other-known-cons other-other)))
 (with-test (:name (:pprint-dispatch :known-cons-type))

--- a/tests/print.impure.lisp
+++ b/tests/print.impure.lisp
@@ -226,7 +226,7 @@
         (*standard-output* (make-broadcast-stream)))
     (wexercise-0-8-7-interpreted "~@W")
     (wexercise-0-8-7-compiled-with-atsign)))
-
+
 ;;; WRITE-TO-STRING was erroneously DEFKNOWNed as FOLDABLE
 
 ;;; This bug from PFD

--- a/tests/seq.impure.lisp
+++ b/tests/seq.impure.lisp
@@ -405,7 +405,7 @@
       ;; FIXME: tests for MAP to come when some brave soul implements
       ;; the analogous type checking for MAP/%MAP.
       )))
-
+
 ;;; ELT should signal an error of type TYPE-ERROR if its index
 ;;; argument isn't a valid sequence index for sequence:
 (defun test-elt-signal (x)
@@ -415,13 +415,13 @@
 (locally
     (declare (optimize (safety 3)))
   (assert-error (elt (list 1 2 3) 3) type-error))
-
+
 ;;; confusion in the refactoring led to this signalling an unbound
 ;;; variable, not a type error.
 (defun svrefalike (x)
   (svref x 0))
 (assert-error (svrefalike #*0) type-error)
-
+
 ;;; checks for uniform bounding index handling.
 ;;;
 ;;; This used to be SAFETY 3 only, but bypassing these checks with
@@ -964,7 +964,7 @@
  (assert-error
   (with-input-from-string (s string :start 6 :end 9)
     (read-char s))))
-
+
 ;;; testing bit-bashing according to _The Practice of Programming_
 (defun fill-bytes-for-testing (bitsize)
   "Return a list of 'bytes' of type (MOD BITSIZE)."
@@ -1121,7 +1121,7 @@
 (loop for i = 1 then (* i 2) do
       (assert (test-inlined-bashing i))
       until (= i sb-vm:n-word-bits))
-
+
 ;;; tests from the Sacla test suite via Eric Marsden, 2007-05-07
 (remove-duplicates (vector 1 2 2 1) :test-not (lambda (a b) (not (= a b))))
 
@@ -1155,7 +1155,7 @@
     (declare (ignore failure-p))
     (assert (= 1 (length warnings)))
     (assert-error (funcall fun 1 #'eql (complement #'eql)))))
-
+
 ;;; tests of deftype types equivalent to STRING or SIMPLE-STRING
 (deftype %string () 'string)
 (deftype %simple-string () 'simple-string)

--- a/tests/stream.impure.lisp
+++ b/tests/stream.impure.lisp
@@ -75,7 +75,7 @@
   (assert (equal (bug225 (make-string-output-stream))
                  '(sb-impl::string-output-stream string-stream stream))))
 
-
+
 ;;; improper buffering on (SIGNED-BYTE 8) streams (fixed by David Lichteblau):
 (with-test (:name (write-byte (unsigned-byte 8) read-byte (signed-byte 8)))
   (let ((p (scratch-file-name)))
@@ -87,7 +87,7 @@
     (with-open-file (s p :element-type '(signed-byte 8))
       (assert (= (read-byte s) -1)))
     (delete-file p)))
-
+
 ;;; :IF-EXISTS got :ERROR and NIL the wrong way round (reported by
 ;;; Milan Zamazal)
 (with-test (:name (open :if-exists :error))
@@ -98,7 +98,7 @@
      (with-open-file (s p :direction :output :if-exists :error)))
     (close stream)
     (delete-file p)))
-
+
 (with-test (:name (read-byte make-string-input-stream type-error))
   (assert-error (read-byte (make-string-input-stream "abc"))
                 type-error))
@@ -124,7 +124,7 @@
             (want "THESE INSERTMBOLS"))
         (assert (equal line want))))
     (delete-file p)))
-
+
 ;;; :DIRECTION :IO didn't work on non-existent pathnames
 (with-test (:name (with-open-file :direction :io :non-existent-pathname))
   (let ((p (scratch-file-name)))
@@ -135,7 +135,7 @@
       (file-position s :start)
       (assert (char= (read-char s) #\1)))
     (delete-file p)))
-
+
 ;;; FILE-POSITION on broadcast-streams is mostly uncontroversial
 (with-test (:name (file-position broadcast-stream 1))
   (assert (= 0 (file-position (make-broadcast-stream))))
@@ -217,7 +217,7 @@
 (with-test (:name (:element-type signed-byte write-byte write-byte))
   (loop for size from 2 to 40 do
            (bin-stream-test :size size :type 'signed-byte)))
-
+
 ;;; Check READ-SEQUENCE signals a TYPE-ERROR when the sequence can't
 ;;; contain a stream element.
 ;;;
@@ -341,7 +341,7 @@
             (assert (subtypep (type-error-expected-type condition)
                               '(signed-byte 8)))))))
     (delete-file pathname)))
-
+
 ;;; Check WRITE-SEQUENCE signals a TYPE-ERROR when the stream can't
 ;;; write a sequence element.
 ;;;
@@ -630,7 +630,7 @@
       (file-position f :start)
       (assert (equal "still open" (read-line f)))))
   (assert (not (probe-file "delete-file-on-stream-test.tmp"))))
-
+
 ;;; READ-CHAR-NO-HANG on bivalent streams (as returned by RUN-PROGRAM)
 ;;; was wrong.  CSR managed to promote the wrongness to all streams in
 ;;; the 1.0.32.x series, breaking slime instantly.

--- a/tests/test-util.lisp
+++ b/tests/test-util.lisp
@@ -67,7 +67,7 @@
 (setenv "SBCL_MACHINE_TYPE" (machine-type))
 (setenv "SBCL_SOFTWARE_TYPE" (software-type))
 
-
+
 ;;; Type tools
 
 (defun random-type (n)
@@ -92,7 +92,7 @@
        (assert (eq ,expected-result ,result))
        (assert (eq ,expected-certainp ,certainp)))))
 
-
+
 ;;; Thread tools
 
 (defun make-kill-thread (&rest args)
@@ -297,7 +297,7 @@
 
 (defun skipped-p (skipped-on)
   (sb-impl::featurep skipped-on))
-
+
 ;;;; MAP-{OPTIMIZATION-QUALITY-COMBINATIONS,OPTIMIZE-DECLARATIONS}
 
 (sb-int:defconstant-eqx +optimization-quality-names+
@@ -431,7 +431,7 @@
 (defun map-optimize-declarations* (function specifier)
   (apply #'map-optimize-declarations
          function (expand-optimize-specifier specifier)))
-
+
 ;;;; CHECKED-COMPILE
 
 (defun prepare-form (thing &key optimize)

--- a/tests/threads.impure.lisp
+++ b/tests/threads.impure.lisp
@@ -11,7 +11,7 @@
 ;;;; absoluely no warranty. See the COPYING and CREDITS files for
 ;;;; more information.
 
-
+
 ;;;; WHITE-BOX TESTS
 
 (shadowing-import 'assertoid:assert-error)
@@ -883,7 +883,7 @@
                                        (sb-debug:print-backtrace :count 10))))))))
     (wait-for-threads threads)))
 
-
+
 
 (defun subtypep-hash-cache-test ()
   (dotimes (i 10000)
@@ -902,7 +902,7 @@
         (loop repeat 30
               collect (make-thread #'subtypep-hash-cache-test)))
   (terpri))
-
+
 ;;;; BLACK BOX TESTS
 
 (with-test (:name (:parallel defclass))

--- a/tests/type.impure.lisp
+++ b/tests/type.impure.lisp
@@ -260,7 +260,7 @@
          (m (find-if #'sb-kernel:member-type-p (sb-kernel:union-type-types x))))
     (assert (equal (sb-kernel:member-type-members m) '(foo)))))
 
-
+
 ;;;; Douglas Thomas Crosher rewrote the CMU CL type test system to
 ;;;; allow inline type tests for CONDITIONs and STANDARD-OBJECTs, and
 ;;;; generally be nicer, and Martin Atzmueller ported the patches.
@@ -411,7 +411,7 @@
 (with-test (:name (:inline-type-tests :compiled))
   (tests-of-inline-type-tests)
   (format t "~&/done with compiled (TESTS-OF-INLINE-TYPE-TESTS)~%"))
-
+
 ;;; Redefinition of classes should alter the type hierarchy (BUG 140):
 (defclass superclass () ())
 (defclass maybe-subclass () ())
@@ -420,7 +420,7 @@
 (assert-tri-eq t t (subtypep 'maybe-subclass 'superclass))
 (defclass maybe-subclass () ())
 (assert-tri-eq nil t (subtypep 'maybe-subclass 'superclass))
-
+
 ;;; Prior to sbcl-0.7.6.27, there was some confusion in ARRAY types
 ;;; specialized on some as-yet-undefined type which would cause this
 ;;; program to fail (bugs #123 and #165). Verify that it doesn't.
@@ -446,7 +446,7 @@
     (assert-tri-eq nil t (subtypep t2 t1))
     (assert-tri-eq t   t (subtypep `(not ,t2) `(not ,t1)))
     (assert-tri-eq nil t (subtypep `(not ,t1) `(not ,t2)))))
-
+
 ;;; not easily visible to user code, but this used to be very
 ;;; confusing.
 (with-test (:name (:ctor typep function))
@@ -462,7 +462,7 @@
                         'function))))
 (with-test (:name (:ctor allocate-instance functionp))
   (assert (functionp (allocate-instance (find-class 'sb-pcl::ctor)))))
-
+
 ;;; from PFD ansi-tests
 (with-test (:name (subtypep :complex-cons-type))
   (let ((t1 '(cons (cons (cons (real -744833699 -744833699) cons)
@@ -472,7 +472,7 @@
                     (integer -234496 215373))
               t)))
     (assert-tri-eq nil t (subtypep `(not ,t2) `(not ,t1)))))
-
+
 (defstruct misc-629a)
 (defclass misc-629b () ())
 (defclass misc-629c () () (:metaclass sb-mop:funcallable-standard-class))
@@ -515,7 +515,7 @@
     (assert-tri-eq t t (subtypep `(and (member ,misc-629c)
                                        sb-kernel:instance)
                                  nil))))
-
+
 ;;; this was broken during the FINALIZE-INHERITANCE rearrangement; the
 ;;; MAKE-INSTANCE finalizes the superclass, thus invalidating the
 ;;; subclass, so SUBTYPEP must be prepared to deal with
@@ -524,13 +524,13 @@
 (with-test (:name (subtypep defclass make-instance))
   (make-instance 'ansi-tests-defclass1)
   (assert-tri-eq t t (subtypep 'ansi-tests-defclass3 'standard-object)))
-
+
 ;;; so was this
 (with-test (:name (type-of defclass :undefine))
   (let ((class (eval '(defclass to-be-type-ofed () ()))))
     (setf (find-class 'to-be-type-ofed) nil)
     (assert (eq (type-of (make-instance class)) class))))
-
+
 ;;; accuracy of CONS :SIMPLE-TYPE-=
 (deftype goldbach-1 () '(satisfies even-and-greater-then-two-p))
 (deftype goldbach-2 () '(satisfies sum-of-two-primes-p))
@@ -557,7 +557,7 @@
   (elt (aref x 0) 0))
 (with-test (:name (array :element-type aref optimize speed :bug-306-a))
   (assert (= 0 (bug-306-a #((0))))))
-
+
 ;;; FUNCALLABLE-INSTANCE is a subtype of function.
 (with-test (:name (subtypep function sb-kernel:funcallable-instance))
   (assert-tri-eq t t (subtypep '(and pathname function) nil))
@@ -572,7 +572,7 @@
 (with-test (:name (subtypep standard-object sb-kernel:instance))
   (assert (not (typep #'print-object '(and standard-object sb-kernel:instance))))
   (assert (not (subtypep 'standard-object '(and standard-object sb-kernel:instance)))))
-
+
 (with-test (:name (subtypep simple-array simple-string condition or))
   (assert-tri-eq t t
                  (subtypep '(or simple-array simple-string) '(or simple-string simple-array)))
@@ -769,7 +769,7 @@
 
     (test 'subtypep-fwd-testb1 'subtypep-fwd-testb2 nil nil)
     (test 'subtypep-fwd-testb2 'subtypep-fwd-testb1 t t)))
-
+
 ;;; Array type unions have some tricky semantics.
 
 (macrolet

--- a/tests/unwind-to-frame-and-call.impure.lisp
+++ b/tests/unwind-to-frame-and-call.impure.lisp
@@ -47,7 +47,7 @@
 (defvar *b*)
 (defvar *c*)
 
-
+
 ;;;; Test RESTART-FRAME
 
 (define-condition restart-condition () ())
@@ -108,7 +108,7 @@
 (with-test (:name (:restart-frame :normal) :fails-on :win32)
   (test-restart 'restart/normal))
 
-
+
 ;;;; Test RETURN-FROM-FRAME with normal functions
 
 (define-condition return-condition () ())
@@ -170,7 +170,7 @@
                  (throw-y))
                'y)))
 
-
+
 ;;;; Test RETURN-FROM-FRAME with local functions
 
 (define-condition in-a () ())
@@ -231,7 +231,7 @@
 (with-test (:name (:return-from-frame :hairy-local-function) :fails-on :win32)
   (test-locals 'hairy-locals))
 
-
+
 ;;;; Test RETURN-FROM-FRAME with anonymous functions
 
 (define-condition anon-condition () ())
@@ -290,7 +290,7 @@
 (with-test (:name (:return-from-frame :anonymous :special) :fails-on :win32)
   (test-anon *anon-4* '*foo* 'make-anon-4))
 
-
+
 ;;;; Test that unwind cleanups are executed
 
 (defvar *unwind-state* nil)

--- a/tests/walk.impure.lisp
+++ b/tests/walk.impure.lisp
@@ -24,7 +24,7 @@
 ;;;; specification.
 
 (in-package :sb-walker)
-
+
 ;;;; utilities to support tests
 
 ;;; string equality modulo deletion of consecutive whitespace (as a crude way
@@ -40,7 +40,7 @@
 (defun string=-modulo-tabspace (x y)
   (string= (string-modulo-tabspace x)
            (string-modulo-tabspace y)))
-
+
 ;;;; tests based on stuff at the end of the original CMU CL
 ;;;; pcl/walk.lisp file
 
@@ -1056,10 +1056,10 @@ Form: C   Context: EVAL; lexically bound
 \(LET* ((A A) (B A) (C B) (B C))
   (DECLARE (SPECIAL A B))
   (LIST A B C))")))
-
+
 ;;;; more tests
 
 ;;; Old PCL hung up on this.
 (defmethod #:foo ()
   (defun #:bar ()))
-
+

--- a/tools-for-build/ucd.lisp
+++ b/tools-for-build/ucd.lisp
@@ -80,7 +80,7 @@
 (defun clear-flag (bit integer)
   (logandc2 integer (ash 1 bit)))
 
-
+
 ;;; Output storage globals
 (defstruct ucd misc decomp)
 
@@ -218,7 +218,7 @@ Length should be adjusted when the standard changes.")
 
 (defvar *block-first* nil)
 
-
+
 ;;; Unicode data file parsing
 (defun hash-misc (gc-index bidi-index ccc digit decomposition-info flags
                   script line-break age)
@@ -599,7 +599,7 @@ Length should be adjusted when the standard changes.")
   (fixup-decompositions)
   nil)
 
-
+
 ;;; PropList.txt
 (defparameter **proplist-properties** nil
   "A list of properties extracted from PropList.txt")
@@ -674,7 +674,7 @@ Length should be adjusted when the standard changes.")
   (setf **proplist-properties** (nreverse **proplist-properties**))
   (values))
 
-
+
 ;;; Collation keys
 (defvar *maximum-variable-key* 1)
 
@@ -715,7 +715,7 @@ Length should be adjusted when the standard changes.")
             (setf (gethash codepoints hash) keys))
        finally (return hash))))
 
-
+
 ;;; Other properties
 (defparameter *confusables*
   (with-input-txt-file (stream "ConfusablesEdited")
@@ -764,7 +764,7 @@ Length should be adjusted when the standard changes.")
     (cons (nreverse (coerce ranges 'vector)) (nreverse names)))
   "Vector of block starts and ends in a form acceptable to `ordered-ranges-position`.
 Used to look up block data.")
-
+
 ;;; Output code
 (defun write-codepoint (code-point stream)
   (declare (type (unsigned-byte 32) code-point))


### PR DESCRIPTION
This diff removes ^L form feed (\f with ascii code 0x0C) from source code files.