### PR TITLE
describe: return the documentation string of macros

### DIFF
--- a/src/pcl/documentation.lisp
+++ b/src/pcl/documentation.lisp
@@ -240,7 +240,9 @@
       (documentation it t)))
 
   (defmethod documentation ((x list) (doc-type (eql 'function)))
-    (maybe-function-documentation x))
+    (if (eql (car x) 'macro-function)
+        (maybe-function-documentation (cadr x))
+        (maybe-function-documentation x)))
 
   (defmethod documentation ((x symbol) (doc-type (eql 'function)))
     (maybe-function-documentation x))
@@ -256,7 +258,9 @@
   (setf (fun-doc x) new-value))
 
 (defmethod (setf documentation) (new-value (x list) (doc-type (eql 'function)))
-  (set-function-name-documentation x new-value))
+  (if (eql (car x) 'macro-function)
+      (set-function-name-documentation (cadr x) new-value)
+      (set-function-name-documentation x new-value)))
 
 (defmethod (setf documentation) (new-value (x list) (doc-type (eql 'compiler-macro)))
   (awhen (compiler-macro-function x)

--- a/tests/interface.impure.lisp
+++ b/tests/interface.impure.lisp
@@ -373,6 +373,19 @@
   (setf (documentation 'bug-643958-test 'function) "bar")
   (assert (equal "bar" (documentation 'bug-643958-test 'function))))
 
+(defmacro test-macro-function ()
+  "foo"
+  :dong!)
+
+(with-test (:name (documentation :macro-function))
+  (assert (equal
+           "foo"
+           (documentation (macro-function 'test-macro-function) 'function)))
+  (setf (documentation (macro-function 'test-macro-function) 'function) "bar")
+  (assert (equal
+           "bar"
+           (documentation (macro-function 'test-macro-function) 'function))))
+
 (with-test (:name (:endianness :in *features*))
   (assert
    (or (member :big-endian *features*)


### PR DESCRIPTION
Fix macro description when called like this:

```
(describe (macro-function 'cffi:with-foreign-pointer-as-string))
```

Macro-functions are already handled by describe-function and describe-object, but the documentation string was never being passed back for the macro-function type.

This is before the patch

```
CL-USER> (describe (macro-function 'with-locked-hash-table))
#<FUNCTION (MACRO-FUNCTION WITH-LOCKED-HASH-TABLE) {52FBEA0B}>
  [compiled function]


Lambda-list: ((HASH-TABLE) &BODY BODY)
Derived type: (FUNCTION (T T) (VALUES CONS &OPTIONAL))
Documentation:
  T
Source file: SYS:SRC;CODE;TARGET-EXTENSIONS.LISP
; No value
```
and after
```
CL-USER> (describe (macro-function 'with-locked-hash-table))
#<FUNCTION (MACRO-FUNCTION WITH-LOCKED-HASH-TABLE) {52FBEA0B}>
  [compiled function]


Lambda-list: ((HASH-TABLE) &BODY BODY)
Derived type: (FUNCTION (T T) (VALUES CONS &OPTIONAL))
Documentation:
  Limits concurrent accesses to HASH-TABLE for the duration of BODY.
  If HASH-TABLE is synchronized, BODY will execute with exclusive
  ownership of the table. If HASH-TABLE is not synchronized, BODY will
  execute with other WITH-LOCKED-HASH-TABLE bodies excluded -- exclusion
  of hash-table accesses not surrounded by WITH-LOCKED-HASH-TABLE is
  unspecified.
Source file: SYS:SRC;CODE;TARGET-EXTENSIONS.LISP
; No value
```