### PR TITLE
support loading an embedded core from a Mach-O or PE section

### DIFF
--- a/src/runtime/coreparse.c
+++ b/src/runtime/coreparse.c
@@ -29,6 +29,10 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#ifdef LISP_FEATURE_DARWIN
+#include <mach-o/loader.h>
+#endif
+
 #include "os.h"
 #include "runtime.h"
 #include "globals.h"
@@ -102,12 +106,156 @@ int lisp_code_in_elf() { return &lisp_code_start != 0; }
 lispobj* get_alien_linkage_table_initializer() { return &alien_linkage_values; }
 #endif
 
-/* Search 'filename' for an embedded core.  An SBCL core has, at the
- * end of the file, a trailer containing optional saved runtime
- * options, the start of the core (an os_vm_offset_t), and a final
- * signature word (the lispobj CORE_MAGIC).  If this trailer is found
- * at the end of the file, the start of the core can be determined
- * from the core size.
+static int read_exactly(int fd, void *buf, size_t size)
+{
+    return read(fd, buf, size) == (ssize_t)size;
+}
+
+static int read_bytes_at(int fd, os_vm_offset_t offset, void *buf, size_t size)
+{
+    return lseek(fd, offset, SEEK_SET) == offset && read_exactly(fd, buf, size);
+}
+
+static os_vm_offset_t validate_core_start(int fd, os_vm_offset_t core_start,
+                                          lispobj *header, os_vm_offset_t lispobj_size)
+{
+    if (core_start < 0)
+        return -1;
+    if (!read_bytes_at(fd, core_start, header, (size_t)lispobj_size) ||
+        *header != CORE_MAGIC)
+        return -1;
+    return core_start;
+}
+
+/* Search for a core appended to the end of an executable. In this
+ * legacy format an SBCL core has, at the end of the file, a trailer
+ * containing optional saved runtime options, the start of the core
+ * (an os_vm_offset_t), and a final signature word (the lispobj
+ * CORE_MAGIC). If this trailer is found at the end of the file, the
+ * start of the core can be determined from the stored offset. */
+static os_vm_offset_t search_for_legacy_appended_core(int fd)
+{
+    lispobj header = 0;
+    os_vm_offset_t core_start = -1;
+    os_vm_offset_t lispobj_size = sizeof(lispobj);
+
+    if (lseek(fd, -lispobj_size, SEEK_END) < 0 ||
+        !read_exactly(fd, &header, (size_t)lispobj_size) ||
+        header != CORE_MAGIC)
+        return -1;
+
+    /* The last word in the file could be CORE_MAGIC by pure coincidence. */
+    if (lseek(fd, -(lispobj_size + (os_vm_offset_t)sizeof(os_vm_offset_t)),
+              SEEK_END) < 0 ||
+        !read_exactly(fd, &core_start, sizeof(os_vm_offset_t)))
+        return -1;
+
+    return validate_core_start(fd, core_start, &header, lispobj_size);
+}
+
+/* The search_for_{format}_core helpers find cores embedded in named
+ * platform sections or segments rather than appended to the end of
+ * the executable. Ordinary executables produced with :executable t
+ * use the appended-core format and do not use these helpers. */
+#if defined(LISP_FEATURE_DARWIN) && defined(LISP_FEATURE_64_BIT)
+static os_vm_offset_t search_for_macho_core(int fd)
+{
+    struct mach_header_64 header;
+    struct stat st;
+    os_vm_offset_t load_commands_end, command_offset;
+    uint32_t i;
+
+    if (fstat(fd, &st) < 0 ||
+        !read_bytes_at(fd, 0, &header, sizeof header) ||
+        header.magic != MH_MAGIC_64)
+        return -1;
+
+    load_commands_end = sizeof header + header.sizeofcmds;
+    if (load_commands_end > (os_vm_offset_t)st.st_size)
+        return -1;
+
+    command_offset = sizeof header;
+    for (i = 0; i < header.ncmds; ++i) {
+        struct load_command command;
+        if (!read_bytes_at(fd, command_offset, &command, sizeof command) ||
+            command.cmdsize < sizeof command ||
+            command_offset + command.cmdsize > load_commands_end)
+            return -1;
+
+        if (command.cmd == LC_SEGMENT_64) {
+            struct segment_command_64 segment;
+            os_vm_offset_t section_offset, command_end;
+            uint32_t j;
+            if (command.cmdsize < sizeof segment ||
+                !read_bytes_at(fd, command_offset, &segment, sizeof segment))
+                return -1;
+            section_offset = command_offset + sizeof segment;
+            command_end = command_offset + command.cmdsize;
+            for (j = 0; j < segment.nsects;
+                 ++j, section_offset += sizeof(struct section_64)) {
+                struct section_64 section;
+                if (section_offset + (os_vm_offset_t)sizeof section > command_end ||
+                    !read_bytes_at(fd, section_offset, &section, sizeof section))
+                    return -1;
+                if (!strncmp(section.segname, "__SBCL", sizeof section.segname) &&
+                    !strncmp(section.sectname, "__core", sizeof section.sectname) &&
+                    section.size)
+                    return section.offset;
+            }
+        }
+        command_offset += command.cmdsize;
+    }
+    return -1;
+}
+#endif
+
+#ifdef LISP_FEATURE_WIN32
+static os_vm_offset_t search_for_pe_core(int fd)
+{
+    struct stat st;
+    IMAGE_DOS_HEADER dos_header;
+    DWORD signature;
+    IMAGE_FILE_HEADER file_header;
+    os_vm_offset_t section_offset;
+    int i;
+
+    if (fstat(fd, &st) < 0 ||
+        !read_bytes_at(fd, 0, &dos_header, sizeof dos_header) ||
+        dos_header.e_magic != IMAGE_DOS_SIGNATURE ||
+        dos_header.e_lfanew < 0)
+        return -1;
+
+    if (!read_bytes_at(fd, dos_header.e_lfanew, &signature, sizeof signature) ||
+        signature != IMAGE_NT_SIGNATURE ||
+        !read_bytes_at(fd, dos_header.e_lfanew + sizeof signature,
+                       &file_header, sizeof file_header))
+        return -1;
+
+    section_offset = dos_header.e_lfanew + sizeof signature +
+        sizeof file_header + file_header.SizeOfOptionalHeader;
+    if (section_offset > st.st_size)
+        return -1;
+
+    for (i = 0; i < file_header.NumberOfSections; ++i) {
+        IMAGE_SECTION_HEADER section;
+        if (section_offset + sizeof section > st.st_size ||
+            !read_bytes_at(fd, section_offset, &section, sizeof section))
+            return -1;
+        if (!memcmp(section.Name, ".sbclcr", 7) && section.Name[7] == 0 &&
+            section.SizeOfRawData != 0)
+            return section.PointerToRawData;
+        section_offset += sizeof section;
+    }
+    return -1;
+}
+#endif
+
+/* Search 'filename' for an embedded core. An SBCL core can be a bare
+ * .core file, can be embedded in an executable section, or can be in
+ * the legacy appended-core format with a trailer containing
+ * optional saved runtime options, the start of the core (an
+ * os_vm_offset_t), and a final signature word (the lispobj
+ * CORE_MAGIC).
  *
  * If an embedded core is present, this returns the offset into the
  * file to load the core from, or -1 if no core is present. */
@@ -131,19 +279,17 @@ search_for_embedded_core(char *filename, struct memsize_options *memsize_options
     }
 
     os_vm_offset_t core_start = -1; // invalid value
-    if (lseek(fd, -lispobj_size, SEEK_END) < 0 ||
-        read(fd, &header, (size_t)lispobj_size) != lispobj_size)
-        goto lose;
-
-    if (header == CORE_MAGIC) {
-        // the last word in the file could be CORE_MAGIC by pure coincidence
-        if (lseek(fd, -(lispobj_size + sizeof(os_vm_offset_t)), SEEK_END) < 0 ||
-            read(fd, &core_start, sizeof(os_vm_offset_t)) != sizeof(os_vm_offset_t))
-            goto lose;
-        if (lseek(fd, core_start, SEEK_SET) != core_start ||
-            read(fd, &header, lispobj_size) != lispobj_size || header != CORE_MAGIC)
-            core_start = -1; // reset to invalid
-    }
+    /* Mach-O and PE section lookup is independent of memsize_options
+     * because (unlike ELF :elf-object cores) the core is stored as
+     * opaque section bytes with no pre-baked linkage information, so
+     * finding one via an explicit --core works fine too. */
+#if defined(LISP_FEATURE_DARWIN) && defined(LISP_FEATURE_64_BIT)
+    core_start = validate_core_start(fd, search_for_macho_core(fd), &header, lispobj_size);
+#endif
+#ifdef LISP_FEATURE_WIN32
+    if (core_start < 0)
+        core_start = validate_core_start(fd, search_for_pe_core(fd), &header, lispobj_size);
+#endif
 #if ELFCORE && !defined(LISP_FEATURE_DARWIN)
     // Specifying "--core" as an ELF file with a lisp.core section doesn't work.
     // (There are bunch of reasons) So only search for a core section if this
@@ -151,16 +297,18 @@ search_for_embedded_core(char *filename, struct memsize_options *memsize_options
     // The two cases can be distinguished based on whether the core is able
     // to set the memsize_options. (Implicit can set them, explicit can't)
     if (core_start < 0 && memsize_options) {
-        if (!(core_start = search_for_elf_core(fd)) ||
-            lseek(fd, core_start, SEEK_SET) != core_start ||
-            read(fd, &header, lispobj_size) != lispobj_size || header != CORE_MAGIC)
+        core_start = search_for_elf_core(fd);
+        if (!core_start ||
+            (core_start = validate_core_start(fd, core_start, &header, lispobj_size)) < 0)
             core_start = -1; // reset to invalid
     }
 #endif
+    if (core_start < 0)
+        core_start = search_for_legacy_appended_core(fd);
     if (core_start > 0 && memsize_options) {
         core_entry_elt_t optarray[RUNTIME_OPTIONS_WORDS];
         // file is already positioned to the first core header entry
-        if (read(fd, optarray, sizeof optarray) == sizeof optarray
+        if (read_exactly(fd, optarray, sizeof optarray)
             && optarray[0] == RUNTIME_OPTIONS_MAGIC) {
             memsize_options->dynamic_space_size = optarray[2];
             memsize_options->thread_control_stack_size = optarray[3];
@@ -169,7 +317,6 @@ search_for_embedded_core(char *filename, struct memsize_options *memsize_options
             memsize_options->present_in_core = optarray[1] == RUNTIME_OPTIONS_WORDS ? 1 : 2;
         }
     }
-lose:
     close(fd);
     return core_start;
 }

--- a/tools-for-build/make-embedded-core-executable.lisp
+++ b/tools-for-build/make-embedded-core-executable.lisp
@@ -1,0 +1,184 @@
+;;;; Wrap a bare SBCL core as an executable that carries the core in
+;;;; a proper Mach-O or PE section, so the result is code-signable.
+;;;;
+;;;; Usage:
+;;;;   sbcl --script make-embedded-core-executable.lisp -- \
+;;;;     --core <core> --output <executable> \
+;;;;     [--sbcl-home <dir>] \
+;;;;     [--application-type console|gui]    ; Windows only
+;;;;
+;;;; SBCL_HOME is resolved from --sbcl-home, or the script's own
+;;;; directory if sbcl.mk sits next to it, or sb-int:sbcl-homedir-pathname.
+
+(in-package "CL-USER")
+
+(defvar *sbcl-home*)
+
+(defun fail (control &rest arguments)
+  (error "~?" control arguments))
+
+(defun sbcl.mk-path ()
+  (let ((path (merge-pathnames "sbcl.mk" *sbcl-home*)))
+    (or (probe-file path)
+        (fail "Embedded-core executable helper requires ~A."
+              (sb-ext:native-namestring path :as-file t)))))
+
+(defun read-runtime-variable (name)
+  (with-open-file (stream (sbcl.mk-path) :external-format :ascii)
+    (loop with prefix = (concatenate 'string name "=")
+          for line = (read-line stream nil)
+          while line
+          when (and (<= (length prefix) (length line))
+                    (string= prefix line :end2 (length prefix)))
+            return (subseq line (length prefix)))))
+
+(defun required-runtime-variable (name)
+  (let ((v (read-runtime-variable name)))
+    (if (and v (not (string= v "")))
+        v
+        (fail "Embedded-core executable helper requires a ~A entry in ~A.~@
+Rebuild SBCL with :SB-LINKABLE-RUNTIME and reinstall it."
+              name (sb-ext:native-namestring (sbcl.mk-path) :as-file t)))))
+
+(defun split-words (string)
+  (when (and string (plusp (length string)))
+    (flet ((spacep (c) (or (char= c #\Space) (char= c #\Tab))))
+      (loop with len = (length string)
+            for start = (position-if-not #'spacep string)
+              then (position-if-not #'spacep string :start end)
+            while start
+            for end = (or (position-if #'spacep string :start start) len)
+            collect (subseq string start end)))))
+
+(defun absolute-runtime-file (name)
+  (sb-ext:native-namestring
+   (sb-ext:parse-native-namestring name nil *sbcl-home*)
+   :as-file t))
+
+(defun absolutize-libsbcl-arg (arg libsbcl)
+  (cond ((member arg libsbcl :test #'string=)
+         (absolute-runtime-file arg))
+        ((and (> (length arg) 4) (string= arg "-Wl," :end1 4)
+              (member (subseq arg 4) libsbcl :test #'string=))
+         (format nil "-Wl,~A" (absolute-runtime-file (subseq arg 4))))
+        (t arg)))
+
+(defun run (command)
+  (let* ((process (sb-ext:run-program (car command) (cdr command)
+                                      :search t :input nil
+                                      :output *standard-output*
+                                      :error *error-output* :wait t))
+         (code (sb-ext:process-exit-code process)))
+    (unless (and (eq :exited (sb-ext:process-status process)) (zerop code))
+      (fail "~A exited with status ~S while building embedded-core executable."
+            (car command) code))))
+
+(defun cc-link (extra-args)
+  (let* ((cc (split-words (required-runtime-variable "CC")))
+         (linkflags (split-words (read-runtime-variable "LINKFLAGS")))
+         (libs (split-words (read-runtime-variable "LIBS")))
+         (libsbcl (split-words (required-runtime-variable "LIBSBCL")))
+         (use-libsbcl (mapcar (lambda (a) (absolutize-libsbcl-arg a libsbcl))
+                              (split-words (required-runtime-variable "USE_LIBSBCL")))))
+    (dolist (file libsbcl)
+      (unless (probe-file (absolute-runtime-file file))
+        (fail "Embedded-core executable helper requires installed runtime asset ~A."
+              file)))
+    (run (append cc linkflags extra-args use-libsbcl libs))))
+
+#+win32
+(defun random-tmp-name (type)
+  (sb-ext:native-namestring
+   (merge-pathnames
+    (make-pathname :name (format nil "sbcl-embedded-core-~36,8,'0R"
+                                 (random (expt 36 8)))
+                   :type type)
+    (sb-ext:parse-native-namestring
+     (or (sb-ext:posix-getenv "TEMP") "C:/Windows/Temp") nil nil
+     :as-directory t))
+   :as-file t))
+
+#+darwin
+(defun build-embedded-core-executable (core output app-type)
+  (declare (ignore app-type))
+  (cc-link (list "-o" output
+                 (format nil "-Wl,-sectcreate,__SBCL,__core,~A" core))))
+
+#+win32
+(defun build-embedded-core-executable (core output app-type)
+  (let ((asm (random-tmp-name "s"))
+        (obj (random-tmp-name "obj"))
+        (subsystem (ecase app-type
+                     (:console '("-Wl,--subsystem,console"))
+                     (:gui '("-Wl,--subsystem,windows")))))
+    (unwind-protect
+         (progn
+           (with-open-file (s asm :direction :output :external-format :ascii
+                                  :if-exists :supersede :if-does-not-exist :create)
+             (format s ".section .sbclcr,\"dr\"~%.incbin ~S~%"
+                     (substitute #\/ #\\ core)))
+           (run (append (split-words (required-runtime-variable "CC"))
+                        (list "-c" "-o" obj asm)))
+           (cc-link (append subsystem (list "-o" output obj))))
+      (ignore-errors (delete-file asm))
+      (ignore-errors (delete-file obj)))))
+
+#-(or darwin win32)
+(defun build-embedded-core-executable (core output app-type)
+  (declare (ignore core output app-type))
+  (fail "Embedded-core executable output is supported only on Darwin and Windows."))
+
+(defun parse-application-type (v)
+  (cond ((string-equal v "console") :console)
+        ((string-equal v "gui") :gui)
+        (t (fail "Unknown application type ~S (use console or gui)." v))))
+
+(defun parse-arguments (args)
+  (when (and args (string= (car args) "--")) (pop args))
+  (let (core output sbcl-home (app-type :console))
+    (declare (ignorable app-type))
+    (flet ((next (name)
+             (or (pop args) (fail "Missing value for ~A." name))))
+      (loop while args do
+        (let ((a (pop args)))
+          (cond ((member a '("-h" "--help") :test #'string=)
+                 (format t "usage: sbcl --script make-embedded-core-executable.lisp -- ~
+--core <core> --output <output>~@
+~8@T[--sbcl-home <dir>]~@
+~8@T[--application-type console|gui]  (Windows only)~%")
+                 (sb-ext:exit :code 0))
+                ((string= a "--core") (setf core (next "--core")))
+                ((string= a "--output") (setf output (next "--output")))
+                ((string= a "--sbcl-home") (setf sbcl-home (next "--sbcl-home")))
+                #+win32
+                ((string= a "--application-type")
+                 (setf app-type (parse-application-type (next "--application-type"))))
+                (t (fail "Unknown option ~S." a))))))
+    (values (or core (fail "Missing required --core option."))
+            (or output (fail "Missing required --output option."))
+            sbcl-home app-type)))
+
+(defun resolve-sbcl-home (override)
+  (or (and override (sb-ext:parse-native-namestring
+                     override nil *default-pathname-defaults*
+                     :as-directory t))
+      (and *load-pathname*
+           (let ((dir (make-pathname :name nil :type nil
+                                     :defaults *load-pathname*)))
+             (when (probe-file (merge-pathnames "sbcl.mk" dir)) dir)))
+      (sb-int:sbcl-homedir-pathname)
+      (fail "Cannot determine SBCL_HOME; pass --sbcl-home.")))
+
+(defun main (&optional (args (cdr sb-ext:*posix-argv*)))
+  (multiple-value-bind (core-arg output-arg sbcl-home-arg app-type)
+      (parse-arguments args)
+    (let* ((*sbcl-home* (resolve-sbcl-home sbcl-home-arg))
+           (core (sb-ext:native-namestring
+                  (truename (sb-ext:parse-native-namestring core-arg))
+                  :as-file t))
+           (output (sb-ext:native-namestring
+                    (sb-ext:parse-native-namestring output-arg) :as-file t)))
+      (build-embedded-core-executable core output app-type))))
+
+(eval-when (:execute)
+  (main))


### PR DESCRIPTION
Appending a core to the end of an executable either doesn't permit or invalidates any code signature on macOS and Windows. This change lets SBCL read the core from a proper Mach-O (__SBCL,__core) or PE (.sbclcr) section, so the resulting binary can be signed and notarized.

This change does *not* change S-L-A-D :EXECUTABLE T to make properly sectioned executables however, since we require various external tools.

search_for_embedded_core now tries Mach-O section lookup on 64-bit Darwin and PE section lookup on Windows before falling back to the existing legacy trailer format (and the ELF lisp.core section on platforms that support it). A bare .core file, a legacy appended-core executable, and an ELF-embedded core all still work.

This change also includes a script to produce embedded core executables on Mac and Windows. Produce a section-embedded executable from a bare core with:

    sbcl --script <sbcl-source>/tools-for-build/make-embedded-core-executable.lisp -- \
         --core my-app.core --output my-app \
         [--sbcl-home <dir>] \
         [--application-type console|gui]    # Windows only

The helper reads CC/LINKFLAGS/LIBSBCL/USE_LIBSBCL/LIBS from the installed sbcl.mk, so it requires an SBCL built with :SB-LINKABLE-RUNTIME. On Darwin it links with
-Wl,-sectcreate,__SBCL,__core,<core>; on Windows it assembles a short .incbin wrapper to pull the core bytes into a .sbclcr section.  The helper is not installed alongside sbcl.mk; pass --sbcl-home to point to the right place if needed (e.g. src/runtime for in-tree use).