### PR TITLE
stack-allocation of struct-typed alien funcall return values

### DIFF
--- a/doc/manual/ffi.texinfo
+++ b/doc/manual/ffi.texinfo
@@ -534,6 +534,21 @@ contain named structure or union types with the slots specified.
 Within the lexical scope of the binding specifiers and body, a locally
 defined foreign structure type @var{foo} can be referenced by its name
 using @code{(struct @var{foo})}.
+
+When a foreign function returns a structure by value, using
+@code{alien-funcall} as the @var{initial-value} allows the returned
+struct to be stack-allocated directly into the local variable's
+storage, avoiding heap allocation:
+
+@lisp
+(with-alien ((result (struct point)
+                     (alien-funcall
+                      (extern-alien "make_point"
+                                    (function (struct point) double double))
+                      1.0d0 2.0d0)))
+  (values (slot result 'x) (slot result 'y)))
+@end lisp
+
 @end defmac
 
 @node  External Foreign Variables

--- a/doc/manual/ffi.texinfo
+++ b/doc/manual/ffi.texinfo
@@ -717,6 +717,7 @@ the only documentation.  Users of a Lisp built with the
 
 @menu
 * The alien-funcall Primitive::
+* The alien-funcall-into Primitive::
 * The define-alien-routine Macro::
 * define-alien-routine Example::
 @end menu
@@ -766,6 +767,43 @@ the @code{(* (struct foo))} objects filled in by the foreign call:
         (setf (svref result i) (deref (deref a) i)))
       ;; Voila.
       result)))
+@end lisp
+
+@node  The alien-funcall-into Primitive
+@comment  node-name,  next,  previous,  up
+@subsection The @code{alien-funcall-into} Primitive
+
+@defun @sbalien{alien-funcall-into} @var{alien-function} @var{result-buffer} &rest @var{arguments}
+
+The @code{alien-funcall-into} function calls a foreign function that
+returns a structure by value, writing the result directly into a
+caller-provided buffer rather than heap-allocating.
+
+@var{alien-function} is the foreign function to call.
+@var{result-buffer} is a @code{system-area-pointer} pointing to memory
+where the struct result will be written.  The buffer is typically
+stack-allocated using @code{with-alien}.
+
+The function returns no values.  The caller accesses the result
+through the buffer.
+
+This function is only available on x86-64 and ARM64.
+
+@end defun
+
+Here is an example that calls a C function returning a struct,
+writing the result to a stack-allocated buffer:
+
+@lisp
+(define-alien-type nil (struct point (x double) (y double)))
+
+(with-alien ((result (struct point)))
+  (alien-funcall-into
+   (extern-alien "make_point"
+                 (function (struct point) double double))
+   (alien-sap (addr result))
+   1.0d0 2.0d0)
+  (values (slot result 'x) (slot result 'y)))
 @end lisp
 
 @node  The define-alien-routine Macro

--- a/src/code/alieneval.lisp
+++ b/src/code/alieneval.lisp
@@ -1273,6 +1273,7 @@
   ;; as indicative of "..." in the C prototype. We can record that too.
   (varargs nil :type (or boolean fixnum (eql :unspecified)) :read-only t)
   (stub nil :type (or null function))
+  (into-stub nil :type (or null function)) ; for alien-funcall-into
   (convention nil :type calling-convention :read-only t))
 ;;; The safe default is to assume that everything is varargs.
 ;;; On x86-64 we have to emit a spurious instruction because of it.

--- a/src/cold/exports.lisp
+++ b/src/cold/exports.lisp
@@ -1220,7 +1220,7 @@ of SBCL which maintained the CMU-CL-style split into two packages.)")
   (:import-from "CL" "*" "ARRAY" "CHAR" "DOUBLE-FLOAT" "FLOAT" "FUNCTION"
                 "BOOLEAN" "INTEGER" "LONG-FLOAT" "SINGLE-FLOAT" "UNION" "VALUES")
   (:import-from "SB-SYS" "SYSTEM-AREA-POINTER")
-  (:export "*" "ADDR" "ALIEN" "ALIEN-FUNCALL" "ALIEN-SAP"
+  (:export "*" "ADDR" "ALIEN" "ALIEN-FUNCALL" "ALIEN-FUNCALL-INTO" "ALIEN-SAP"
            "ALIEN-SIZE" "ARRAY" "BOOLEAN" "CAST" "CHAR" "C-STRING"
            "DEFINE-ALIEN-ROUTINE" "DEFINE-ALIEN-TYPE" "DEFINE-ALIEN-VARIABLE"
            "DEREF" "DOUBLE-FLOAT" "DOUBLE" "ENUM" "EXTERN-ALIEN"


### PR DESCRIPTION
`alien-funcall-into` primitive that calls foreign functions returning structs by value, writing results to caller-provided buffer
instead of heap