### PR TITLE
Increase hardcoded macosx-version-min

### DIFF
--- a/contrib/sb-grovel/def-to-lisp.lisp
+++ b/contrib/sb-grovel/def-to-lisp.lisp
@@ -201,10 +201,10 @@ code:
        #+(and x86-64 darwin inode64)
        `("-arch" "x86_64" ,(format nil "-mmacosx-version-min=~A"
                                    (or (sb-ext:posix-getenv "SBCL_MACOSX_VERSION_MIN")
-                                       "10.6"))
+                                       "10.12"))
                  "-D_DARWIN_USE_64_BIT_INODE")
        #+(and x86-64 darwin (not inode64))
-       '("-arch" "x86_64" "-mmacosx-version-min=10.4")
+       '("-arch" "x86_64" "-mmacosx-version-min=10.12")
        #+(and x86-64 sunos) '("-m64")
        (list "-o" (namestring exefile) (namestring sourcefile)))
       :search t

--- a/src/runtime/Config.x86-64-darwin
+++ b/src/runtime/Config.x86-64-darwin
@@ -15,8 +15,8 @@ ifdef SBCL_MACOSX_VERSION_MIN
   CFLAGS += -mmacosx-version-min=$(SBCL_MACOSX_VERSION_MIN)
   LINKFLAGS += -mmacosx-version-min=$(SBCL_MACOSX_VERSION_MIN)
 else
-  CFLAGS += -mmacosx-version-min=10.6
-  LINKFLAGS += -mmacosx-version-min=10.6
+  CFLAGS += -mmacosx-version-min=10.12
+  LINKFLAGS += -mmacosx-version-min=10.12
 endif
 ifdef LISP_FEATURE_INODE64
 CFLAGS += -D_DARWIN_USE_64_BIT_INODE


### PR DESCRIPTION
SBCL heavy uses clock_gettime which was introduced at macOS 10.12, such settings just confuses everyone.

It is still possible to build on legacy system but with some library which re-implements clock_gettime for legacy system like MacPorts Legacy Support.