### PR TITLE
Remove *.dSYM on macOS in `clean.sh`

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -105,6 +105,7 @@ find . \( \
         -name '*.o' -o \
         -name '*.so' -o \
         -name '*.d' -o \
+        -name '*.dSYM' -o \
         -name 'foo.c' -o \
         -name 'test-output' -o \
         -name 'test-lab' -o \


### PR DESCRIPTION
 The build process creates them, thus they must be removed beforehand, in order to prevent carrying over build artefacts from a previous build.
