### PR TITLE
compile fix for haiku

### DIFF
--- a/src/runtime/x86-64-haiku-os.c
+++ b/src/runtime/x86-64-haiku-os.c
@@ -47,10 +47,10 @@ os_restore_fp_control(os_context_t *context)
     // just guessing here
 
     /* reset exception flags and restore control flags on SSE2 FPU */
-    unsigned int temp = (context->uc_mcontext.fpu.mxcsr) & ~0x3F;
+    unsigned int temp = (context->uc_mcontext.fpu.fp_fxsave.mxcsr) & ~0x3F;
     asm ("ldmxcsr %0" : : "m" (temp));
     /* same for x87 FPU. */
-    asm ("fldcw %0" : : "m" (context->uc_mcontext.fpu.control));
+    asm ("fldcw %0" : : "m" (context->uc_mcontext.fpu.fp_fxsave.control));
 }
 
 void


### PR DESCRIPTION
hello,

after attempting an initial bootstrap sbcl on haiku, i noticed that the bootstrap issues ran into some compile issues in the runtime. it would throw up an error around the build step

```
cc -g -Wall -Wundef -Wsign-compare -Wpointer-arith -O3 -Wunused-parameter -fno-omit-frame-pointer -momit-leaf-frame-pointer -g
dwarf-2 -I.  -c -o x86-64-haiku-os.o x86-64-haiku-os.c

```

the following change should allow the bootstrap (using abcl) to get past  building the runtime. tested on a nightly build of haiku with a checkout of sbcl

```
> uname -a
Haiku shredder 1 hrev55490 Oct  8 2021 06:03:40 x86_64 x86_64 Haiku

```