### PR TITLE
do not hardcode LD=ld in GNUmakefile

### DIFF
--- a/make-target-contrib.sh
+++ b/make-target-contrib.sh
@@ -29,8 +29,12 @@ if [ -z "$CC" ]; then
     fi
 fi
 
+if [ -z "${LD}" ]; then
+    LD=ld
+fi
+
 unset EXTRA_CFLAGS # avoid any potential interference 
-export CC LANG LC_ALL
+export CC LD LANG LC_ALL
 
 # Load our build configuration
 . output/build-config

--- a/src/runtime/GNUmakefile
+++ b/src/runtime/GNUmakefile
@@ -24,7 +24,6 @@ SBCL_PAXCTL ?= :
 LINKFLAGS += -g
 DEPEND_FLAGS = -MM
 GREP = grep
-LD = ld
 
 # By default, don't make and use a library, just use the object files.
 LIBSBCL = $(OBJS)


### PR DESCRIPTION
When cross compiling for an alternate libc implementation (e.g. musl for
static linking) a different linker required. It is currenly impossible
to pass LD=some-other-linker-ld in the environment or as part of a call
to make because the GNUmakefile hardcodes LD=ld. This commit fixes that
an also make it so that make-target-contrib.sh inhertis LD in the same
way that it inherits CC.

I'm to 100% sure that this works as expected. I've tried it in what should be a clean environment without issue, but am not entirely sure that LD will be set correctly be default.