### PR TITLE
runtime.c: fix time header for LISP_FEATURE_AVOID_CLOCK_GETTIME case

### DIFF
--- a/src/runtime/runtime.c
+++ b/src/runtime/runtime.c
@@ -40,7 +40,11 @@
 #include <locale.h>
 #include <limits.h>
 
+#ifdef LISP_FEATURE_AVOID_CLOCK_GETTIME
+#include <sys/time.h>
+#else
 #include <time.h>
+#endif
 
 #ifndef LISP_FEATURE_WIN32
 #include <signal.h>


### PR DESCRIPTION
@catap Looks like we had an incorrect header here, gcc14 errs out, complaining re implicitly defined `gettimeofday`.
Also see: https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man2/gettimeofday.2.html