### PR TITLE
struct-by-value: generate-struct-store-code handling of partial words

### DIFF
--- a/src/compiler/aliencomp.lisp
+++ b/src/compiler/aliencomp.lisp
@@ -558,28 +558,68 @@
 
 ;;;; ALIEN-FUNCALL support
 
-;;; Generate code to store struct register values to memory
+;;; Size-dispatched SETF forms that write exactly SIZE bytes (1..8)
+;;; from TEMP, a (unsigned-byte 64), into [result-sap+offset].  Used
+;;; for the trailing partial eightbyte of a struct-by-value return.
 #-sb-xc-host
-(defun generate-struct-store-code (temps register-slots result-sap)
+(defun %gen-int-slot-store (result-sap offset size temp)
+  (ecase size
+    (8 `(setf (sb-sys:sap-ref-64 ,result-sap ,offset) ,temp))
+    (4 `(setf (sb-sys:sap-ref-32 ,result-sap ,offset)
+              (ldb (byte 32 0) ,temp)))
+    (2 `(setf (sb-sys:sap-ref-16 ,result-sap ,offset)
+              (ldb (byte 16 0) ,temp)))
+    (1 `(setf (sb-sys:sap-ref-8 ,result-sap ,offset)
+              (ldb (byte 8 0) ,temp)))
+    ((3 5 6 7)
+     ;; No primitive store matches; fall back to byte-granular.
+     `(progn
+        ,@(loop for i from 0 below size collect
+                `(setf (sb-sys:sap-ref-8 ,result-sap ,(+ offset i))
+                       (ldb (byte 8 ,(* i 8)) ,temp)))))))
+
+;;; Generate code to store struct register values to memory.
+#-sb-xc-host
+(defun generate-struct-store-code (temps register-slots bytes result-sap)
   "Generate SETF forms to store register values to struct memory."
   (let ((offset 0)
         (stores nil)
         (temp-idx 0))
     (dolist (class register-slots)
-      (case class
-        (:integer
-         (push `(setf (sb-sys:sap-ref-64 ,result-sap ,offset) ,(nth temp-idx temps)) stores)
-         (incf offset 8)
-         (incf temp-idx))
-        (:double
-         (push `(setf (sb-sys:sap-ref-double ,result-sap ,offset) ,(nth temp-idx temps)) stores)
-         (incf offset 8)
-         (incf temp-idx))
-        ;; :single is ARM64 HFA only - x86-64 classifies all floats as :double
-        (:single
-         (push `(setf (sb-sys:sap-ref-single ,result-sap ,offset) ,(nth temp-idx temps)) stores)
-         (incf offset 4)
-         (incf temp-idx))))
+      (let* ((remaining (- bytes offset))
+             (slot-size (case class
+                          ((:integer :double) (min 8 remaining))
+                          (:single (min 4 remaining)))))
+        (ecase class
+          (:integer
+           (push (%gen-int-slot-store result-sap offset slot-size
+                                      (nth temp-idx temps))
+                 stores)
+           (incf offset 8)
+           (incf temp-idx))
+          (:double
+           (cond
+             ((= slot-size 8)
+              (push `(setf (sb-sys:sap-ref-double ,result-sap ,offset)
+                           ,(nth temp-idx temps))
+                    stores))
+             ((= slot-size 4)
+              (push `(setf (sb-sys:sap-ref-32 ,result-sap ,offset)
+                           (sb-kernel:double-float-low-bits
+                            ,(nth temp-idx temps)))
+                    stores))
+             (t
+              (error "Unexpected :double slot size ~A at offset ~A ~
+                      (struct size ~A)" slot-size offset bytes)))
+           (incf offset 8)
+           (incf temp-idx))
+          ;; :single is ARM64 HFA only - x86-64 classifies all floats as :double
+          (:single
+           (push `(setf (sb-sys:sap-ref-single ,result-sap ,offset)
+                        ,(nth temp-idx temps))
+                 stores)
+           (incf offset 4)
+           (incf temp-idx)))))
     (nreverse stores)))
 
 ;;; Build the function expression for %alien-funcall, optimizing to use
@@ -632,7 +672,7 @@
 ;;; Returns (values) - caller wraps result as alien if needed.
 #-sb-xc-host
 (defun generate-struct-return-code (func-expr alien-type return-type deports buffer-var)
-  (multiple-value-bind (in-registers-p register-slots)
+  (multiple-value-bind (in-registers-p register-slots bytes)
       (sb-alien::struct-return-info return-type)
     (cond
       ;; Large struct: pass buffer as hidden first arg
@@ -645,7 +685,7 @@
        (let ((temps (loop repeat (length register-slots) collect (gensym))))
          `(multiple-value-bind ,temps
               (%alien-funcall ,func-expr ',alien-type ,@deports)
-            ,@(generate-struct-store-code temps register-slots buffer-var)
+            ,@(generate-struct-store-code temps register-slots bytes buffer-var)
             (values)))))))
 
 (deftransform alien-funcall ((function &rest args)

--- a/tests/alien-struct-access.c
+++ b/tests/alien-struct-access.c
@@ -71,3 +71,16 @@ double gp_3f_sum (struct gp_3f s) {
 
 IDENTITY(gp_i8)   IDENTITY(gp_i16)  IDENTITY(gp_i32) IDENTITY(gp_1f)
 IDENTITY(gp_i8x7) IDENTITY(gp_i8x9) IDENTITY(gp_i8x15) IDENTITY(gp_3f)
+
+/*
+ * functions that return structs by value
+ */
+struct gp_i8  gp_i8_make  (int8_t  v) { struct gp_i8  s; s.m0 = v; return s; }
+struct gp_i16 gp_i16_make (int16_t v) { struct gp_i16 s; s.m0 = v; return s; }
+struct gp_i32 gp_i32_make (int32_t v) { struct gp_i32 s; s.m0 = v; return s; }
+struct gp_1f  gp_1f_make  (float   v) { struct gp_1f  s; s.m0 = v; return s; }
+struct gp_3f  gp_3f_make  (float a, float b, float c) {
+  struct gp_3f s;
+  s.a = a; s.b = b; s.c = c;
+  return s;
+}

--- a/tests/alien-struct-access.impure.lisp
+++ b/tests/alien-struct-access.impure.lisp
@@ -175,35 +175,35 @@
 
 ;;; Over-write probes (return-buffer side).
 
-(with-test (:name :overwrite-i8 :broken-on :sbcl)
+(with-test (:name :overwrite-i8)
   (probe-overwrite 1 (struct gp-i8)
                    "gp_i8_make"
                    (function (struct gp-i8) (signed 8))
                    (-42)
                    (assert (= (slot s 'm0) -42))))
 
-(with-test (:name :overwrite-i16 :broken-on :sbcl)
+(with-test (:name :overwrite-i16)
   (probe-overwrite 2 (struct gp-i16)
                    "gp_i16_make"
                    (function (struct gp-i16) (signed 16))
                    (12345)
                    (assert (= (slot s 'm0) 12345))))
 
-(with-test (:name :overwrite-i32 :broken-on :sbcl)
+(with-test (:name :overwrite-i32)
   (probe-overwrite 4 (struct gp-i32)
                    "gp_i32_make"
                    (function (struct gp-i32) (signed 32))
                    (#x7abcdef0)
                    (assert (= (slot s 'm0) #x7abcdef0))))
 
-(with-test (:name :overwrite-1f :broken-on :sbcl)
+(with-test (:name :overwrite-1f)
   (probe-overwrite 4 (struct gp-1f)
                    "gp_1f_make"
                    (function (struct gp-1f) single-float)
                    (42.5f0)
                    (assert (= (slot s 'm0) 42.5f0))))
 
-(with-test (:name :overwrite-3f :broken-on :sbcl)
+(with-test (:name :overwrite-3f)
   (probe-overwrite 12 (struct gp-3f)
                    "gp_3f_make"
                    (function (struct gp-3f)

--- a/tests/alien-struct-access.impure.lisp
+++ b/tests/alien-struct-access.impure.lisp
@@ -64,30 +64,48 @@
               ,@body)
          (setf flag saved)))))
 
-(defmacro with-guarded-struct ((var size type-form) &body body)
-  (let ((sap (gensym "SAP-"))
+(defmacro with-fault-handler (label &body body)
+  `(with-memory-faults
+     (handler-case (progn ,@body)
+       (sb-sys:memory-fault-error (c)
+         (error "~A: ~A" ,label c)))))
+
+;;; VAR is bound to a deref'd struct view of a freshly-allocated
+;;; guarded buffer.
+;;;
+;;; Optional SAP-VAR names the raw system-area-pointer to that same
+;;; buffer, for probes that need to pass it to ALIEN-FUNCALL-INTO.
+
+(defmacro with-guarded-struct ((var size type-form &optional sap-var) &body body)
+  (let ((sap-sym (or sap-var (gensym "SAP-")))
         (size-sym (gensym "SIZE-")))
     `(let* ((,size-sym ,size)
-            (,sap (guarded-alloc ,size-sym)))
-       (when (sb-sys:sap= ,sap (sb-sys:int-sap 0))
-         (error "guarded_struct_alloc(~A) failed" ,size-sym))
+            (,sap-sym (guarded-alloc ,size-sym)))
+       (when (sb-sys:sap= ,sap-sym (sb-sys:int-sap 0))
+         (error "guarded_alloc(~A) failed" ,size-sym))
        (unwind-protect
             (let ((,var (sb-alien:deref
-                         (sb-alien:sap-alien ,sap (* ,type-form)))))
+                         (sb-alien:sap-alien ,sap-sym (* ,type-form)))))
               ,@body)
-         (guarded-free ,sap ,size-sym)))))
+         (guarded-free ,sap-sym ,size-sym)))))
 
-(defmacro probe-overread (size type-form init-form sum-fn expected-sum
+(defmacro probe-overread (size type-form init-form value-fn expected-value
                           &key (tolerance 0))
   `(with-guarded-struct (s ,size ,type-form)
      ,init-form
-     (let ((result (with-memory-faults
-                       (handler-case (,sum-fn s)
-                         (sb-sys:memory-fault-error (c)
-                           (error "OVER-READ: ~A" c))))))
+     (let ((result (with-fault-handler "OVER-READ" (,value-fn s))))
        ,(if (zerop tolerance)
-            `(assert (= result ,expected-sum))
-            `(assert (< (abs (- result ,expected-sum)) ,tolerance))))))
+            `(assert (= result ,expected-value))
+            `(assert (< (abs (- result ,expected-value)) ,tolerance))))))
+
+(defmacro probe-overwrite (size type-form make-name fn-type
+                           call-args check-body)
+  `(with-guarded-struct (s ,size ,type-form sap)
+     (declare (ignorable s))
+     (with-fault-handler "OVER-WRITE"
+       (alien-funcall-into (extern-alien ,make-name ,fn-type)
+                           sap ,@call-args))
+     ,check-body))
 
 (with-test (:name :overread-i8)
   (probe-overread 1 (struct gp-i8)
@@ -142,19 +160,56 @@
 (with-test (:name :overread-i8-identity)
   (with-guarded-struct (s 1 (struct gp-i8))
     (setf (slot s 'm0) 99)
-    (let ((r (with-memory-faults
-               (handler-case (gp-i8-identity s)
-                 (sb-sys:memory-fault-error (c)
-                   (error "OVER-READ in identity: ~A" c))))))
+    (let ((r (with-fault-handler "OVER-READ in identity"
+               (gp-i8-identity s))))
       (assert (= (slot r 'm0) 99)))))
 
 (with-test (:name :overread-3f-identity)
   (with-guarded-struct (s 12 (struct gp-3f))
     (setf (slot s 'a) 7.5f0 (slot s 'b) -1.25f0 (slot s 'c) 0.5f0)
-    (let ((r (with-memory-faults
-               (handler-case (gp-3f-identity s)
-                 (sb-sys:memory-fault-error (c)
-                   (error "OVER-READ in identity: ~A" c))))))
+    (let ((r (with-fault-handler "OVER-READ in identity"
+               (gp-3f-identity s))))
       (assert (= (slot r 'a) 7.5f0))
       (assert (= (slot r 'b) -1.25f0))
       (assert (= (slot r 'c) 0.5f0)))))
+
+;;; Over-write probes (return-buffer side).
+
+(with-test (:name :overwrite-i8 :broken-on :sbcl)
+  (probe-overwrite 1 (struct gp-i8)
+                   "gp_i8_make"
+                   (function (struct gp-i8) (signed 8))
+                   (-42)
+                   (assert (= (slot s 'm0) -42))))
+
+(with-test (:name :overwrite-i16 :broken-on :sbcl)
+  (probe-overwrite 2 (struct gp-i16)
+                   "gp_i16_make"
+                   (function (struct gp-i16) (signed 16))
+                   (12345)
+                   (assert (= (slot s 'm0) 12345))))
+
+(with-test (:name :overwrite-i32 :broken-on :sbcl)
+  (probe-overwrite 4 (struct gp-i32)
+                   "gp_i32_make"
+                   (function (struct gp-i32) (signed 32))
+                   (#x7abcdef0)
+                   (assert (= (slot s 'm0) #x7abcdef0))))
+
+(with-test (:name :overwrite-1f :broken-on :sbcl)
+  (probe-overwrite 4 (struct gp-1f)
+                   "gp_1f_make"
+                   (function (struct gp-1f) single-float)
+                   (42.5f0)
+                   (assert (= (slot s 'm0) 42.5f0))))
+
+(with-test (:name :overwrite-3f :broken-on :sbcl)
+  (probe-overwrite 12 (struct gp-3f)
+                   "gp_3f_make"
+                   (function (struct gp-3f)
+                             single-float single-float single-float)
+                   (1.0f0 2.0f0 3.0f0)
+                   (progn
+                     (assert (= (slot s 'a) 1.0f0))
+                     (assert (= (slot s 'b) 2.0f0))
+                     (assert (= (slot s 'c) 3.0f0)))))


### PR DESCRIPTION
Fixes for writing register values past end of output buffer.