### PR TITLE
Use NEWS date instead of build date

### DIFF
--- a/make-config.sh
+++ b/make-config.sh
@@ -723,7 +723,7 @@ if [ `uname` = "SunOS" ] ; then
   # use /usr/xpg4/bin/id instead of /usr/bin/id
   PATH=/usr/xpg4/bin:$PATH
 fi
-echo '"'`hostname`-`id -un`-`date +%Y-%m-%d-%H-%M-%S`'"' > output/build-id.inc
+echo '"'${HOSTNAME:-`hostname`}-`id -un`-`date -r NEWS +%Y-%m-%d-%H-%M-%S`'"' > output/build-id.inc
 
 if [ -n "$SBCL_HOST_LOCATION" ]; then
     echo //setting up host configuration


### PR DESCRIPTION
Use `NEWS` file date instead of build date
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good.

This date call works with GNU date and BSD date.

Also allow to override hostname.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).