### PR TITLE
Mention of automatic detection of calling convention in ffi.texinfo

### DIFF
--- a/doc/manual/ffi.texinfo
+++ b/doc/manual/ffi.texinfo
@@ -700,7 +700,8 @@ calling @code{load-shared-object}.
 @section Foreign Function Calls
 
 The foreign function call interface allows a Lisp program to call
-many functions written in languages that use the C calling convention.
+functions written in other languages. Calling convention
+is detected automatically.
 
 Lisp sets up various signal handling routines and other environment
 information when it first starts up, and expects these to be in place


### PR DESCRIPTION
u/stassats mentioned in this reddit thread https://www.reddit.com/r/Common_Lisp/comments/13hfrl0/write_windows_event_log_in_sbcl/ that calling convention is detected automatically. I got confused by this statement in the manual so I propose a change.