### PR TITLE
arm/Darwin: disable futex on BigSur

### DIFF
--- a/make-config.sh
+++ b/make-config.sh
@@ -628,9 +628,9 @@ case "$sbcl_os" in
         ;;
     darwin)
         printf ' :unix :bsd :darwin :mach-o' >> $ltf
+        darwin_version=`uname -r`
+        darwin_version_major=${DARWIN_VERSION_MAJOR:-${darwin_version%%.*}}
         if [ $sbcl_arch = "x86-64" ]; then
-            darwin_version=`uname -r`
-            darwin_version_major=${DARWIN_VERSION_MAJOR:-${darwin_version%%.*}}
 
             if (( 8 < $darwin_version_major )); then
 	        printf ' :inode64' >> $ltf
@@ -638,6 +638,9 @@ case "$sbcl_os" in
         fi
         if [ $sbcl_arch = "arm64" ]; then
             printf ' :darwin-jit :gcc-tls' >> $ltf
+            if (( 20 < $darwin_version_major )); then
+	        printf ' :sb-futex' >> $ltf
+            fi
         fi
         if $android; then
             echo "Android build is unsupported on darwin"

--- a/src/cold/shared.lisp
+++ b/src/cold/shared.lisp
@@ -291,7 +291,7 @@
              (arch (target-platform-keyword)))
         ;; Win32 conditionally adds :sb-futex in grovel-features.sh
         ;; Futexes aren't available in all macos versions, but they are available in all versions that support arm, so always enable them there
-        (when (target-featurep '(:and :sb-thread (:or :linux :freebsd :openbsd (:and :darwin :arm64))))
+        (when (target-featurep '(:and :sb-thread (:or :linux :freebsd :openbsd)))
           (pushnew :sb-futex sb-xc:*features*))
         (when (target-featurep :immobile-space)
           (when (target-featurep :x86-64)


### PR DESCRIPTION
Unconditional enable of futex on macOS on arm had happened at 4ce2310cc5d9db835423168cac0d28ed8caff3eb, unfortunately it brokes build on macOS 11 aka BigSur as:
```
  fatal error encountered in SBCL pid 42995 pthread 0x16b513000:
  GC invariant lost, file "thread.c", line 256
```
Building with `--without-sb-futex` won't help because it's enforced on all arm darwin machines.

Here I've moved enabling it into `make-config.sh` on macOS 12 or never.