### PR TITLE
Support stack allocation of returned alien structs

### DIFF
--- a/src/compiler/generic/vm-fndb.lisp
+++ b/src/compiler/generic/vm-fndb.lisp
@@ -911,3 +911,8 @@
 
 (defknown sb-vm::%weakvec-ref (weak-pointer index) t (flushable))
 (defknown sb-vm::%weakvec-set (weak-pointer index t) (values) ())
+
+;;; %allocate-struct-alien allocates memory for struct-by-value returns
+;;; and wraps it in an alien-value in order to support stack allocation via
+;;; dynamic-extent declarations.
+(defknown %allocate-struct-alien (index t) sb-alien-internals:alien-value (flushable))

--- a/src/compiler/x86-64/c-call.lisp
+++ b/src/compiler/x86-64/c-call.lisp
@@ -805,19 +805,16 @@ Floats are passed in integer registers."
     (inst and rsp-tn -16)
     (move result rsp-tn)))
 
-(macrolet ((alien-stack-ptr ()
-             #+sb-thread `(thread-slot-ea ,(symbol-thread-slot '*alien-stack-pointer*))
-             #-sb-thread '(static-symbol-value-ea '*alien-stack-pointer*)))
-  (define-vop (alloc-alien-stack-space)
-    (:info amount)
-    (:results (result :scs (sap-reg any-reg)))
-    (:result-types system-area-pointer)
-    (:generator 0
-      (aver (not (location= result rsp-tn)))
-      (unless (zerop amount)
-        (let ((delta (align-up amount 8)))
-          (inst sub :qword (alien-stack-ptr) delta)))
-      (inst mov result (alien-stack-ptr)))))
+(define-vop (alloc-alien-stack-space)
+  (:info amount)
+  (:results (result :scs (sap-reg any-reg)))
+  (:result-types system-area-pointer)
+  (:generator 0
+    (aver (not (location= result rsp-tn)))
+    (unless (zerop amount)
+      (let ((delta (align-up amount 8)))
+        (inst sub :qword (alien-stack-pointer-ea) delta)))
+    (inst mov result (alien-stack-pointer-ea))))
 
 ;;; Callbacks
 

--- a/src/compiler/x86-64/macros.lisp
+++ b/src/compiler/x86-64/macros.lisp
@@ -139,6 +139,15 @@
 (defmacro store-binding-stack-pointer (reg)
   `(store-tl-symbol-value ,reg *binding-stack-pointer*))
 
+
+;; Return the EA for the alien stack pointer thread slot.
+;; This is used by VOPs that need to both read and modify the alien stack.
+#+sb-thread
+(defmacro alien-stack-pointer-ea ()
+  `(thread-slot-ea ,(symbol-thread-slot '*alien-stack-pointer*)))
+#-sb-thread
+(defmacro alien-stack-pointer-ea ()
+  `(static-symbol-value-ea '*alien-stack-pointer*))
 ;;;; error code
 (defun emit-error-break (vop kind code values)
   (assemble ()


### PR DESCRIPTION
Allow dynamic-extent declaration for return-by-value structs by defining the VOP alloc-struct-alien-stack that supports all-at-once allocation of struct memory, sap and alien-value.