### PR TITLE
handle systems that do not support denormalized floats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,8 @@ tools-for-build/determine-endianness.exe
 tools-for-build/grovel-headers
 tools-for-build/grovel-headers.exe
 tools-for-build/mmap-rwx
+tools-for-build/testftz
+tools-for-build/testftz.exe
 tools-for-build/where-is-mcontext
 contrib/asdf/asdf-upstream
 doc/manual/*.html

--- a/make-config.sh
+++ b/make-config.sh
@@ -778,6 +778,18 @@ else
         $GNUMAKE -C tools-for-build determine-endianness -I ../src/runtime
         tools-for-build/determine-endianness >> $ltf
     fi
+    if $android
+    then
+        $CC tools-for-build/testftz*.c -o tools-for-build/testftz -lm
+        if android_run tools-for-build/testftz; then
+            printf ' :normalize-float' >> $ltf
+        fi
+    else
+        $GNUMAKE -C tools-for-build testftz OS_LIBS+=-lm
+        if tools-for-build/testftz; then
+            printf ' :normalize-float' >> $ltf
+        fi
+    fi
     export sbcl_os sbcl_arch android
     sh tools-for-build/grovel-features.sh >> $ltf
 fi

--- a/src/code/early-float.lisp
+++ b/src/code/early-float.lisp
@@ -59,21 +59,6 @@
 (defconstant most-negative-double-float #.most-negative-double-float)
 (defconstant pi #.pi)
 
-(defconstant least-positive-single-float (single-from-bits 0 0 1))
-(defconstant least-positive-short-float (single-from-bits 0 0 1))
-(defconstant least-negative-single-float (single-from-bits 1 0 1))
-(defconstant least-negative-short-float (single-from-bits 1 0 1))
-(defconstant least-positive-double-float (double-from-bits 0 0 1))
-#-long-float
-(defconstant least-positive-long-float (double-from-bits 0 0 1))
-#+(and long-float x86)
-(defconstant least-positive-long-float (long-from-bits 0 0 1))
-(defconstant least-negative-double-float (double-from-bits 1 0 1))
-#-long-float
-(defconstant least-negative-long-float (double-from-bits 1 0 1))
-#+(and long-float x86)
-(defconstant least-negative-long-float (long-from-bits 1 0 1))
-
 (defconstant least-positive-normalized-single-float
   (single-from-bits 0 sb-vm:single-float-normal-exponent-min 0))
 (defconstant least-positive-normalized-short-float
@@ -100,6 +85,41 @@
 (defconstant least-negative-normalized-long-float
   (long-from-bits 1 sb-vm:long-float-normal-exponent-min
                   (ash sb-vm:long-float-hidden-bit 32)))
+
+#-normalize-float
+(progn
+  (defconstant least-positive-single-float (single-from-bits 0 0 1))
+  (defconstant least-positive-short-float (single-from-bits 0 0 1))
+  (defconstant least-negative-single-float (single-from-bits 1 0 1))
+  (defconstant least-negative-short-float (single-from-bits 1 0 1))
+  (defconstant least-positive-double-float (double-from-bits 0 0 1))
+  #-long-float
+  (defconstant least-positive-long-float (double-from-bits 0 0 1))
+  #+(and long-float x86)
+  (defconstant least-positive-long-float (long-from-bits 0 0 1))
+  (defconstant least-negative-double-float (double-from-bits 1 0 1))
+  #-long-float
+  (defconstant least-negative-long-float (double-from-bits 1 0 1))
+  #+(and long-float x86)
+  (defconstant least-negative-long-float (long-from-bits 1 0 1)))
+#+normalize-float
+(progn
+  (defconstant least-positive-single-float
+    least-positive-normalized-single-float)
+  (defconstant least-positive-short-float
+    least-positive-normalized-short-float)
+  (defconstant least-negative-single-float
+    least-negative-normalized-single-float)
+  (defconstant least-negative-short-float
+    least-negative-normalized-short-float)
+  (defconstant least-positive-double-float
+    least-positive-normalized-double-float)
+  (defconstant least-positive-long-float
+    least-positive-normalized-long-float)
+  (defconstant least-negative-double-float
+    least-negative-normalized-double-float)
+  (defconstant least-negative-long-float
+    least-negative-normalized-long-float))
 
 (defconstant most-positive-short-float most-positive-single-float)
 (defconstant most-negative-short-float most-negative-single-float)

--- a/tools-for-build/Makefile
+++ b/tools-for-build/Makefile
@@ -15,7 +15,9 @@ CFLAGS:=-I../src/runtime $(CFLAGS)
 LDFLAGS:=$(LDFLAGS)
 LDLIBS:=$(OS_LIBS)
 
-all: grovel-headers determine-endianness where-is-mcontext mmap-rwx avx2
+all: grovel-headers determine-endianness where-is-mcontext mmap-rwx avx2 testftz
+
+testftz: testftz.o testftz-main.o
 
 clean:
 	rm -f *.o grovel-headers determine-endianness where-is-mcontext mmap-rwx avx2

--- a/tools-for-build/testftz-main.c
+++ b/tools-for-build/testftz-main.c
@@ -1,0 +1,5 @@
+double ftz(int);
+
+int main() {
+    return ftz(1)>0;
+}

--- a/tools-for-build/testftz.c
+++ b/tools-for-build/testftz.c
@@ -1,0 +1,14 @@
+#include <stdint.h>
+#include <math.h>
+
+/* make sure we don't use builtin */
+double (*myceil)(double x) = &ceil;
+
+double ftz(int i) {
+    union {
+        uint64_t i;
+        double f;
+    } v;
+    v.i = i;
+    return myceil(v.f);
+}


### PR DESCRIPTION
A feature of gcc on Intel platforms is to enable the FTZ and DAZ features available on modern Intel CPUs. Those features convert denormal floating point values to zero to avoid expensive and slow exception handling inside the CPU. Details can be found at https://www.intel.com/content/www/us/en/develop/documentation/cpp-compiler-developer-guide-and-reference/top/compiler-reference/floating-point-operations/set-the-ftz-and-daz-flags.html

Some Linux distributions now started to make this flag the compiler default and build the standard runtime libraries with this switch turned on. On those systems the definition of least-*-*-float evaluates to zero, no longer adhering to their specification, and as such failing test cases relying on them. Compiling sbcl with this compiler feature explicitly turned off is not preventing this problem from happening since we use functions from libm that is built with this switch turned on and as such will apply the conversions nevertheless to our surprise.

Therefore this introduces a new feature "normalize-float" for systems with that behavior. This automatically gets switched on by an automated test. The test is designed to detect similar behavior also on non-Intel systems. The definitions of least-*-*-float are adapted accordingly.

This can be found at https://bugs.launchpad.net/sbcl/+bug/2002810 as well.