### PR TITLE
Add MSG-WAITALL socket option for Windows

### DIFF
--- a/contrib/sb-bsd-sockets/constants-win32.lisp
+++ b/contrib/sb-bsd-sockets/constants-win32.lisp
@@ -41,6 +41,8 @@
  (:integer SHUT_WR "SD_SEND")
  (:integer SHUT_RDWR "SD_BOTH")
 
+ (:integer msg-waitall "MSG_WAITALL")
+
  (:integer EADDRINUSE "WSAEADDRINUSE")
  (:integer EAGAIN "WSAEWOULDBLOCK")
  (:integer EBADF "WSAEBADF")

--- a/contrib/sb-bsd-sockets/win32-sockets.lisp
+++ b/contrib/sb-bsd-sockets/win32-sockets.lisp
@@ -72,5 +72,4 @@
 (defconstant msg-trunc 0)
 (defconstant msg-eor 0)
 (defconstant msg-nosignal 0)
-(defconstant msg-waitall 0)
 (defconstant msg-eor 0)


### PR DESCRIPTION
This PR fixes bug [#1979132](https://bugs.launchpad.net/sbcl/+bug/1979132), I have tested on Windows 11, `WAITALL` option for `sb-bsd-sockets:SOCKET-RECEIVE` works properly after this change.