### PR TITLE
Add wrapper around clock_gettime, needed for NetBSD

### DIFF
--- a/src/code/unix.lisp
+++ b/src/code/unix.lisp
@@ -67,6 +67,7 @@
                              "sb_select" ; int-syscall
                              "sb_getitimer" ; syscall*
                              "sb_setitimer" ; syscall*
+                             "sb_clock_gettime" ; syscall*
                              "sb_utimes") ; posix
                          :test #'string=)
                  (subseq x 3)
@@ -1049,13 +1050,14 @@ avoiding atexit(3) hooks, etc. Otherwise exit(2) is called."
   (defun clock-gettime (clockid)
     (declare (type (signed-byte 32) clockid))
     (with-alien ((ts (struct timespec)))
-      (alien-funcall (extern-alien "clock_gettime" (function int int (* (struct timespec))))
-                     clockid (addr ts))
-      ;; 'seconds' is definitely a fixnum for 64-bit, because most-positive-fixnum
-      ;; can express 1E11 years in seconds.
-      (values #+64-bit (truly-the fixnum (slot ts 'tv-sec))
-              #-64-bit (slot ts 'tv-sec)
-              (truly-the (integer 0 #.(expt 10 9)) (slot ts 'tv-nsec)))))
+      (syscall* ("sb_clock_gettime" int (* (struct timespec)))
+                ;; 'seconds' is definitely a fixnum for 64-bit, because
+                ;; most-positive-fixnum can express 1E11 years in seconds.
+                (values #+64-bit (truly-the fixnum (slot ts 'tv-sec))
+                        #-64-bit (slot ts 'tv-sec)
+                        (truly-the (integer 0 #.(expt 10 9))
+                                   (slot ts 'tv-nsec)))
+                clockid (addr ts))))
 
   (declaim (inline get-time-of-day))
   (defun get-time-of-day ()

--- a/src/runtime/wrap.c
+++ b/src/runtime/wrap.c
@@ -616,6 +616,12 @@ int sb_utimes(char *path, struct timeval times[2])
 {
     return utimes(path, times);
 }
+
+int sb_clock_gettime(clockid_t clock_id, struct timespec *tp)
+{
+    return clock_gettime(clock_id, tp);
+}
+
 #ifndef LISP_FEATURE_SB_THREAD
 #include <signal.h>
 int sb_sigprocmask(int how, const sigset_t *set, sigset_t *oldset)


### PR DESCRIPTION
Hi,

this patch is needed for NetBSD because struct timespec evolved (long ago) and clock_gettime() is versioned.

Compilation of sbcl fails under at least NetBSD/aarch64 because (fortunately) make-source-info explicitly requests unsigned-byte and gets served a negative value due to clock-gettime reading the struct timespec fields with an inconsistent size wrt the syscall actually made.

There are two other incorrect calls of clock_gettime() in tests/deadlock.impure.lisp, and I don't know if there is a clean way à la syscall* to fix them. Otherwise #+netbsd "sb_clock_gettime" #-netbsd "clock_gettime" should do.

Regards,