### PR TITLE
fix building when root directory contain non-ASCII characters

### DIFF
--- a/contrib/sb-posix/posix-tests.lisp
+++ b/contrib/sb-posix/posix-tests.lisp
@@ -511,7 +511,8 @@
 
 #-(and darwin x86)
 (deftest readdir.1
-  (let ((dir (sb-posix:opendir "/")))
+  (let ((dir (sb-posix:opendir "/"))
+        (sb-alien::*default-c-string-external-format* :latin-1))
     (unwind-protect
        (block dir-loop
          (loop for dirent = (sb-posix:readdir dir)


### PR DESCRIPTION
This is a backport a patch from MacPorts which was used here for years.

See: https://github.com/macports/macports-ports/blob/ebe87150a51a2b9e5f7ca9393d70f73c34c03f36/lang/sbcl/files/patch-contrib-sb-posix-posix-tests.lisp.diff

Cc: @easye