### PR TITLE
runtime/thread.c: fix including pthread on macOS

### DIFF
--- a/src/runtime/thread.c
+++ b/src/runtime/thread.c
@@ -12,6 +12,9 @@
 #ifdef __linux__
 #define _GNU_SOURCE // for pthread_setname_np()
 #endif
+#ifdef __APPLE__
+#define _DARWIN_C_SOURCE // for pthread_mach_thread_np()
+#endif
 #include "genesis/sbcl.h"
 
 #include <stdlib.h>


### PR DESCRIPTION
Something recently has broken visibility of pthread-related symbols on macOS (perhaps `_XOPEN_SOURCE`).
Fix the build.