### PR TITLE
determine-endianness: Convert to C preprocessor check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,6 @@ tests/run-tests-*
 tests/last-random-state.lisp-expr
 tests/ansi-test/
 tools-for-build/avx2*
-tools-for-build/determine-endianness
-tools-for-build/determine-endianness.exe
 tools-for-build/grovel-headers
 tools-for-build/grovel-headers.exe
 tools-for-build/mmap-rwx

--- a/tools-for-build/Makefile
+++ b/tools-for-build/Makefile
@@ -15,9 +15,9 @@ CFLAGS:=-I../src/runtime $(CFLAGS)
 LDFLAGS:=$(LDFLAGS)
 LDLIBS:=$(OS_LIBS)
 
-all: grovel-headers determine-endianness where-is-mcontext mmap-rwx avx2
+all: grovel-headers where-is-mcontext mmap-rwx avx2
 
 clean:
-	rm -f *.o grovel-headers determine-endianness where-is-mcontext mmap-rwx avx2
+	rm -f *.o grovel-headers where-is-mcontext mmap-rwx avx2
 	rm -f *.exe
 	rm -fr *.dSYM

--- a/tools-for-build/determine-endianness.c
+++ b/tools-for-build/determine-endianness.c
@@ -17,35 +17,10 @@
  * more information.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
-
-int main (int __attribute__((unused)) argc, char __attribute__((unused)) *argv[]) {
-    int foo = 0x20212223;
-    char *bar = (char *) &foo;
-    switch(*bar) {
-    case ' ':
-        printf(" :big-endian");
-        break;
-    case '#':
-        printf(" :little-endian");
-        break;
-    default:
-        /* FIXME: How do we do sane error processing in Unix?  This
-           program will be called from a script, in a manner somewhat
-           like:
-
-               tools-for-build/determine-endianness >> $ltf
-
-           but what if we have a too-smart C compiler that actually
-           gets us down to this branch?  I suppose that if we have a C
-           compiler that is that smart, we're doomed to miscompile the
-           runtime anyway, so we won't get here.  Still, it might be
-           good to have "set -e" in the various scripts so that we can
-           exit with an error here and have it be caught by the build
-           tools.  -- CSR, 2002-11-24
-        */
-        exit(1);
-    }
-    exit(0);
-}
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#warning " :big-endian"
+#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#warning " :little-endian"
+#else
+#error No __BYTE_ORDER__ macro
+#endif


### PR DESCRIPTION
Tested on GCC, Clang & tcc.

Just a small step towards easier cross-compilation, this avoids needing to run a program targeted to another architecture.