### PR TITLE
run-sbcl.sh set BASE using realpath and dirname

### DIFF
--- a/run-sbcl.sh
+++ b/run-sbcl.sh
@@ -26,7 +26,12 @@ while [ -h "$this" ]; do
         this=`dirname "$this"`/"$link"
     fi
 done
-BASE=`dirname "$this"`
+
+# need realpath to BASE because relative paths
+# have bad interactions with asdf:load-system
+# for systems that try to require implementation
+# specific values found in SBCL_HOME
+BASE=$(realpath $(dirname "$this"))
 
 CORE_DEFINED=no
 


### PR DESCRIPTION
If SBCL_HOME is a relative path then it is computed relative
to `*default-pathname-defaults*`. When running asdf:load-system
`*default-pathname-defaults*` is set to the path of the system
being loaded. If there is a call to (require 'thing) anywhere
in the system definition then SBCL_HOME will be expanded
incorrectly and the require will fail.

Since SBCL_HOME is set from BASE in run-sbcl.sh this patch is
the simplest fix to restore correct behavior. I do not know
whether SBCL_HOME should ever be allowed to be a relative path
and I it doesn't seem that ASDF is doing anything wrong here
since the issue is in the package that is calling require at
a somewhat strange time.