### PR TITLE
Fix building by lisp without endian features

### DIFF
--- a/src/cold/shebang.lisp
+++ b/src/cold/shebang.lisp
@@ -34,7 +34,9 @@
 (defun compatible-vector-raw-bits () ; T if the host and target match on word size and endianness
   (flet ((endianness (features)
            (let ((result (intersection '(:little-endian :big-endian) features)))
-             (assert (and result (not (cdr result))))
+             ;; some lisp implementation may not have little-endian / big-endian
+             ;; features which shouldn't trigger that assert
+             (assert (or (not result) (and result (not (cdr result)))))
              (car result)))
          (wordsize (features)
            (if (member :64-bit features) 64 32)))


### PR DESCRIPTION
Some lisp may not have little-endian or big-endian in features which leads to trigger that asset that shouldn't happened because target features contains it and it should downgrade to bvref-64/bvref-32 instead of native-bvref-word.

This issue was introduced at 1ec9a7270aeb2f2b4d7d14919e323b44ee117be8