### PR TITLE
x86-64, arm64, contrib: cooperative user-space coroutines

### DIFF
--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -3,7 +3,7 @@ vpath %.fasl ../obj/sbcl-home/contrib/
 contribs = sb-posix sb-bsd-sockets sb-introspect sb-cltl2 sb-aclrepl \
      sb-sprof sb-capstone sb-md5 sb-capstone sb-executable sb-gmp sb-mpfr \
      sb-queue sb-rotate-byte sb-rt sb-simple-streams sb-concurrency sb-cover \
-     sb-simd sb-grovel sb-perf asdf
+     sb-simd sb-grovel sb-perf sb-fiber asdf
 
 active_contribs = $(filter-out $(SBCL_CONTRIB_BLOCKLIST),$(contribs))
 

--- a/contrib/Makefile
+++ b/contrib/Makefile
@@ -3,7 +3,7 @@ vpath %.fasl ../obj/sbcl-home/contrib/
 contribs = sb-posix sb-bsd-sockets sb-introspect sb-cltl2 sb-aclrepl \
      sb-sprof sb-capstone sb-md5 sb-capstone sb-executable sb-gmp sb-mpfr \
      sb-queue sb-rotate-byte sb-rt sb-simple-streams sb-concurrency sb-cover \
-     sb-simd sb-grovel sb-perf sb-manual asdf
+     sb-simd sb-grovel sb-perf sb-manual sb-fiber asdf
 
 active_contribs = $(filter-out $(SBCL_CONTRIB_BLOCKLIST),$(contribs))
 

--- a/contrib/sb-fiber/Makefile
+++ b/contrib/sb-fiber/Makefile
@@ -1,0 +1,3 @@
+SYSTEM=sb-fiber
+CFLAGS+=-I$(SBCL_TOP)/src/runtime
+include ../asdf-module.mk

--- a/contrib/sb-fiber/README.md
+++ b/contrib/sb-fiber/README.md
@@ -1,0 +1,112 @@
+# sb-fiber notes
+
+These are some technical notes on implementation of fibers.
+User-facing API documentation can be found in `sb-fiber.texinfo`.
+
+## Code organization
+
+| Role       | Files                               |
+|------------|-------------------------------------|
+| Lisp API   | `contrib/sb-fiber/fiber.lisp`       |
+| Lisp <-> C | `contrib/sb-fiber/fiber-ffi.lisp`   |
+| VOPs       | `contrib/sb-fiber/<arch>-vops.lisp` |
+| Assembly   | `src/assembly/<arch>/tramps.lisp`   |
+| Runtime    | `src/runtime/<arch>-fiber.{c, h}`   |
+|            | `src/runtime/fiber.{c, h}`          |
+
+C manages allocation of stacks, GC integration, binding stack swap,
+pseudo-atomic entry and exit, and defines per-architecture context
+structures to hold callee-saved registers that are preserved when a
+fiber is switched.
+
+Lisp manages argument validation, catch and unwind chain save and
+install, `*current-fiber*`, re-signaling conditions captured by the
+trampoline, and defines the VOP that implements register swap inline
+at the `switch-fiber` call site.
+
+## Stack layout
+
+Fibers' control and binding stacks are mapped regions with guard pages
+that follow the per-thread overflow layout.  On
+`#-c-stack-is-control-stack` targets (e.g. arm64) the Lisp control
+stack and the C stack are separate regions that both belong to a
+fiber.
+
+## Binding stack swap
+
+A binding stack entry is `(value, tls-index)`, where value is the
+TLS value held just before the binding was pushed.  `N` nested
+bindings of the same symbol form a chain: entry `k` stores `V_{k-1}`,
+and the live TLS slot holds `V_N`.
+
+`swap_bindings_{forward,backward}` in `fiber.c`:
+
+To suspend a fiber, walk the entries from newest to oldest, exchanging
+each entry's saved value with the live TLS.  After the pass, entry `k`
+holds `V_k` and TLS holds `V_0`. To resume, walk oldest to newest.
+
+The `:tls-load-indirect` feature maintains an indirect cell per TLS
+slot pointing at the live value; `exchange_binding_with_tls` maintains
+it alongside the TLS exchange.
+
+## Pseudo-atomic switch window
+
+A thread is inconsistent during `switch-fiber`, so the swap is bracketed
+by pseudo-atomic. The Lisp shim enters PA by calling the C function
+`sb_fiber_switch_prep`, which stages BSP swap, control stack bounds
+swap, state flip, and binding stack swap.
+
+The `%swap-regs` VOP then does the register and SP swap, and
+transfers control to the resuming fiber's stack.  The resuming side,
+at the VOP's `RESUME` label, exits PA and checks to see if a signal
+arrived during the window.
+
+`sb_fiber_exit_pa` is the same exit path for the trampoline's
+auto-return flow, which runs in C and can't use the VOP's exit.
+
+## GC
+
+`extra_thread_data->fiber_list` enumerates every registered fiber on
+a thread: GC walks it.
+
+Suspended fibers marked runnable or new have their saved SP range
+`[ctx.sp .. stack_end)` and their callee-saved registers
+conservatively pinned.  On arm64 the separate Lisp control stack
+`[base, csp_save)` is pinned the same way; the region above
+`csp_save` is dead and unscanned.
+
+On arm64, a conservative scanner walks `[base, CSP_save)` on a
+suspended fiber and pins anything pointer-shaped.
+
+`sb_fiber_lisp_stack_suspend` maintains a `dirty_high` per fiber: the
+address such that `[dirty_high, usable_end)` is known clean.  On each
+suspend:
+
+- `CSP == dirty_high` (tight yield loop): no scrub.
+- `CSP < dirty_high` (fiber returned to a shallower depth): scrub
+  `[CSP, dirty_high)`.
+- `CSP > dirty_high` (fiber grew above prior clean boundary):
+  scrub all the way to `usable_end`.
+
+Tight-yield fibers pay zero scrub cost after the first suspend.
+
+## Trampoline
+
+When a fiber's entry function returns normally, control re-enters
+`fiber_tramp_c`, which marks the fiber dead and switches to
+`self->return_fiber` via `sb_fiber_switch_prep` + the assembly
+`fiber_swap_context`.
+
+The resuming fiber exits PA via its own VOP tail or
+`sb_fiber_exit_pa`.
+
+The Lisp wrapper for the resumed fiber is found via
+`*current-fiber*`. The Lisp shim sets it to `to` before the swap, and
+TLS persists across the stack swap unchanged.
+
+## Image survival
+
+A saved core's restart restores Lisp wrappers but not the C
+`sb_fiber_ctx` structs they point at.  An `*init-hooks*` callback
+clears `*current-fiber*` on startup; user code holding wrappers across
+`save-lisp-and-die` is on its own, like `sb-thread`.

--- a/contrib/sb-fiber/README.md
+++ b/contrib/sb-fiber/README.md
@@ -20,9 +20,9 @@ structures to hold callee-saved registers that are preserved when a
 fiber is switched.
 
 Lisp manages argument validation, catch and unwind chain save and
-install, `*current-fiber*`, re-signaling conditions captured by the
-trampoline, and defines the VOP that implements register swap inline
-at the `switch-fiber` call site.
+install, re-signaling conditions captured by the trampoline, and
+defines the VOP that implements register swap inline at the
+`switch-fiber` call site.
 
 ## Stack layout
 
@@ -100,13 +100,15 @@ When a fiber's entry function returns normally, control re-enters
 The resuming fiber exits PA via its own VOP tail or
 `sb_fiber_exit_pa`.
 
-The Lisp wrapper for the resumed fiber is found via
-`*current-fiber*`. The Lisp shim sets it to `to` before the swap, and
-TLS persists across the stack swap unchanged.
+The Lisp wrapper for the resumed fiber is found via the
+`current_fiber` slot of `struct thread`.  The Lisp shim stores `to`
+there before the swap.  The resumed side stores itself again after the
+swap because the C auto-return path does not write the slot.
 
 ## Image survival
 
 A saved core's restart restores Lisp wrappers but not the C
-`sb_fiber_ctx` structs they point at.  An `*init-hooks*` callback
-clears `*current-fiber*` on startup; user code holding wrappers across
-`save-lisp-and-die` is on its own, like `sb-thread`.
+`sb_fiber_ctx` structs they point at.  Thread structures are rebuilt
+at startup, so every thread begins with no current fiber; user code
+holding wrappers across `save-lisp-and-die` is on its own, like
+`sb-thread`.

--- a/contrib/sb-fiber/arm64-vops.lisp
+++ b/contrib/sb-fiber/arm64-vops.lisp
@@ -1,0 +1,38 @@
+;;;; Inline register/SP swap for SWITCH-FIBER
+
+(in-package "SB-VM")
+
+(sb-c:defknown sb-fiber::%swap-regs
+    (system-area-pointer system-area-pointer) (values)
+    (sb-c:always-translatable))
+
+(define-vop (fiber-swap-regs)
+  (:translate sb-fiber::%swap-regs)
+  (:policy :fast-safe)
+  (:args (from :scs (sap-reg) :target from-tmp)
+         (to :scs (sap-reg) :target to-tmp))
+  (:arg-types system-area-pointer system-area-pointer)
+  (:temporary (:sc sap-reg :offset nl0-offset
+               :from (:argument 0) :to (:result 0))
+              from-tmp)
+  (:temporary (:sc sap-reg :offset nl1-offset
+               :from (:argument 1) :to (:result 0))
+              to-tmp)
+  (:temporary (:sc unsigned-reg :offset nl2-offset) temp)
+  (:generator 10
+    (move from-tmp from)
+    (move to-tmp to)
+    (inst adr lr-tn RESUME)
+    (emit-save-fiber-regs from-tmp temp)
+    (emit-restore-fiber-regs to-tmp temp)
+    (inst ret)
+    RESUME
+    (inst dmb :ishst)
+    (inst str wzr-tn
+          (@ thread-tn (* n-word-bytes thread-pseudo-atomic-bits-slot)))
+    (inst ldr (32-bit-reg temp)
+          (@ thread-tn (+ (* n-word-bytes thread-pseudo-atomic-bits-slot) 4)))
+    (let ((not-interrupted (gen-label)))
+      (inst cbz temp not-interrupted)
+      (inst brk pending-interrupt-trap)
+      (emit-label not-interrupted))))

--- a/contrib/sb-fiber/constants.lisp
+++ b/contrib/sb-fiber/constants.lisp
@@ -1,0 +1,20 @@
+;;; -*- Lisp -*-
+
+("fiber.h" "stddef.h")
+
+((:integer-no-check +fiber-new+      "FIBER_NEW")
+ (:integer-no-check +fiber-runnable+ "FIBER_RUNNABLE")
+ (:integer-no-check +fiber-running+  "FIBER_RUNNING")
+ (:integer-no-check +fiber-dead+     "FIBER_DEAD")
+
+ ;; (only map the fields the Lisp shim actually touches)
+ (:structure fiber-ctx ("struct sb_fiber_ctx"
+                         ((signed 32) state "int" "state")
+                         (integer owner "void *" "owner")
+                         (integer return-fiber "void *" "return_fiber")
+                         (integer catch "lispobj" "current_catch_block")
+                         (integer unwind "lispobj" "current_unwind_protect_block")
+                         (integer bsp "lispobj *" "binding_stack_pointer")
+                         (integer bs-start "lispobj *" "binding_stack_start_for_thread")
+                         (integer bs-base "lispobj *" "binding_stack_base")
+                         (integer bs-end "lispobj *" "binding_stack_end"))))

--- a/contrib/sb-fiber/fiber-ffi.lisp
+++ b/contrib/sb-fiber/fiber-ffi.lisp
@@ -1,0 +1,300 @@
+;;;; -*-  Lisp -*-
+;;;;
+;;;; sb-fiber FFI bindings, alien-routines, fiber struct and other
+;;;; runtime support
+
+(in-package :sb-fiber)
+
+#+sb-fiber
+(progn
+
+(define-alien-routine ("sb_fiber_create" %fiber-create)
+    system-area-pointer
+  (stack-size unsigned-long)
+  (binding-stack-size unsigned-long))
+
+(define-alien-routine ("sb_fiber_create_main" %fiber-create-main)
+    system-area-pointer
+  (thread system-area-pointer))
+
+(define-alien-routine ("sb_fiber_release" %fiber-release)
+    void
+  (fiber system-area-pointer))
+
+(define-alien-routine ("sb_fiber_register" %fiber-register)
+    void
+  (thread system-area-pointer)
+  (fiber system-area-pointer))
+
+(define-alien-routine ("sb_fiber_unregister" %fiber-unregister)
+    void
+  (thread system-area-pointer)
+  (fiber system-area-pointer))
+
+(define-alien-routine ("sb_fiber_migrate" %fiber-migrate)
+    int
+  (fiber system-area-pointer)
+  (dest-thread system-area-pointer))
+
+(define-alien-routine ("sb_fiber_prepare" %fiber-prepare)
+    void
+  (fiber system-area-pointer)
+  (fn system-area-pointer)
+  (arg system-area-pointer))
+
+(define-alien-routine ("sb_fiber_control_stack_size_bytes"
+                       %fiber-control-stack-size-bytes)
+    unsigned-long
+  (fiber system-area-pointer))
+
+(define-alien-routine ("sb_fiber_control_stack_used_bytes"
+                       %fiber-control-stack-used-bytes)
+    unsigned-long
+  (fiber system-area-pointer))
+
+;;; --- Conditions ---------------------------------------------------------
+
+(define-condition fiber-error (error)
+  ((fiber :initarg :fiber :reader fiber-error-fiber :initform nil))
+  (:documentation
+   "Base class for sb-fiber errors that carry a fiber. Subclasses are
+the recommended targets for HANDLER-CASE in scheduler code."))
+
+(define-condition dead-fiber-error (fiber-error) ()
+  (:documentation
+   "Operation attempted on a fiber that has been released or has run to
+completion.")
+  (:report (lambda (c stream)
+             (format stream "fiber ~S is dead or released"
+                     (fiber-error-fiber c)))))
+
+(define-condition pinned-fiber-error (fiber-error)
+  ((depth :initarg :depth :reader pinned-fiber-error-depth))
+  (:documentation
+   "SWITCH-FIBER was asked to suspend a fiber whose pin count is
+nonzero. Schedulers may CATCH and retry later.")
+  (:report (lambda (c stream)
+             (format stream "fiber ~S is pinned (depth ~D); cannot suspend"
+                     (fiber-error-fiber c)
+                     (pinned-fiber-error-depth c)))))
+
+(define-condition fiber-thread-mismatch-error (fiber-error)
+  ((role :initarg :role :reader fiber-thread-mismatch-error-role))
+  (:documentation
+   "A switch references a fiber owned by a different OS thread. A fiber
+is bound to its owner thread (changeable via FIBER-MIGRATE); ROLE is
+:FROM or :TO.")
+  (:report (lambda (c stream)
+             (format stream "fiber ~S (~(~A~)) is owned by a different thread"
+                     (fiber-error-fiber c)
+                     (fiber-thread-mismatch-error-role c)))))
+
+(define-condition fiber-state-error (fiber-error)
+  ((state    :initarg :state    :reader fiber-state-error-state)
+   (expected :initarg :expected :reader fiber-state-error-expected))
+  (:documentation
+   "Fiber was not in an acceptable state for the requested operation.
+STATE is the actual keyword state; EXPECTED is a list of acceptable
+states.")
+  (:report (lambda (c stream)
+             (format stream "fiber ~S is in state ~S, expected ~{~S~^ or ~}"
+                     (fiber-error-fiber c)
+                     (fiber-state-error-state c)
+                     (fiber-state-error-expected c)))))
+
+(define-condition no-current-fiber-error (fiber-error)
+  ((operation :initarg :operation :initform nil
+              :reader no-current-fiber-error-operation))
+  (:documentation
+   "An operation requiring a current fiber was attempted on a thread with
+no fiber bound in *CURRENT-FIBER*.")
+  (:report (lambda (c stream)
+             (format stream "~@[~(~A~): ~]no current fiber; establish one ~
+with make-main-fiber or with-fiber-thread"
+                     (no-current-fiber-error-operation c)))))
+
+(declaim (inline %fiber-ctx))
+(defun %fiber-ctx (sap)
+  (declare (type sb-sys:system-area-pointer sap))
+  (sb-alien:sap-alien sap (* fiber-ctx)))
+
+(declaim (inline %switch-prep))
+(defun %switch-prep (from to)
+  (declare (type system-area-pointer from to))
+  (locally (declare (optimize (sb-c:alien-funcall-saves-fp-and-pc 0)))
+    (alien-funcall (sb-alien:extern-alien "sb_fiber_switch_prep"
+                    (function void system-area-pointer system-area-pointer))
+                   from to))
+  (values))
+
+(defstruct (fiber (:constructor %make-fiber)
+                  (:print-object %print-fiber))
+  (sap (sb-sys:int-sap 0) :type sb-sys:system-area-pointer)
+  (function nil :type (or null function))
+  (pending-condition nil :type (or null condition))
+  (escape-condition nil :type (or null condition))
+  (escape-throw-tag nil :type symbol)
+  (escape-throw-values nil :type list)
+  (pin-count 0 :type (and fixnum unsigned-byte))
+  (return-fiber nil :type (or null fiber))
+  (name nil :type (or null string))
+  (thread nil :type (or null sb-thread:thread))
+  (value nil :type list)
+  (released-p nil :type boolean))
+
+(declaim (inline %fiber-state))
+(defun %fiber-state (fiber)
+  "Read the C-side state word of FIBER (an integer +fiber-...+ value)."
+  (declare (type fiber fiber))
+  (fiber-ctx-state (%fiber-ctx (fiber-sap fiber))))
+
+(declaim (inline fiber-main-p))
+(defun fiber-main-p (fiber)
+  "Return T if FIBER represents a thread's own stack (created by
+MAKE-MAIN-FIBER or WITH-FIBER-THREAD), NIL if FIBER is a worker fiber
+created by MAKE-FIBER."
+  (declare (type fiber fiber))
+  (null (fiber-function fiber)))
+
+(declaim (inline deliver-pending maybe-escape))
+(defun deliver-pending (fiber)
+  "Post-resume delivery hook. If FIBER has an interrupt-staged
+condition, ERROR it (and clear the slot); otherwise a no-op. Called on
+the fiber that is about to (re-)run, so interrupt-fiber semantics fire
+in the target's own context."
+  (declare (type fiber fiber))
+  (let ((c (shiftf (fiber-pending-condition fiber) nil)))
+    (when c (error c))))
+
+(defun maybe-escape (fiber)
+  "Post-resume delivery hook. If FIBER's entry function exited via an
+unhandled error, re-ERROR that condition on the resumer's stack (and
+clear the slot); otherwise a no-op. Called on the resumer side so the
+escaped error re-fires in the resumer's context."
+  (declare (type fiber fiber))
+  (let ((c (shiftf (fiber-escape-condition fiber) nil)))
+    (when c (error c))))
+
+(defun maybe-escape-throw (fiber)
+  "Post-resume delivery hook. If a thread-root unwind tag escaped
+FIBER's entry function, re-THROW it on the resumer's stack (and clear
+the slot); otherwise a no-op."
+  (declare (type fiber fiber))
+  (let ((tag (shiftf (fiber-escape-throw-tag fiber) nil)))
+    (when tag
+      (throw tag (values-list (shiftf (fiber-escape-throw-values fiber) nil))))))
+
+(defun %print-fiber (fiber stream)
+  (print-unreadable-object (fiber stream :type t :identity t)
+    (format stream "~@[~A ~]~A" (fiber-name fiber) (fiber-state fiber))))
+
+(defvar *current-fiber* nil
+  "Fiber currently running on this thread, or NIL.")
+
+(define-alien-callable sb-fiber-lisp-entry void
+    ((arg unsigned-long))
+  (let ((f *current-fiber*))
+    (when (and f (fiber-function f))
+      (assert (= arg (sb-sys:sap-int (fiber-sap f))))
+      (let ((sb-kernel:*handler-clusters* sb-kernel::**initial-handler-clusters**)
+            (sb-kernel:*restart-clusters* nil))
+        (block done
+          (flet ((run ()
+                   ;; Non-error signals propagate normally so SIGNAL from
+                   ;; inside the fiber behaves like SIGNAL anywhere else.
+                   (handler-case
+                       (let ((rv-list
+                               (multiple-value-list
+                                (progn (deliver-pending f)
+                                       (funcall (fiber-function f))))))
+                         (when (fiber-return-fiber f)
+                           (setf (fiber-value (fiber-return-fiber f)) rv-list)))
+                     (error (c)
+                       (setf (fiber-escape-condition f) c)))
+                   (return-from done)))
+            (macrolet ((with-root-catch (tag &body inner)
+                         `(let ((vals (multiple-value-list (catch ,tag ,@inner))))
+                            (setf (fiber-escape-throw-tag f) ,tag
+                                  (fiber-escape-throw-values f) vals)
+                            (return-from done))))
+              (with-root-catch 'sb-impl::toplevel-catcher
+                (with-root-catch 'sb-impl::%end-of-the-world
+                  (with-root-catch 'sb-thread::%abort-thread
+                    (with-root-catch 'sb-thread::%return-from-thread
+                      (run))))))))))))
+
+(declaim (inline %thread-slot (setf %thread-slot)))
+(defun %thread-slot (th-sap slot)
+  (declare (type sb-sys:system-area-pointer th-sap) (type fixnum slot))
+  (sb-sys:sap-ref-word th-sap (ash slot sb-vm:word-shift)))
+
+(defun (setf %thread-slot) (val th-sap slot)
+  (declare (type sb-sys:system-area-pointer th-sap)
+           (type fixnum slot val))
+  (setf (sb-sys:sap-ref-word th-sap (ash slot sb-vm:word-shift)) val))
+
+(declaim (inline %current-thread-bits))
+(defun %current-thread-bits ()
+  (sb-sys:sap-int (sb-thread:current-thread-sap)))
+
+(defvar *fiber-lisp-entry-sap*
+  (sb-alien:alien-sap (alien-callable-function 'sb-fiber-lisp-entry))
+  "SAP of the SB-FIBER-LISP-ENTRY trampoline, resolved once at load
+time and reused by every MAKE-FIBER.")
+
+;;; --- %switch phases ---
+
+(declaim (inline check-switch))
+(defun check-switch (from to from-ctx to-ctx)
+  "Validate that *current thread* may switch FROM -> TO."
+  (declare (type fiber from to))
+  (let ((th-int (%current-thread-bits)))
+    (unless (= (fiber-ctx-owner from-ctx) th-int)
+      (error 'fiber-thread-mismatch-error :fiber from :role :from))
+    (unless (= (fiber-ctx-owner to-ctx) th-int)
+      (error 'fiber-thread-mismatch-error :fiber to :role :to)))
+  (unless (= (fiber-ctx-state from-ctx) +fiber-running+)
+    (error 'fiber-state-error
+           :fiber from :state (fiber-state from) :expected '(:running)))
+  (unless (zerop (fiber-pin-count from))
+    (error 'pinned-fiber-error :fiber from :depth (fiber-pin-count from)))
+  (let ((ts (fiber-ctx-state to-ctx)))
+    (unless (or (= ts +fiber-runnable+) (= ts +fiber-new+))
+      (error 'fiber-state-error
+             :fiber to :state (fiber-state to) :expected '(:runnable :new)))))
+
+(declaim (inline stage-return))
+(defun stage-return (from to from-sap to-ctx values)
+  "Record the return path and staged values on TO before the swap.
+Safe to do outside PA: these touch Lisp-owned slots only."
+  (declare (type fiber from to) (type list values))
+  (setf (fiber-ctx-return-fiber to-ctx) (sb-sys:sap-int from-sap)
+        (fiber-return-fiber to)        from
+        (fiber-value to)               values))
+
+(declaim (inline swap-frames))
+(defun swap-frames (th-sap from-ctx to-ctx)
+  "Save FROM's catch/unwind frames, install TO's, then install TO's
+binding-stack pointer and base. Runs inside PA: catch/unwind chains
+point into the running fiber's stack and must swap atomically with SP."
+  (declare (type sb-sys:system-area-pointer th-sap))
+  (let ((tc (%thread-slot th-sap sb-vm::thread-current-catch-block-slot))
+        (tu (%thread-slot th-sap sb-vm::thread-current-unwind-protect-block-slot)))
+    (setf (fiber-ctx-catch from-ctx)  tc
+          (fiber-ctx-unwind from-ctx) tu
+          (%thread-slot th-sap sb-vm::thread-current-catch-block-slot)
+            (fiber-ctx-catch to-ctx)
+          (%thread-slot th-sap sb-vm::thread-current-unwind-protect-block-slot)
+            (fiber-ctx-unwind to-ctx)))
+  ;; BSP install: prep already captured FROM's BSP.
+  (setf (%thread-slot th-sap sb-vm::thread-binding-stack-pointer-slot)
+          (fiber-ctx-bsp to-ctx)
+        (%thread-slot th-sap sb-vm::thread-binding-stack-start-slot)
+          (fiber-ctx-bs-start to-ctx)))
+
+(declaim (inline flip-states))
+(defun flip-states (from-ctx to-ctx)
+  (setf (fiber-ctx-state from-ctx) +fiber-runnable+
+        (fiber-ctx-state to-ctx)   +fiber-running+))
+
+)

--- a/contrib/sb-fiber/fiber-ffi.lisp
+++ b/contrib/sb-fiber/fiber-ffi.lisp
@@ -188,12 +188,25 @@ the slot); otherwise a no-op."
   (print-unreadable-object (fiber stream :type t :identity t)
     (format stream "~@[~A ~]~A" (fiber-name fiber) (fiber-state fiber))))
 
-(defvar *current-fiber* nil
-  "Fiber currently running on this thread, or NIL.")
+;;; The current fiber is stored in a slot of the C thread structure.
+
+(declaim (inline current-fiber (setf %current-fiber))
+         (ftype (function () (or null fiber)) current-fiber))
+(defun current-fiber ()
+  "Return the fiber currently running on this thread, or NIL if the
+thread has no main fiber."
+  (sb-sys:sap-ref-lispobj (sb-thread:current-thread-sap)
+                          (ash sb-vm::thread-current-fiber-slot sb-vm:word-shift)))
+
+(defun (setf %current-fiber) (fiber)
+  (declare (type (or null fiber) fiber))
+  (setf (sb-sys:sap-ref-lispobj (sb-thread:current-thread-sap)
+                                (ash sb-vm::thread-current-fiber-slot sb-vm:word-shift))
+        fiber))
 
 (define-alien-callable sb-fiber-lisp-entry void
     ((arg unsigned-long))
-  (let ((f *current-fiber*))
+  (let ((f (current-fiber)))
     (when (and f (fiber-function f))
       (assert (= arg (sb-sys:sap-int (fiber-sap f))))
       (let ((sb-kernel:*handler-clusters* sb-kernel::**initial-handler-clusters**)

--- a/contrib/sb-fiber/fiber.lisp
+++ b/contrib/sb-fiber/fiber.lisp
@@ -1,0 +1,348 @@
+;;;; -*-  Lisp -*-
+;;;;
+;;;; sb-fiber API
+
+(in-package :sb-fiber)
+
+#+sb-fiber
+(progn
+
+(defvar *default-fiber-stack-size* 65536
+  "Default control stack size (bytes) for MAKE-FIBER.")
+
+(defvar *default-fiber-binding-stack-size* 8192
+  "Default binding stack size (bytes) for MAKE-FIBER.")
+
+(defmacro with-fiber-sap ((sap alloc-form) &body body)
+  "Bind SAP to ALLOC-FORM.  Signal if the SAP is null; on non-local
+exit from BODY, call %FIBER-RELEASE on SAP."
+  (let ((ok (gensym "OK")))
+    `(let ((,sap ,alloc-form))
+       (when (zerop (sb-sys:sap-int ,sap))
+         (error "failed to allocate fiber"))
+       (let (,ok)
+         (unwind-protect
+              (multiple-value-prog1 (progn ,@body) (setf ,ok t))
+           (unless ,ok (%fiber-release ,sap)))))))
+
+;;; --- Lifecycle ---
+
+(defun %install-fiber (sap function name)
+  "Wrap an allocated SAP in a fiber struct, prepare it (if a worker),
+and register it with the current thread.  Caller arranges
+%FIBER-RELEASE on failure."
+  (let ((f (%make-fiber :sap sap :function function :name name
+                        :thread sb-thread:*current-thread*)))
+    (when function
+      (%fiber-prepare sap *fiber-lisp-entry-sap* sap))
+    (%fiber-register (sb-thread:current-thread-sap) sap)
+    f))
+
+(defun make-main-fiber (&key name)
+  "Create a fiber representing the current thread's own stack and bind
+*CURRENT-FIBER* to it.  NAME is a string label used by PRINT-OBJECT."
+  (with-fiber-sap (sap (%fiber-create-main (sb-thread:current-thread-sap)))
+    (setf *current-fiber* (%install-fiber sap nil name))))
+
+(defmacro with-fiber-thread ((&key name) &body body)
+  "Register a main fiber on the calling thread for the dynamic extent
+of BODY and release it on exit.  A no-op if BODY is reached with
+*CURRENT-FIBER* already bound.  NAME is forwarded to MAKE-MAIN-FIBER."
+  (let ((created (gensym "CREATED")))
+    `(let* ((*current-fiber* *current-fiber*)
+            (,created (unless *current-fiber* (make-main-fiber :name ,name))))
+       (unwind-protect (progn ,@body)
+         (when ,created (release-fiber ,created))))))
+
+(defun make-fiber (function &key name
+                                 (stack-size *default-fiber-stack-size*)
+                              (binding-stack-size
+                               *default-fiber-binding-stack-size*))
+  "Create a fiber that runs FUNCTION (zero-argument) when first
+switched to.  NAME is a string label used by PRINT-OBJECT.
+
+When FUNCTION returns, the fiber is marked DEAD and control switches
+back to its most recent resumer, delivering FUNCTION's return value
+as that resumer's SWITCH-FIBER value.
+
+The calling thread must already have a main fiber bound in
+*CURRENT-FIBER*.  Use MAKE-MAIN-FIBER or WITH-FIBER-THREAD to establish
+one before calling MAKE-FIBER.  Signals an error otherwise.
+
+Fibers are auto-released when their owning thread exits; explicit
+RELEASE-FIBER is only needed if you want to reclaim resources sooner."
+  (unless *current-fiber*
+    (error 'no-current-fiber-error :operation 'make-fiber))
+  (with-fiber-sap (sap (%fiber-create stack-size binding-stack-size))
+    (%install-fiber sap function name)))
+
+(defun release-fiber (fiber)
+  "Release FIBER.  For a worker fiber, unmaps its stacks and frees the
+bookkeeping struct.  For a main fiber, just frees the struct; the
+thread's own stack and binding stack are untouched.  Signals
+FIBER-STATE-ERROR if FIBER is a worker that is still RUNNING.
+Registered fibers are released automatically when their owning thread
+exits."
+  (unless (fiber-released-p fiber)
+    (when (and (not (fiber-main-p fiber))
+               (= (%fiber-state fiber) +fiber-running+))
+      (error 'fiber-state-error
+             :fiber fiber :state :running
+             :expected '(:new :runnable :dead)))
+    (%fiber-release (shiftf (fiber-sap fiber) (sb-sys:int-sap 0)))
+    (setf (fiber-thread fiber)     nil
+          (fiber-released-p fiber) t)
+    (when (eq *current-fiber* fiber)
+      (setf *current-fiber* nil))))
+
+(defun fiber-state (fiber)
+  "Return the current state of FIBER as a keyword: :NEW, :RUNNABLE,
+:RUNNING, or :DEAD."
+  (if (fiber-released-p fiber)
+      :dead
+      (svref #.(coerce '(:new :runnable :running :dead) 'simple-vector)
+             (%fiber-state fiber))))
+
+(declaim (inline fiber-alive-p))
+(defun fiber-alive-p (fiber)
+  "Return T if FIBER has not finished running and has not been
+released."
+  (declare (type fiber fiber))
+  (and (not (fiber-released-p fiber))
+       (/= (%fiber-state fiber) +fiber-dead+)))
+
+(declaim (inline current-fiber)
+         (ftype (function () (or null fiber)) current-fiber))
+(defun current-fiber ()
+  "Return the fiber currently running on this thread, or NIL if no
+main fiber is bound."
+  *current-fiber*)
+
+;;; --- Stack-usage accessors ---
+
+(defun fiber-control-stack-size (fiber)
+  "Bytes of usable control-stack region mapped for FIBER.  For a
+worker fiber, the size passed to MAKE-FIBER (rounded up to a page);
+for a main fiber, the calling thread's control stack."
+  (declare (type fiber fiber))
+  (if (fiber-released-p fiber)
+      0
+      (%fiber-control-stack-size-bytes (fiber-sap fiber))))
+
+(defun fiber-control-stack-usage (fiber)
+  "Bytes of FIBER's control stack currently in use.  For a :RUNNABLE
+or :NEW fiber, this is the depth at suspension (or initial trampoline
+frame for :NEW).  For a :RUNNING fiber, this may be the saved SP from
+the last suspend."
+  (declare (type fiber fiber))
+  (if (fiber-released-p fiber)
+      0
+      (%fiber-control-stack-used-bytes (fiber-sap fiber))))
+
+(defun fiber-binding-stack-size (fiber)
+  "Bytes of binding-stack region mapped for FIBER.  Returns 0 for a
+main fiber (its binding stack is the thread's own, not owned by the
+fiber wrapper)."
+  (declare (type fiber fiber))
+  (if (fiber-released-p fiber)
+      0
+      (let* ((c (%fiber-ctx (fiber-sap fiber)))
+             (b (fiber-ctx-bs-base c))
+             (e (fiber-ctx-bs-end c)))
+        (if (or (zerop b) (zerop e)) 0 (- e b)))))
+
+(defun fiber-binding-stack-usage (fiber)
+  "Bytes of binding stack currently in use by FIBER (BSP minus
+binding-stack start).  Works for both worker and main fibers."
+  (declare (type fiber fiber))
+  (if (fiber-released-p fiber)
+      0
+      (let* ((c        (%fiber-ctx (fiber-sap fiber)))
+             (bsp      (fiber-ctx-bsp c))
+             (bs-start (fiber-ctx-bs-start c)))
+        (if (or (zerop bsp) (zerop bs-start))
+            0
+            (max 0 (- bsp bs-start))))))
+
+(defun %switch (from to values update-return-p)
+  "Internal switch primitive.  Suspend FROM and resume TO with VALUES
+staged on TO's value slot.  If UPDATE-RETURN-P, also set TO's
+return-fiber to FROM (resume/switch semantics); otherwise leave it
+alone (yield semantics -- preserves TO's prior caller chain)."
+  (declare (type fiber from to)
+           (type list values))
+  (cond ((fiber-released-p from)
+         (error 'dead-fiber-error :fiber from))
+        ((fiber-released-p to)
+         (error 'dead-fiber-error :fiber to)))
+  (let* ((from-sap (fiber-sap from))
+         (to-sap (fiber-sap to))
+         (th-sap (sb-thread:current-thread-sap))
+         (from-ctx (%fiber-ctx from-sap))
+         (to-ctx (%fiber-ctx to-sap)))
+    (check-switch from to from-ctx to-ctx)
+    (if update-return-p
+        (stage-return from to from-sap to-ctx values)
+        (setf (fiber-value to) values))
+    (setf *current-fiber* to)
+    (%switch-prep from-sap to-sap)
+    (swap-frames th-sap from-ctx to-ctx)
+    (flip-states from-ctx to-ctx)
+    (%swap-regs from-sap to-sap)
+    ;; Control re-enters here when some later switch resumes from.
+    (setf *current-fiber* from))
+  ;; Post-resume delivery (each a no-op unless its slot is set).  Order is
+  ;; deliberate: from's own staged interrupt fires first, in from's context,
+  ;; and if it does it unwinds and preempts the rest -- an interrupt on the
+  ;; resumed fiber outranks delivering to's escape.  to is already dead once
+  ;; it has an escape, so a preempted escape is dropped, not redelivered.
+  (deliver-pending from)
+  (maybe-escape to)
+  (maybe-escape-throw to)
+  (values-list (fiber-value from)))
+
+(defun switch-fiber (from to &rest values)
+  "Suspend FROM and resume TO, delivering VALUES to the resumer as
+multiple values.  Sets TO's return-fiber to FROM, so a subsequent
+YIELD-FIBER inside TO will return to FROM.  Returns whatever the next
+switch back to FROM delivers, also as multiple values."
+  (declare (type fiber from to))
+  (%switch from to values t))
+
+(defun resume-fiber (to &rest values)
+  "Suspend the current fiber and resume TO, delivering VALUES as
+multiple values.  Equivalent to (SWITCH-FIBER *CURRENT-FIBER* TO
+. VALUES): sets TO's return-fiber to *CURRENT-FIBER*, so YIELD-FIBER
+inside TO comes back here.
+
+  YIELD-FIBER  -- suspend self, deliver to the return fiber, preserve
+                  the return fiber's own caller chain.
+  RESUME-FIBER -- suspend self, deliver to a chosen fiber, make self
+                  that fiber's return fiber.
+  SWITCH-FIBER -- explicit FROM/TO form of RESUME-FIBER."
+  (declare (type fiber to))
+  (let ((from *current-fiber*))
+    (unless from
+      (error 'no-current-fiber-error :operation 'resume-fiber))
+    (%switch from to values t)))
+
+(defmacro with-fiber ((var function &rest make-args) &body body)
+  "Create a fiber, bind it to VAR, execute BODY, release on exit."
+  `(let ((,var (make-fiber ,function ,@make-args)))
+     (unwind-protect (progn ,@body)
+       (release-fiber ,var))))
+
+(defun yield-fiber (&rest values)
+  "Switch from the current fiber to its return fiber, delivering VALUES
+as multiple values to the resumer.  Returns whatever the next
+switch-in delivers (as multiple values).  Errors if the current fiber
+has no recorded return fiber (never resumed)."
+  (let ((self *current-fiber*))
+    (unless self
+      (error 'no-current-fiber-error :operation 'yield-fiber))
+    (let ((target (fiber-return-fiber self)))
+      (unless target
+        (error "fiber ~S has no return fiber (never resumed)" self))
+      (%switch self target values nil))))
+
+(defun join-fiber (fiber)
+  "Resume FIBER from the current fiber until it runs to completion,
+and return its entry-function values.  FIBER must be RUNNABLE or NEW
+and on the current thread."
+  (declare (type fiber fiber))
+  (loop with vs
+        while (fiber-alive-p fiber)
+        do (setf vs (multiple-value-list (resume-fiber fiber)))
+        finally (return (values-list vs))))
+
+(defun interrupt-fiber (fiber condition)
+  "Stage CONDITION to be signalled in FIBER on its next resume.
+Cooperative -- nothing happens until SWITCH-FIBER delivers control
+into FIBER, at which point CONDITION is signalled in the fiber's own
+context.  A NEW fiber is effectively cancelled (the condition fires
+before its entry function runs)."
+  (declare (type fiber fiber)
+           (type condition condition))
+  (unless (fiber-alive-p fiber)
+    (error 'dead-fiber-error :fiber fiber))
+  (setf (fiber-pending-condition fiber) condition)
+  fiber)
+
+(defmacro with-interrupted-fiber ((fiber condition) &body body)
+  "Stage CONDITION on FIBER for delivery on its next resume, then
+execute BODY.  On exit (normal or non-local), if the staged condition
+has not been consumed by a resume it is cleared."
+  (let ((f (gensym "FIBER"))
+        (c (gensym "CONDITION")))
+    `(let ((,f ,fiber)
+           (,c ,condition))
+       (interrupt-fiber ,f ,c)
+       (unwind-protect (progn ,@body)
+         (when (eq (fiber-pending-condition ,f) ,c)
+           (setf (fiber-pending-condition ,f) nil))))))
+
+(declaim (inline fiber-condition))
+(defun fiber-condition (fiber)
+  "The condition staged for FIBER's next resume by INTERRUPT-FIBER, or
+NIL.  Cleared when FIBER consumes it on resume.  (An entry-function
+escape is a separate channel, re-signaled in the resumer rather than
+in FIBER, and is not visible here.)"
+  (declare (type fiber fiber))
+  (fiber-pending-condition fiber))
+
+(declaim (inline fiber-pinned-p))
+(defun fiber-pinned-p (fiber)
+  "Return T if FIBER's pin count is greater than zero. SWITCH-FIBER
+will only suspend a fiber with a pin count of zero."
+  (declare (type fiber fiber))
+  (plusp (fiber-pin-count fiber)))
+
+(defmacro with-fiber-pinned (() &body body)
+  "Increment the current fiber's pin count for the dynamic extent of
+BODY; SWITCH-FIBER refuses to suspend a pinned fiber.  Pins nest."
+  (let ((f (gensym "PINNED-FIBER")))
+    `(let ((,f (or *current-fiber*
+                   (error 'no-current-fiber-error
+                          :operation 'with-fiber-pinned))))
+       (incf (fiber-pin-count ,f))
+       (unwind-protect (progn ,@body)
+         (decf (fiber-pin-count ,f))))))
+
+;;; --- Cross-thread migration ---
+
+(defun fiber-migrate (fiber dest-thread)
+  "Atomically move FIBER's ownership from its current owner thread to
+DEST-THREAD.  After this returns, FIBER may be switched into only from
+DEST-THREAD.
+
+FIBER must be in state :RUNNABLE."
+  (declare (type fiber fiber)
+           (type sb-thread:thread dest-thread))
+  (when (fiber-released-p fiber)
+    (error 'dead-fiber-error :fiber fiber))
+  (let ((state (%fiber-state fiber)))
+    (unless (= state +fiber-runnable+)
+      (error 'fiber-state-error
+             :fiber fiber
+             :state (fiber-state fiber)
+             :expected '(:runnable))))
+  (let ((dest-sap (sb-thread::thread-primitive-thread dest-thread)))
+    (when (zerop dest-sap)
+      (error "destination thread is not live"))
+    (let ((rc (%fiber-migrate (fiber-sap fiber)
+                              (sb-sys:int-sap dest-sap))))
+      (case rc
+        (0
+         (setf (fiber-thread fiber) dest-thread)
+         fiber)
+        (-1
+         (error 'fiber-state-error
+                :fiber fiber
+                :state (fiber-state fiber)
+                :expected '(:runnable)))
+        (-2
+         (error 'fiber-error :fiber fiber))
+        (t
+         (error "unexpected return code ~D from fiber migration" rc))))))
+
+)

--- a/contrib/sb-fiber/fiber.lisp
+++ b/contrib/sb-fiber/fiber.lisp
@@ -39,18 +39,18 @@ and register it with the current thread.  Caller arranges
     f))
 
 (defun make-main-fiber (&key name)
-  "Create a fiber representing the current thread's own stack and bind
-*CURRENT-FIBER* to it.  NAME is a string label used by PRINT-OBJECT."
+  "Create a fiber representing the current thread's own stack and make
+it this thread's current fiber.  NAME is a string label used by
+PRINT-OBJECT."
   (with-fiber-sap (sap (%fiber-create-main (sb-thread:current-thread-sap)))
-    (setf *current-fiber* (%install-fiber sap nil name))))
+    (setf (%current-fiber) (%install-fiber sap nil name))))
 
 (defmacro with-fiber-thread ((&key name) &body body)
   "Register a main fiber on the calling thread for the dynamic extent
-of BODY and release it on exit.  A no-op if BODY is reached with
-*CURRENT-FIBER* already bound.  NAME is forwarded to MAKE-MAIN-FIBER."
+of BODY and release it on exit.  A no-op if the thread already has a
+current fiber.  NAME is forwarded to MAKE-MAIN-FIBER."
   (let ((created (gensym "CREATED")))
-    `(let* ((*current-fiber* *current-fiber*)
-            (,created (unless *current-fiber* (make-main-fiber :name ,name))))
+    `(let ((,created (unless (current-fiber) (make-main-fiber :name ,name))))
        (unwind-protect (progn ,@body)
          (when ,created (release-fiber ,created))))))
 
@@ -65,13 +65,13 @@ When FUNCTION returns, the fiber is marked DEAD and control switches
 back to its most recent resumer, delivering FUNCTION's return value
 as that resumer's SWITCH-FIBER value.
 
-The calling thread must already have a main fiber bound in
-*CURRENT-FIBER*.  Use MAKE-MAIN-FIBER or WITH-FIBER-THREAD to establish
-one before calling MAKE-FIBER.  Signals an error otherwise.
+The calling thread must already have a current fiber.  Use
+MAKE-MAIN-FIBER or WITH-FIBER-THREAD to establish one before calling
+MAKE-FIBER.  Signals an error otherwise.
 
 Fibers are auto-released when their owning thread exits; explicit
 RELEASE-FIBER is only needed if you want to reclaim resources sooner."
-  (unless *current-fiber*
+  (unless (current-fiber)
     (error 'no-current-fiber-error :operation 'make-fiber))
   (with-fiber-sap (sap (%fiber-create stack-size binding-stack-size))
     (%install-fiber sap function name)))
@@ -92,8 +92,8 @@ exits."
     (%fiber-release (shiftf (fiber-sap fiber) (sb-sys:int-sap 0)))
     (setf (fiber-thread fiber)     nil
           (fiber-released-p fiber) t)
-    (when (eq *current-fiber* fiber)
-      (setf *current-fiber* nil))))
+    (when (eq (current-fiber) fiber)
+      (setf (%current-fiber) nil))))
 
 (defun fiber-state (fiber)
   "Return the current state of FIBER as a keyword: :NEW, :RUNNABLE,
@@ -110,13 +110,6 @@ released."
   (declare (type fiber fiber))
   (and (not (fiber-released-p fiber))
        (/= (%fiber-state fiber) +fiber-dead+)))
-
-(declaim (inline current-fiber)
-         (ftype (function () (or null fiber)) current-fiber))
-(defun current-fiber ()
-  "Return the fiber currently running on this thread, or NIL if no
-main fiber is bound."
-  *current-fiber*)
 
 ;;; --- Stack-usage accessors ---
 
@@ -184,18 +177,17 @@ alone (yield semantics -- preserves TO's prior caller chain)."
     (if update-return-p
         (stage-return from to from-sap to-ctx values)
         (setf (fiber-value to) values))
-    (setf *current-fiber* to)
+    (setf (%current-fiber) to)
     (%switch-prep from-sap to-sap)
     (swap-frames th-sap from-ctx to-ctx)
     (flip-states from-ctx to-ctx)
     (%swap-regs from-sap to-sap)
-    ;; Control re-enters here when some later switch resumes from.
-    (setf *current-fiber* from))
-  ;; Post-resume delivery (each a no-op unless its slot is set).  Order is
-  ;; deliberate: from's own staged interrupt fires first, in from's context,
-  ;; and if it does it unwinds and preempts the rest -- an interrupt on the
-  ;; resumed fiber outranks delivering to's escape.  to is already dead once
-  ;; it has an escape, so a preempted escape is dropped, not redelivered.
+    ;; C auto-return taken when a fiber's entry function returns does
+    ;; not touch the slot, so store it again here.
+    (setf (%current-fiber) from))
+  ;; Post-resume delivery (each a no-op unless its slot is set).
+  ;; From's own staged interrupt fires first, in from's context, and
+  ;; if it does it unwinds and preempts the rest.
   (deliver-pending from)
   (maybe-escape to)
   (maybe-escape-throw to)
@@ -211,8 +203,8 @@ switch back to FROM delivers, also as multiple values."
 
 (defun resume-fiber (to &rest values)
   "Suspend the current fiber and resume TO, delivering VALUES as
-multiple values.  Equivalent to (SWITCH-FIBER *CURRENT-FIBER* TO
-. VALUES): sets TO's return-fiber to *CURRENT-FIBER*, so YIELD-FIBER
+multiple values.  Equivalent to (SWITCH-FIBER (CURRENT-FIBER) TO
+. VALUES): sets TO's return-fiber to the current fiber, so YIELD-FIBER
 inside TO comes back here.
 
   YIELD-FIBER  -- suspend self, deliver to the return fiber, preserve
@@ -221,7 +213,7 @@ inside TO comes back here.
                   that fiber's return fiber.
   SWITCH-FIBER -- explicit FROM/TO form of RESUME-FIBER."
   (declare (type fiber to))
-  (let ((from *current-fiber*))
+  (let ((from (current-fiber)))
     (unless from
       (error 'no-current-fiber-error :operation 'resume-fiber))
     (%switch from to values t)))
@@ -237,7 +229,7 @@ inside TO comes back here.
 as multiple values to the resumer.  Returns whatever the next
 switch-in delivers (as multiple values).  Errors if the current fiber
 has no recorded return fiber (never resumed)."
-  (let ((self *current-fiber*))
+  (let ((self (current-fiber)))
     (unless self
       (error 'no-current-fiber-error :operation 'yield-fiber))
     (let ((target (fiber-return-fiber self)))
@@ -301,7 +293,7 @@ will only suspend a fiber with a pin count of zero."
   "Increment the current fiber's pin count for the dynamic extent of
 BODY; SWITCH-FIBER refuses to suspend a pinned fiber.  Pins nest."
   (let ((f (gensym "PINNED-FIBER")))
-    `(let ((,f (or *current-fiber*
+    `(let ((,f (or (current-fiber)
                    (error 'no-current-fiber-error
                           :operation 'with-fiber-pinned))))
        (incf (fiber-pin-count ,f))

--- a/contrib/sb-fiber/package.lisp
+++ b/contrib/sb-fiber/package.lisp
@@ -1,0 +1,54 @@
+;;;; -*-  Lisp -*-
+
+(defpackage :sb-fiber
+  (:use :cl :sb-alien :sb-ext)
+  (:export
+   #:*current-fiber*
+   #:current-fiber
+   #:*default-fiber-stack-size*
+   #:*default-fiber-binding-stack-size*
+   #:fiber
+   #:fiberp
+   #:make-fiber
+   #:make-main-fiber
+   #:with-fiber-thread
+   #:release-fiber
+   #:fiber-name
+   #:fiber-thread
+   #:fiber-return-fiber
+   #:switch-fiber
+   #:resume-fiber
+   #:yield-fiber
+   #:join-fiber
+   #:interrupt-fiber
+   #:with-interrupted-fiber
+   #:fiber-condition
+   #:fiber-alive-p
+   #:fiber-main-p
+   #:fiber-released-p
+   #:fiber-state
+   #:fiber-control-stack-size
+   #:fiber-control-stack-usage
+   #:fiber-binding-stack-size
+   #:fiber-binding-stack-usage
+   #:with-fiber
+   #:with-fiber-pinned
+   #:fiber-pinned-p
+   #:fiber-pin-count
+   #:fiber-migrate
+   ;; Conditions
+   #:fiber-error
+   #:fiber-error-fiber
+   #:dead-fiber-error
+   #:pinned-fiber-error
+   #:pinned-fiber-error-depth
+   #:fiber-thread-mismatch-error
+   #:fiber-thread-mismatch-error-role
+   #:fiber-state-error
+   #:fiber-state-error-state
+   #:fiber-state-error-expected
+   #:no-current-fiber-error
+   #:no-current-fiber-error-operation))
+
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (setf (sb-int:system-package-p (find-package "SB-FIBER")) t))

--- a/contrib/sb-fiber/package.lisp
+++ b/contrib/sb-fiber/package.lisp
@@ -3,7 +3,6 @@
 (defpackage :sb-fiber
   (:use :cl :sb-alien :sb-ext)
   (:export
-   #:*current-fiber*
    #:current-fiber
    #:*default-fiber-stack-size*
    #:*default-fiber-binding-stack-size*

--- a/contrib/sb-fiber/sb-fiber.asd
+++ b/contrib/sb-fiber/sb-fiber.asd
@@ -1,0 +1,21 @@
+;;;; -*-  Lisp -*-
+
+(error "Can't build contribs with ASDF")
+
+(defsystem "sb-fiber"
+  :defsystem-depends-on ("sb-grovel")
+  :components ((:file "package")
+               (:sb-grovel-constants-file "constants"
+                :package :sb-fiber
+                :if-feature (:and :sb-fiber (:or :x86-64 :arm64) (:not :win32))
+                :depends-on ("package"))
+               (:file "x86-64-vops"
+                :if-feature (:and :sb-fiber :x86-64)
+                :depends-on ("package"))
+               (:file "arm64-vops"
+                :if-feature (:and :sb-fiber :arm64)
+                :depends-on ("package"))
+               (:file "fiber-ffi"
+                :depends-on ("package" "constants"))
+               (:file "fiber"
+                :depends-on ("package" "constants" "fiber-ffi"))))

--- a/contrib/sb-fiber/sb-fiber.texinfo
+++ b/contrib/sb-fiber/sb-fiber.texinfo
@@ -1,0 +1,249 @@
+@node sb-fiber
+@section sb-fiber
+@cindex Fiber
+@cindex Sb-fiber
+
+@code{sb-fiber} provides user-space coroutines with their own control
+and binding stacks, cooperatively scheduled and running on a single OS
+thread at a time, with explicit cross-thread migration.
+
+@code{switch-fiber} is the only control-transfer operation and is
+intended to be the building block for schedulers, I/O integration, and
+fiber-aware synchronization in user application code.
+
+@subsection API
+
+@deffn Function make-fiber function &key name (stack-size 65536) (binding-stack-size 8192)
+Create a new fiber whose entry @var{function} runs when first switched
+to.  @var{name}, if supplied, is a string label used by
+@code{print-object}.  Registered fibers are released automatically at
+thread exit; @code{release-fiber} is only needed if you want to
+reclaim resources sooner.
+
+The calling thread must already have a main fiber bound in
+@code{*current-fiber*}.  Use @code{make-main-fiber} or
+@code{with-fiber-thread} to establish one before calling
+@code{make-fiber}; otherwise an error is signalled.
+
+If @var{function} returns normally, the fiber is marked @code{:dead}
+and control switches back to its return fiber, with the function's
+return value (see @code{switch-fiber}).  If @var{function} exits via
+an unhandled condition, the condition is stored on the fiber and
+re-signaled in the caller's context.
+@end deffn
+
+@deffn Function make-main-fiber &key name
+Create a fiber representing the current thread's own stack and bind
+@code{*current-fiber*}.  Most code should use
+@code{with-fiber-thread}; @code{make-main-fiber} is the explicit form
+for callers that manage fiber-thread lifetime by hand.
+@end deffn
+
+@deffn Macro with-fiber-thread () &body body
+Register a main fiber on the calling thread for the dynamic extent of
+@var{body} and release it on exit.  A no-op if @code{*current-fiber*}
+is already bound on entry (nesting is safe).
+@end deffn
+
+@deffn Function fiber-name fiber
+The @code{:name} string supplied to @code{make-fiber}, or @code{nil}.
+@end deffn
+
+@deffn Function fiber-thread fiber
+The @code{sb-thread:thread} that currently owns @var{fiber} (the only
+thread that may switch into it, until @code{fiber-migrate} hands it to
+another), or @code{nil} if @var{fiber} has been released.  Useful for
+assertions in scheduler code.
+@end deffn
+
+@deffn Function release-fiber fiber
+Reclaim @var{fiber}'s resources.  For a worker fiber, unmaps its
+stacks and frees the bookkeeping struct.  For a main fiber, just frees
+the struct; the thread's own stack and binding stack are untouched.
+@var{fiber} must not be RUNNING (other than a main fiber, which is
+always RUNNING until released).  Optional: registered fibers are
+released automatically when their owning thread exits.
+@end deffn
+
+@deffn Macro with-fiber (var function &rest make-args) &body body
+@code{make-fiber} + @code{unwind-protect} + @code{release-fiber}.
+@end deffn
+
+@deffn Function switch-fiber from to &rest values
+Suspend @var{from} and resume @var{to}, delivering @var{values} as
+multiple values to the resumer.  Returns whatever the next switch-in
+delivers (or @var{to}'s entry function's return values if it ran to
+completion), also as multiple values.  Both fibers must be registered
+to the current thread; @var{from} must be @code{:running} and
+@var{to} must be @code{:runnable} or @code{:new}.
+
+The switch preserves the resumed fiber's control stack, binding stack,
+@code{*handler-clusters*}, @code{*restart-clusters*}, current catch
+and unwind-protect chains, callee-saved registers, and (on x86-64)
+the SSE control word.  @code{*current-fiber*} (per-thread) tracks the
+resumed fiber.
+
+If @var{to}'s entry function previously escaped via an unhandled
+condition, that condition is re-signaled here in the caller's
+context.
+@end deffn
+
+@deffn Function resume-fiber to &rest values
+Suspend the current fiber and resume @var{to}, delivering @var{values}
+as multiple values.  Equivalent to
+@code{(switch-fiber *current-fiber* to . values)}; supplied as the
+common-case shorthand and to make the trio symmetric:
+
+@itemize
+@item @code{yield-fiber}  -- suspend self, deliver to the return fiber.
+@item @code{resume-fiber} -- suspend self, deliver to a chosen fiber.
+@item @code{switch-fiber} -- explicit @code{from}/@code{to} form.
+@end itemize
+
+Errors if @code{*current-fiber*} is unbound.
+@end deffn
+
+@deffn Function yield-fiber &rest values
+Switch to the current fiber's return fiber, delivering @var{values} as
+multiple values to the resumer's @code{switch-fiber} return.  Returns
+whatever the next switch-in delivers, also as multiple values.  Errors
+if the current fiber has never been resumed.
+@end deffn
+
+@deffn Function join-fiber fiber
+Resume @var{fiber} from @code{*current-fiber*} repeatedly until its
+entry function returns; return that function's values as multiple
+values.  Parallels @code{sb-thread:join-thread} for cooperative
+coroutines.
+@end deffn
+
+@deffn Function interrupt-fiber fiber condition
+Stage @var{condition} to be signaled in @var{fiber} on its next
+resume.  Nothing happens until @code{switch-fiber} delivers control
+into @var{fiber}, at which point @var{condition} is signaled in the
+fiber's own context (for a runnable fiber) or raised by the trampoline
+before the entry function runs (for a new fiber).
+@end deffn
+
+@deffn Function fiber-condition fiber
+The condition (if any) staged for @var{fiber}'s next resume, or
+@code{nil}.  Cleared when consumed by @code{switch-fiber}.
+@end deffn
+
+@deffn Macro with-fiber-pinned () &body body
+Mark the current fiber unsuspendable for the dynamic extent of
+@var{body}; @code{switch-fiber} signals an error if invoked with a
+pinned @code{from}.  Pins nest.  Intended for FFI: wrap any region
+containing live foreign frames so a yield can't leave them atop a
+re-entered stack.
+@end deffn
+
+@deffn Function fiber-pinned-p fiber
+@code{t} if @var{fiber} has a nonzero pin count.
+@end deffn
+
+@deffn Function fiber-alive-p fiber
+@code{t} if @var{fiber}'s state is not @code{:dead} (i.e. it has not
+run to completion or been released).
+@end deffn
+
+@deffn Function fiber-main-p fiber
+@code{t} if @var{fiber} represents a thread's own stack (created by
+@code{make-main-fiber} or @code{with-fiber-thread}), @code{nil} if it
+is a worker fiber created by @code{make-fiber}.
+@end deffn
+
+@deffn Function fiber-state fiber
+Keyword state: @code{:new}, @code{:runnable}, @code{:running}, or
+@code{:dead}.
+@end deffn
+
+@deffn Function fiber-migrate fiber dest-thread
+Atomically transfer ownership of @var{fiber} from its current owner
+thread to @var{dest-thread}; afterwards only @var{dest-thread} may
+switch into it.  @var{fiber} must be @code{:runnable} (signals
+@code{fiber-state-error} otherwise) and @var{dest-thread} must be
+live.  Returns @var{fiber}.
+@end deffn
+
+@subsection Conditions
+
+All sb-fiber precondition errors inherit from @code{fiber-error}.
+Schedulers can @code{handler-case} on the base class to catch them
+uniformly, or on a subclass for targeted recovery.
+
+@deffn Condition fiber-error
+Base class; one initarg/reader: @code{:fiber} / @code{fiber-error-fiber}.
+@end deffn
+
+@deffn Condition dead-fiber-error
+Signaled when @code{switch-fiber} or @code{interrupt-fiber} touches a
+fiber that has been released or has run to completion.
+@end deffn
+
+@deffn Condition pinned-fiber-error
+Signaled when @code{switch-fiber} would suspend a fiber whose pin
+count is nonzero.  Reader @code{pinned-fiber-error-depth} returns the
+pin count.  FFI-aware schedulers can catch this and retry once their
+foreign region exits.
+@end deffn
+
+@deffn Condition fiber-thread-mismatch-error
+Signaled when a switch references a fiber owned by a different OS
+thread.  Reader @code{fiber-thread-mismatch-error-role} returns
+@code{:from} or @code{:to}.
+@end deffn
+
+@deffn Condition fiber-state-error
+Signaled when a fiber is not in an acceptable state for the requested
+operation.  Readers: @code{fiber-state-error-state} (the actual
+keyword), @code{fiber-state-error-expected} (a list of accepted
+states).
+@end deffn
+
+@deffn Condition no-current-fiber-error
+Signaled when an operation that requires a current fiber
+(@code{make-fiber}, @code{resume-fiber}, @code{yield-fiber},
+@code{with-fiber-pinned}) runs on a thread with no fiber bound in
+@code{*current-fiber*}.  Establish one with @code{make-main-fiber} or
+@code{with-fiber-thread}.  Reader
+@code{no-current-fiber-error-operation} returns the operator that
+signaled, or @code{nil}.  Carries no fiber.
+@end deffn
+
+@subsection Example
+
+@lisp
+(require :sb-fiber)
+(use-package :sb-fiber)
+
+(with-fiber-thread ()
+  (let ((child (make-fiber
+                (lambda ()
+                  (format t "hello from child~%")
+                  (yield-fiber)
+                  (format t "back again~%")))))
+    (resume-fiber child)
+    (format t "main resumed~%")
+    (resume-fiber child)))
+@end lisp
+
+Prints @code{hello from child}, @code{main resumed}, @code{back again}.
+
+A realistic scheduler layers non-blocking I/O on top: when a fiber
+would block on an fd, it registers with
+@code{poll}/@code{epoll}/@code{kqueue} and yields; the scheduler's
+poll loop wakes it when ready.
+
+@subsection Further Notes
+
+@itemize
+@item @strong{Platforms.}  x86-64 and arm64 POSIX only.
+@item @strong{No preemption.}  Tight compute loops starve the scheduler.
+@item @strong{Handler isolation.}  A fiber's entry function runs with
+fresh @code{*handler-clusters*} / @code{*restart-clusters*}.
+@item @strong{Image survival.}  Fibers do not survive
+@code{save-lisp-and-die}; drop wrapper references before saving.
+@item @strong{Garbage collection.}  A suspended fiber's C control stack
+is scanned conservatively even on the otherwise-precise arm64 backend.
+@end itemize

--- a/contrib/sb-fiber/sb-fiber.texinfo
+++ b/contrib/sb-fiber/sb-fiber.texinfo
@@ -20,8 +20,8 @@ to.  @var{name}, if supplied, is a string label used by
 thread exit; @code{release-fiber} is only needed if you want to
 reclaim resources sooner.
 
-The calling thread must already have a main fiber bound in
-@code{*current-fiber*}.  Use @code{make-main-fiber} or
+The calling thread must already have a current fiber.  Use
+@code{make-main-fiber} or
 @code{with-fiber-thread} to establish one before calling
 @code{make-fiber}; otherwise an error is signalled.
 
@@ -33,16 +33,21 @@ re-signaled in the caller's context.
 @end deffn
 
 @deffn Function make-main-fiber &key name
-Create a fiber representing the current thread's own stack and bind
-@code{*current-fiber*}.  Most code should use
+Create a fiber representing the current thread's own stack and make
+it the thread's current fiber.  Most code should use
 @code{with-fiber-thread}; @code{make-main-fiber} is the explicit form
 for callers that manage fiber-thread lifetime by hand.
 @end deffn
 
 @deffn Macro with-fiber-thread () &body body
 Register a main fiber on the calling thread for the dynamic extent of
-@var{body} and release it on exit.  A no-op if @code{*current-fiber*}
-is already bound on entry (nesting is safe).
+@var{body} and release it on exit.  A no-op if the thread already has
+a current fiber on entry (nesting is safe).
+@end deffn
+
+@deffn Function current-fiber
+The fiber currently running on the calling thread, or @code{nil} if
+the thread has no main fiber.
 @end deffn
 
 @deffn Function fiber-name fiber
@@ -80,8 +85,8 @@ to the current thread; @var{from} must be @code{:running} and
 The switch preserves the resumed fiber's control stack, binding stack,
 @code{*handler-clusters*}, @code{*restart-clusters*}, current catch
 and unwind-protect chains, callee-saved registers, and (on x86-64)
-the SSE control word.  @code{*current-fiber*} (per-thread) tracks the
-resumed fiber.
+the SSE control word.  @code{current-fiber} reports the resumed
+fiber.
 
 If @var{to}'s entry function previously escaped via an unhandled
 condition, that condition is re-signaled here in the caller's
@@ -91,7 +96,7 @@ context.
 @deffn Function resume-fiber to &rest values
 Suspend the current fiber and resume @var{to}, delivering @var{values}
 as multiple values.  Equivalent to
-@code{(switch-fiber *current-fiber* to . values)}; supplied as the
+@code{(switch-fiber (current-fiber) to . values)}; supplied as the
 common-case shorthand and to make the trio symmetric:
 
 @itemize
@@ -100,7 +105,7 @@ common-case shorthand and to make the trio symmetric:
 @item @code{switch-fiber} -- explicit @code{from}/@code{to} form.
 @end itemize
 
-Errors if @code{*current-fiber*} is unbound.
+Errors if the thread has no current fiber.
 @end deffn
 
 @deffn Function yield-fiber &rest values
@@ -111,7 +116,7 @@ if the current fiber has never been resumed.
 @end deffn
 
 @deffn Function join-fiber fiber
-Resume @var{fiber} from @code{*current-fiber*} repeatedly until its
+Resume @var{fiber} from the current fiber repeatedly until its
 entry function returns; return that function's values as multiple
 values.  Parallels @code{sb-thread:join-thread} for cooperative
 coroutines.
@@ -204,8 +209,8 @@ states).
 @deffn Condition no-current-fiber-error
 Signaled when an operation that requires a current fiber
 (@code{make-fiber}, @code{resume-fiber}, @code{yield-fiber},
-@code{with-fiber-pinned}) runs on a thread with no fiber bound in
-@code{*current-fiber*}.  Establish one with @code{make-main-fiber} or
+@code{with-fiber-pinned}) runs on a thread that has no current fiber.
+Establish one with @code{make-main-fiber} or
 @code{with-fiber-thread}.  Reader
 @code{no-current-fiber-error-operation} returns the operator that
 signaled, or @code{nil}.  Carries no fiber.

--- a/contrib/sb-fiber/x86-64-vops.lisp
+++ b/contrib/sb-fiber/x86-64-vops.lisp
@@ -1,0 +1,31 @@
+;;;; Inline register/SP/MXCSR swap for SWITCH-FIBER
+
+(in-package "SB-VM")
+
+(sb-c:defknown sb-fiber::%swap-regs
+    (system-area-pointer system-area-pointer) (values)
+    (sb-c:always-translatable))
+
+(define-vop (fiber-swap-regs)
+  (:translate sb-fiber::%swap-regs)
+  (:policy :fast-safe)
+  (:args (from :scs (sap-reg) :target from-tmp)
+         (to   :scs (sap-reg) :target to-tmp))
+  (:arg-types system-area-pointer system-area-pointer)
+  (:temporary (:sc sap-reg :offset rax-offset
+               :from (:argument 0) :to (:result 0))
+              from-tmp)
+  (:temporary (:sc sap-reg :offset rcx-offset
+               :from (:argument 1) :to (:result 0))
+              to-tmp)
+  (:temporary (:sc unsigned-reg :offset rdx-offset) temp)
+  (:generator 10
+    (move from-tmp from)
+    (move to-tmp to)
+    (inst lea temp (rip-relative-ea RESUME))
+    (inst push temp)
+    (emit-save-fiber-regs from-tmp)
+    (emit-restore-fiber-regs to-tmp)
+    (inst ret)
+    RESUME
+    (emit-end-pseudo-atomic)))

--- a/make-target-2-load.lisp
+++ b/make-target-2-load.lisp
@@ -87,7 +87,7 @@
            ;; though I don't think they should all be public.
            :MSAN :UBSAN
            :SB-SAFEPOINT
-           :SB-THREAD :SB-UNICODE
+           :SB-THREAD :SB-UNICODE :SB-FIBER
            ;; Things which (I think) at least one person has requested be kept around
            :SB-LDB
            ;; We keep the :SB-PACKAGE-LOCKS feature despite it no longer
@@ -442,6 +442,9 @@ Please check that all strings which were not recognizable to the compiler
                             ;; need this for defining a vop which
                             ;; tests the x86-64 allocation profiler
                             sb-vm::pseudo-atomic
+                            ,@(or #+(and sb-fiber (or x86-64 arm64))
+                                  '(sb-vm::emit-save-fiber-regs
+                                    sb-vm::emit-restore-fiber-regs))
                             ,@(or #+(or arm64 x86 x86-64)
                                   '(sb-vm::%vector-cas-pair
                                     sb-vm::%instance-cas-pair

--- a/src/assembly/arm64/tramps.lisp
+++ b/src/assembly/arm64/tramps.lisp
@@ -204,3 +204,23 @@
   (loadw lr-tn lexenv-tn closure-fun-slot fun-pointer-lowtag)
   (inst add lr-tn lr-tn 4)
   (inst br lr-tn))
+
+#+sb-fiber
+(progn
+
+(define-assembly-routine (fiber-swap-regs (:return-style :none))
+    ((:temp nl0 unsigned-reg nl0-offset)
+     (:temp nl1 unsigned-reg nl1-offset)
+     (:temp nl2 unsigned-reg nl2-offset))
+  (emit-save-fiber-regs nl0 nl2)
+  (emit-restore-fiber-regs nl1 nl2)
+  (inst ret))
+
+(define-assembly-routine (fiber-tramp (:return-style :none))
+    ((:temp arg unsigned-reg nl0-offset))
+  (let ((r9-tn (make-random-tn (sc-or-lose 'unsigned-reg) r9-offset))) ; r9 == x19
+    (inst mov arg r9-tn))
+  (inst bl (make-fixup "fiber_tramp_c" :foreign))
+  (inst brk 0))
+
+) ; end #+sb-fiber

--- a/src/assembly/x86-64/tramps.lisp
+++ b/src/assembly/x86-64/tramps.lisp
@@ -314,3 +314,20 @@
   uncontended
   (inst pop rax-tn))
 ) ; end PROGN
+
+#+sb-fiber
+(progn
+(define-assembly-routine (fiber-swap-regs (:return-style :none))
+    ((:temp rdi unsigned-reg rdi-offset)
+     (:temp rsi unsigned-reg rsi-offset))
+  (emit-save-fiber-regs rdi)
+  (emit-restore-fiber-regs rsi)
+  (inst ret))
+
+(define-assembly-routine (fiber-tramp (:return-style :none))
+    ((:temp rdi unsigned-reg rdi-offset)
+     (:temp r12 unsigned-reg r12-offset))
+  (inst mov rdi r12)
+  (inst call (make-fixup "fiber_tramp_c" :foreign))
+  (inst ud2))
+) ; end #+sb-fiber

--- a/src/assembly/x86-64/tramps.lisp
+++ b/src/assembly/x86-64/tramps.lisp
@@ -313,3 +313,20 @@
   uncontended
   (inst pop rax-tn))
 ) ; end PROGN
+
+#+sb-fiber
+(progn
+(define-assembly-routine (fiber-swap-regs (:return-style :none))
+    ((:temp rdi unsigned-reg rdi-offset)
+     (:temp rsi unsigned-reg rsi-offset))
+  (emit-save-fiber-regs rdi)
+  (emit-restore-fiber-regs rsi)
+  (inst ret))
+
+(define-assembly-routine (fiber-tramp (:return-style :none))
+    ((:temp rdi unsigned-reg rdi-offset)
+     (:temp r12 unsigned-reg r12-offset))
+  (inst mov rdi r12)
+  (inst call (make-fixup "fiber_tramp_c" :foreign))
+  (inst ud2))
+) ; end #+sb-fiber

--- a/src/code/room.lisp
+++ b/src/code/room.lisp
@@ -1534,7 +1534,7 @@ We could try a few things to mitigate this:
       (format t "~5x ~s~%" (car x) (cdr x)))
     (format t "Wasted indices:~%")
     (let ((n 0))
-      (loop for i from thread-lisp-thread-slot below (length used)
+      (loop for i from primitive-thread-object-length below (length used)
             do (when (zerop (bit used i))
                  (format t " ~5x" i)
                  (incf n)

--- a/src/cold/base-target-features.lisp-expr
+++ b/src/cold/base-target-features.lisp-expr
@@ -183,6 +183,9 @@
  ;; x86oid Darwin, FreeBSD, and Solaris.
  ; :sb-thread
 
+ ;; low-level fiber primitives support
+ ; :sb-fiber
+
  ;; futex support
  ;;
  ;; While on linux we are able to use futexes for our locking

--- a/src/cold/shared.lisp
+++ b/src/cold/shared.lisp
@@ -389,6 +389,12 @@
           ":GENCGC and :CHENEYGC are incompatible")
          ("(and sb-safepoint (not (and (or arm64 x86 x86-64) (or darwin linux win32))))"
           ":SB-SAFEPOINT not supported on selected arch/OS")
+         ("(and sb-fiber sb-safepoint)"
+          ":SB-FIBER and :SB-SAFEPOINT are incompatible")
+         ("(and sb-fiber (not (or x86-64 arm64)))"
+          ":SB-FIBER requires :X86-64 or :ARM64")
+         ("(and sb-fiber win32)"
+          ":SB-FIBER is not supported on :WIN32")
          ("(not (or elf mach-o win32))"
           "No execute object file format feature defined")
          ("(and cons-profiling (not sb-thread))" ":CONS-PROFILING requires :SB-THREAD")

--- a/src/cold/shared.lisp
+++ b/src/cold/shared.lisp
@@ -392,6 +392,12 @@
           ":GENCGC and :CHENEYGC are incompatible")
          ("(and sb-safepoint (not (and (or arm64 x86 x86-64) (or darwin linux win32))))"
           ":SB-SAFEPOINT not supported on selected arch/OS")
+         ("(and sb-fiber sb-safepoint)"
+          ":SB-FIBER and :SB-SAFEPOINT are incompatible")
+         ("(and sb-fiber (not (or x86-64 arm64)))"
+          ":SB-FIBER requires :X86-64 or :ARM64")
+         ("(and sb-fiber win32)"
+          ":SB-FIBER is not supported on :WIN32")
          ("(not (or elf mach-o win32))"
           "No execute object file format feature defined")
          ("(and cons-profiling (not sb-thread))" ":CONS-PROFILING requires :SB-THREAD")

--- a/src/compiler/arm64/macros.lisp
+++ b/src/compiler/arm64/macros.lisp
@@ -609,3 +609,38 @@
         (setf prev-constant nil)
         (load-stack-tn ,temp ,tn)
         ,temp))))
+
+#+sb-fiber
+(flet ((u (offset) (make-random-tn (sc-or-lose 'unsigned-reg) offset))
+       (a (offset) (make-random-tn (sc-or-lose 'any-reg) offset))
+       (d (offset) (make-random-tn (sc-or-lose 'double-reg) offset)))
+;;; Save and restore a fiber's callee-saved GP/FP register state.
+;;; Offsets match `sb_fiber_regs` struct.
+(defun emit-save-fiber-regs (base tmp)
+  (inst mov-sp tmp nsp-tn)
+  (inst str tmp (@ base #x00))
+  (inst stp cfp-tn        lr-tn          (@ base #x08))   ; x29 x30
+  (inst stp (u r9-offset) (u r10-offset) (@ base #x18))   ; x19 x20
+  (inst stp thread-tn     lexenv-tn      (@ base #x28))   ; x21 x22
+  (inst stp nargs-tn      (a nfp-offset) (@ base #x38))   ; x23 x24
+  (inst stp ocfp-tn       null-tn        (@ base #x48))   ; x25 x26
+  (inst stp csp-tn        cardtable-tn   (@ base #x58))   ; x27 x28
+  (inst stp (d  8)        (d  9)         (@ base #x68))
+  (inst stp (d 10)        (d 11)         (@ base #x78))
+  (inst stp (d 12)        (d 13)         (@ base #x88))
+  (inst stp (d 14)        (d 15)         (@ base #x98)))
+
+(defun emit-restore-fiber-regs (base tmp)
+  (inst ldr tmp (@ base #x00))
+  (inst mov-sp nsp-tn tmp)
+  (inst ldp cfp-tn        lr-tn          (@ base #x08))   ; x29 x30
+  (inst ldp (u r9-offset) (u r10-offset) (@ base #x18))   ; x19 x20
+  (inst ldp thread-tn     lexenv-tn      (@ base #x28))   ; x21 x22
+  (inst ldp nargs-tn      (a nfp-offset) (@ base #x38))   ; x23 x24
+  (inst ldp ocfp-tn       null-tn        (@ base #x48))   ; x25 x26
+  (inst ldp csp-tn        cardtable-tn   (@ base #x58))   ; x27 x28
+  (inst ldp (d  8)        (d  9)         (@ base #x68))
+  (inst ldp (d 10)        (d 11)         (@ base #x78))
+  (inst ldp (d 12)        (d 13)         (@ base #x88))
+  (inst ldp (d 14)        (d 15)         (@ base #x98)))
+)

--- a/src/compiler/arm64/macros.lisp
+++ b/src/compiler/arm64/macros.lisp
@@ -617,3 +617,39 @@
 
 (defun bic-mask (x)
   (ldb (byte 64 0) (lognot x)))
+
+#+sb-fiber
+(flet ((u (offset) (make-random-tn (sc-or-lose 'unsigned-reg) offset))
+       (a (offset) (make-random-tn (sc-or-lose 'any-reg) offset))
+       (d (offset) (make-random-tn (sc-or-lose 'double-reg) offset)))
+;;; Save and restore a fiber's callee-saved GP/FP register state.
+;;; Offsets match `sb_fiber_regs` struct.
+(defun emit-save-fiber-regs (base tmp)
+  (inst mov-sp tmp nsp-tn)
+  (inst str tmp (@ base #x00))
+  (inst stp cfp-tn        lr-tn          (@ base #x08))   ; x29 x30
+  (inst stp (u r9-offset) (u r10-offset) (@ base #x18))   ; x19 x20
+  (inst stp thread-tn     lexenv-tn      (@ base #x28))   ; x21 x22
+  (inst stp nargs-tn      (a nfp-offset) (@ base #x38))   ; x23 x24
+  (inst stp ocfp-tn       null-tn        (@ base #x48))   ; x25 x26
+  (inst stp csp-tn        cardtable-tn   (@ base #x58))   ; x27 x28
+  (inst stp (d  8)        (d  9)         (@ base #x68))
+  (inst stp (d 10)        (d 11)         (@ base #x78))
+  (inst stp (d 12)        (d 13)         (@ base #x88))
+  (inst stp (d 14)        (d 15)         (@ base #x98)))
+
+(defun emit-restore-fiber-regs (base tmp)
+  (inst ldr tmp (@ base #x00))
+  (inst mov-sp nsp-tn tmp)
+  (inst ldp cfp-tn        lr-tn          (@ base #x08))   ; x29 x30
+  (inst ldp (u r9-offset) (u r10-offset) (@ base #x18))   ; x19 x20
+  (inst ldp thread-tn     lexenv-tn      (@ base #x28))   ; x21 x22
+  (inst ldp nargs-tn      (a nfp-offset) (@ base #x38))   ; x23 x24
+  (inst ldp ocfp-tn       null-tn        (@ base #x48))   ; x25 x26
+  (inst ldp csp-tn        cardtable-tn   (@ base #x58))   ; x27 x28
+  (inst ldp (d  8)        (d  9)         (@ base #x68))
+  (inst ldp (d 10)        (d 11)         (@ base #x78))
+  (inst ldp (d 12)        (d 13)         (@ base #x88))
+  (inst ldp (d 14)        (d 15)         (@ base #x98)))
+)
+

--- a/src/compiler/arm64/parms.lisp
+++ b/src/compiler/arm64/parms.lisp
@@ -112,13 +112,21 @@
 ;;; space directly after the static symbols.  That way, the raw-addr
 ;;; can be loaded directly out of them by indirecting relative to NIL.
 ;;;
+;;; Lisp assembly routines whose entry addresses need to be
+;;; discoverable from C (fiber_tramp_c, sb_fiber_prepare).
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defparameter *runtime-asm-routines*
+    '(#+sb-fiber fiber-swap-regs
+      #+sb-fiber fiber-tramp)))
+
 (defconstant-eqx +static-symbols+
  `#(#-sb-thread
     ,@'(*binding-stack-pointer*
         *pseudo-atomic-atomic*
         *pseudo-atomic-interrupted*)
      ;; interrupt handling
-     ,@+common-static-symbols+)
+     ,@+common-static-symbols+
+     ,@*runtime-asm-routines*)
   #'equalp)
 
 (defconstant-eqx +static-fdefns+ `#(,@common-static-fdefns) #'equalp)

--- a/src/compiler/generic/objdef.lisp
+++ b/src/compiler/generic/objdef.lisp
@@ -607,9 +607,12 @@ during backtrace.
   ;; hardcode a 3 here or oversize the array and let confusion reign.
   ;; Also remember, limit is an exclusive upper bound so "size" is 1 less.
   (mv-return-values :length #.(- (1- sb-xc:multiple-values-limit) 3))
-  ;; The *current-thread* MUST be the last slot in the C thread structure.
-  ;; It it the only slot that needs to be noticed by the garbage collector.
-  (lisp-thread :pointer t :special sb-thread:*current-thread*))
+  ;; The garbage collector scans the C thread structure from LISP-THREAD
+  ;; through the end of thread-local storage, so every slot that holds a
+  ;; Lisp object must come at or after this point.
+  (lisp-thread :pointer t :special sb-thread:*current-thread*)
+  ;; The fiber currently running on this thread, or NIL.
+  (current-fiber))
 
 (defconstant code-header-size-shift #+64-bit 32 #-64-bit n-widetag-bits)
 (defconstant-eqx code-serialno-byte

--- a/src/compiler/x86-64/macros.lisp
+++ b/src/compiler/x86-64/macros.lisp
@@ -479,3 +479,28 @@
          (word-index (+ instance-slots-offset (dsd-index slot))))
     `(ea ,(- (ash word-index word-shift) instance-pointer-lowtag)
          ,base-reg)))
+
+#+sb-fiber
+(progn
+;;; Save and restore a fiber's callee-saved register state.  Offsets
+;;; match `sb_fiber_regs` struct.
+(defun emit-save-fiber-regs (base)
+  (inst mov (ea #x00 base) rsp-tn)
+  (inst mov (ea #x08 base) rbx-tn)
+  (inst mov (ea #x10 base) rbp-tn)
+  (inst mov (ea #x18 base) r12-tn)
+  (inst mov (ea #x20 base) r13-tn)
+  (inst mov (ea #x28 base) r14-tn)
+  (inst mov (ea #x30 base) r15-tn)
+  (inst stmxcsr (ea #x38 base)))
+
+(defun emit-restore-fiber-regs (base)
+  (inst mov rsp-tn (ea #x00 base))
+  (inst mov rbx-tn (ea #x08 base))
+  (inst mov rbp-tn (ea #x10 base))
+  (inst mov r12-tn (ea #x18 base))
+  (inst mov r13-tn (ea #x20 base))
+  (inst mov r14-tn (ea #x28 base))
+  (inst mov r15-tn (ea #x30 base))
+  (inst ldmxcsr (ea #x38 base)))
+)

--- a/src/compiler/x86-64/macros.lisp
+++ b/src/compiler/x86-64/macros.lisp
@@ -494,3 +494,28 @@
          (word-index (+ instance-slots-offset (dsd-index slot))))
     `(ea ,(- (ash word-index word-shift) instance-pointer-lowtag)
          ,base-reg)))
+
+#+sb-fiber
+(progn
+;;; Save and restore a fiber's callee-saved register state.  Offsets
+;;; match `sb_fiber_regs` struct.
+(defun emit-save-fiber-regs (base)
+  (inst mov (ea #x00 base) rsp-tn)
+  (inst mov (ea #x08 base) rbx-tn)
+  (inst mov (ea #x10 base) rbp-tn)
+  (inst mov (ea #x18 base) r12-tn)
+  (inst mov (ea #x20 base) r13-tn)
+  (inst mov (ea #x28 base) r14-tn)
+  (inst mov (ea #x30 base) r15-tn)
+  (inst stmxcsr (ea #x38 base)))
+
+(defun emit-restore-fiber-regs (base)
+  (inst mov rsp-tn (ea #x00 base))
+  (inst mov rbx-tn (ea #x08 base))
+  (inst mov rbp-tn (ea #x10 base))
+  (inst mov r12-tn (ea #x18 base))
+  (inst mov r13-tn (ea #x20 base))
+  (inst mov r14-tn (ea #x28 base))
+  (inst mov r15-tn (ea #x30 base))
+  (inst ldmxcsr (ea #x38 base)))
+)

--- a/src/compiler/x86-64/parms.lisp
+++ b/src/compiler/x86-64/parms.lisp
@@ -179,6 +179,14 @@
 ;;;; static symbols
 
 (defvar *binding-stack-pointer*)
+
+;;; Assembly routines whose entry addresses need to be discoverable
+;;; from C
+(eval-when (:compile-toplevel :load-toplevel :execute)
+  (defparameter *runtime-asm-routines*
+    '(#+sb-fiber fiber-swap-regs
+      #+sb-fiber fiber-tramp)))
+
 ;;; These symbols reside in low static space and referenced off NULL-TN
 (defconstant-eqx +static-symbols+
  `#(,@+common-static-symbols+
@@ -189,7 +197,8 @@
     #-sb-thread *alien-stack-pointer*    ; a thread slot if #+sb-thread
     ;; Asm code assembled by DEFINE-ALIEN-CALLABLE resides in static space and looks up
     ;; the address of the C helper via the SYMBOL-VALUE slot of this Lisp symbol.
-    callback-wrapper-trampoline)
+    callback-wrapper-trampoline
+    ,@*runtime-asm-routines*)
   #'equalp)
 
 ;; No static-fdefns are actually needed, but #() here causes the

--- a/src/runtime/Config.arm64-android
+++ b/src/runtime/Config.arm64-android
@@ -22,6 +22,11 @@ ASSEM_SRC = arm64-assem.S
 ARCH_SRC = arm64-arch.c
 
 OS_SRC = linux-os.c linux-mman.c arm64-linux-os.c android-os.c arm64-android-os.c
+
+ifdef LISP_FEATURE_SB_FIBER
+  OS_SRC += fiber.c arm64-fiber.c
+endif
+
 OS_LIBS = -ldl
 
 CFLAGS += -std=gnu99 -Wunused-parameter -fno-omit-frame-pointer -momit-leaf-frame-pointer

--- a/src/runtime/Config.arm64-bsd
+++ b/src/runtime/Config.arm64-bsd
@@ -14,6 +14,10 @@ ARCH_SRC = arm64-arch.c
 
 OS_SRC = bsd-os.c arm64-bsd-os.c
 
+ifdef LISP_FEATURE_SB_FIBER
+  OS_SRC += fiber.c arm64-fiber.c
+endif
+
 ifdef LISP_FEATURE_GENCGC
   GC_SRC = fullcgc.c gencgc.c traceroot.c
 endif

--- a/src/runtime/Config.arm64-darwin
+++ b/src/runtime/Config.arm64-darwin
@@ -13,6 +13,10 @@ CFLAGS += -g -Wall -fdollars-in-identifiers -arch arm64
 
 OS_SRC = bsd-os.c arm64-bsd-os.c darwin-os.c arm64-darwin-os.c
 
+ifdef LISP_FEATURE_SB_FIBER
+  OS_SRC += fiber.c arm64-fiber.c
+endif
+
 OS_LIBS = -lc -ldl
 ifdef LISP_FEATURE_SB_THREAD
   OS_LIBS += -lpthread

--- a/src/runtime/Config.arm64-linux
+++ b/src/runtime/Config.arm64-linux
@@ -13,6 +13,11 @@ ASSEM_SRC = arm64-assem.S
 ARCH_SRC = arm64-arch.c
 
 OS_SRC = linux-os.c linux-mman.c arm64-linux-os.c
+
+ifdef LISP_FEATURE_SB_FIBER
+  OS_SRC += fiber.c arm64-fiber.c
+endif
+
 OS_LIBS = -ldl -Wl,-no-as-needed
 
 ifdef LISP_FEATURE_IMMOBILE_SPACE

--- a/src/runtime/Config.x86-64-android
+++ b/src/runtime/Config.x86-64-android
@@ -20,6 +20,10 @@ ASSEM_SRC = x86-64-assem.S
 ARCH_SRC = x86-64-arch.c
 
 OS_SRC = linux-os.c linux-mman.c x86-64-linux-os.c android-os.c x86-64-android-os.c
+
+ifdef LISP_FEATURE_SB_FIBER
+  OS_SRC += fiber.c x86-64-fiber.c
+endif
 OS_LIBS = -ldl
 
 CFLAGS += -Wunused-parameter -fno-omit-frame-pointer -momit-leaf-frame-pointer

--- a/src/runtime/Config.x86-64-bsd
+++ b/src/runtime/Config.x86-64-bsd
@@ -14,6 +14,10 @@ ASSEM_SRC = x86-64-assem.S
 ARCH_SRC = x86-64-arch.c
 
 OS_SRC = bsd-os.c x86-64-bsd-os.c
+
+ifdef LISP_FEATURE_SB_FIBER
+  OS_SRC += fiber.c x86-64-fiber.c
+endif
 OS_LIBS = # -ldl
 ifdef LISP_FEATURE_SB_CORE_COMPRESSION
   OS_LIBS += -lzstd

--- a/src/runtime/Config.x86-64-darwin
+++ b/src/runtime/Config.x86-64-darwin
@@ -39,6 +39,10 @@ endif
 ASSEM_SRC = x86-64-assem.S
 ARCH_SRC = x86-64-arch.c
 
+ifdef LISP_FEATURE_SB_FIBER
+  OS_SRC += fiber.c x86-64-fiber.c
+endif
+
 LINKFLAGS += -arch x86_64 -dynamic -twolevel_namespace -bind_at_load -pagezero_size 0x100000
 
 CFLAGS += -arch x86_64 -fno-omit-frame-pointer

--- a/src/runtime/Config.x86-64-haiku
+++ b/src/runtime/Config.x86-64-haiku
@@ -13,6 +13,10 @@ ASSEM_SRC = x86-64-assem.S
 ARCH_SRC = x86-64-arch.c
 OS_SRC = haiku-os.c x86-64-haiku-os.c
 
+ifdef LISP_FEATURE_SB_FIBER
+  OS_SRC += fiber.c x86-64-fiber.c
+endif
+
 CFLAGS += -I/boot/system/develop/headers/private/system/arch/x86_64
 LINKFLAGS += -Wl,--export-dynamic
 OS_LIBS += -lbe -lnetwork -lbsd

--- a/src/runtime/Config.x86-64-linux
+++ b/src/runtime/Config.x86-64-linux
@@ -13,6 +13,10 @@ ASSEM_SRC = x86-64-assem.S
 ARCH_SRC = x86-64-arch.c
 OS_SRC = linux-os.c linux-mman.c x86-64-linux-os.c
 
+ifdef LISP_FEATURE_SB_FIBER
+  OS_SRC += fiber.c x86-64-fiber.c
+endif
+
 # The "--Wl,--export-dynamic" flags are here to help people
 # experimenting with callbacks from C to SBCL, by allowing linkage to
 # SBCL src/runtime/*.c symbols from C. Work on this is good, but it's

--- a/src/runtime/Config.x86-64-sunos
+++ b/src/runtime/Config.x86-64-sunos
@@ -12,6 +12,10 @@ ASSEM_SRC = x86-64-assem.S
 ARCH_SRC = x86-64-arch.c
 
 OS_SRC = sunos-os.c x86-64-sunos-os.c
+
+ifdef LISP_FEATURE_SB_FIBER
+  OS_SRC += fiber.c x86-64-fiber.c
+endif
 OS_LIBS= -ldl -lsocket -lnsl -lrt
 ifdef LISP_FEATURE_SB_CORE_COMPRESSION
   OS_LIBS += -lzstd

--- a/src/runtime/alloc.c
+++ b/src/runtime/alloc.c
@@ -22,6 +22,7 @@
 #include "arch.h" // why is this where funcall2 is declared???
 #include "genesis/symbol.h"
 #include "code.h"
+#include "fiber.h"
 
 lispobj* atomic_bump_static_space_free_ptr(int nbytes)
 {
@@ -811,6 +812,9 @@ alloc_thread_struct(void* spaces) {
 void free_thread_struct(struct thread *th)
 {
     struct extra_thread_data *extra_data = thread_extra_data(th);
+#ifdef LISP_FEATURE_SB_FIBER
+    sb_fiber_release_registered(th);
+#endif
     if (extra_data->arena_savearea) free(extra_data->arena_savearea);
     os_deallocate((os_vm_address_t) th->os_address, THREAD_STRUCT_SIZE);
 }

--- a/src/runtime/alloc.c
+++ b/src/runtime/alloc.c
@@ -701,6 +701,7 @@ alloc_thread_struct(void* spaces) {
         (lispobj*)((char*)th->binding_stack_start+BINDING_STACK_SIZE);
     set_binding_stack_pointer(th,th->binding_stack_start);
     th->this = th;
+    th->current_fiber = NIL;
     th->os_thread = 0;
     // Once allocated, the allocation profiling buffer sticks around.
     // If present and enabled, assign into the new thread.

--- a/src/runtime/arm64-fiber.c
+++ b/src/runtime/arm64-fiber.c
@@ -1,0 +1,161 @@
+#include "fiber.h"
+#include "align.h"
+#include "genesis/symbol.h"
+#include "genesis/static-symbols.h"
+#include "os.h"
+#include "thread.h"
+#include "validate.h"
+#include <stdint.h>
+#include <string.h>
+#include <sys/mman.h>
+
+#ifndef MAP_STACK
+#define MAP_STACK 0
+#endif
+
+void sb_fiber_prepare(struct sb_fiber_ctx *f,
+                      void (*fn)(void *), void *arg)
+{
+    f->entry_fn = fn;
+    f->entry_arg = arg;
+    /* AAPCS64 requires SP to be 16-byte aligned at public interfaces. */
+    f->regs.sp  = (void *)((uintptr_t)f->stack_end & ~(uintptr_t)0xF);
+    f->regs.fp  = 0;
+    f->regs.lr  = (void *)SYMBOL(FIBER_TRAMP)->value;
+    f->regs.x19 = (void *)f;
+    f->regs.x20 = 0;
+    f->regs.x21 = 0;
+    f->regs.x22 = 0;
+    f->regs.x23 = 0;
+    f->regs.x24 = 0;
+    f->regs.x25 = 0;
+    f->regs.x26 = 0;
+    f->regs.x27 = 0;
+    f->regs.x28 = 0;
+    f->regs.d8 = f->regs.d9 = f->regs.d10 = f->regs.d11 = 0.0;
+    f->regs.d12 = f->regs.d13 = f->regs.d14 = f->regs.d15 = 0.0;
+}
+
+void *sb_fiber_sp(const struct sb_fiber_ctx *f)
+{
+    return f->regs.sp;
+}
+
+int sb_fiber_gc_regs(const struct sb_fiber_ctx *f, lispobj *out, int max)
+{
+    static const int n = 11;
+    if (max < n) return 0;
+    int i = 0;
+    out[i++] = (lispobj)f->regs.fp;
+    out[i++] = (lispobj)f->regs.x19;
+    out[i++] = (lispobj)f->regs.x20;
+    out[i++] = (lispobj)f->regs.x21;
+    out[i++] = (lispobj)f->regs.x22;
+    out[i++] = (lispobj)f->regs.x23;
+    out[i++] = (lispobj)f->regs.x24;
+    out[i++] = (lispobj)f->regs.x25;
+    out[i++] = (lispobj)f->regs.x26;
+    out[i++] = (lispobj)f->regs.x27;
+    out[i++] = (lispobj)f->regs.x28;
+    return i;
+}
+
+void sb_fiber_rebind_thread(struct sb_fiber_ctx *f, struct thread *new_owner)
+{
+    f->regs.x21 = (void *)new_owner;
+}
+
+int sb_fiber_lisp_stack_alloc(struct sb_fiber_ctx *f, size_t size)
+{
+    size_t ps = os_reported_page_size;
+    size_t guard = STACK_GUARD_SIZE;
+    size = ALIGN_UP(size ? size : 65536, ps);
+    size_t total = size + 3*guard;
+    void *p = mmap(NULL, total, PROT_READ | PROT_WRITE,
+                   MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK, -1, 0);
+    if (p == MAP_FAILED) return -1;
+    mprotect((char *)p + size + guard,   guard, PROT_NONE);
+    mprotect((char *)p + size + 2*guard, guard, PROT_NONE);
+    f->control_stack_base       = (lispobj *)p;
+    f->control_stack_end        = (lispobj *)((char *)p + total);
+    f->control_stack_pointer    = (lispobj *)p;
+    f->control_frame_pointer    = NULL;
+    f->control_stack_alloc_size = total;
+    f->cs_guard_protected       = 1;
+    f->dirty_high               = (lispobj *)p;
+    return 0;
+}
+
+void sb_fiber_lisp_stack_free(struct sb_fiber_ctx *f)
+{
+    if (f->control_stack_alloc_size && f->control_stack_base)
+        munmap(f->control_stack_base, f->control_stack_alloc_size);
+    f->control_stack_base       = NULL;
+    f->control_stack_end        = NULL;
+    f->control_stack_pointer    = NULL;
+    f->control_frame_pointer    = NULL;
+    f->control_stack_alloc_size = 0;
+}
+
+void sb_fiber_lisp_stack_capture_main(struct sb_fiber_ctx *f, struct thread *th)
+{
+    f->control_stack_base       = th->control_stack_start;
+    f->control_stack_end        = th->control_stack_end;
+    f->control_stack_pointer    = th->control_stack_pointer;
+    f->control_frame_pointer    = th->control_frame_pointer;
+    f->control_stack_alloc_size = 0;   /* not owned */
+    f->cs_guard_protected =
+        th->state_word.control_stack_guard_page_protected;
+    f->dirty_high = th->control_stack_pointer;
+}
+
+void sb_fiber_lisp_stack_suspend(struct sb_fiber_ctx *f, struct thread *th)
+{
+    f->control_stack_base    = th->control_stack_start;
+    f->control_stack_end     = th->control_stack_end;
+    f->control_stack_pointer = th->control_stack_pointer;
+    f->control_frame_pointer = th->control_frame_pointer;
+    f->cs_guard_protected    =
+        th->state_word.control_stack_guard_page_protected;
+    if (f->control_stack_pointer && f->control_stack_end) {
+        char *csp = (char *)f->control_stack_pointer;
+        char *usable_end = (char *)f->control_stack_end
+                           - 3 * STACK_GUARD_SIZE;
+        char *dirty_high = (char *)f->dirty_high;
+        if (csp > dirty_high) {
+            if (csp < usable_end)
+                memset(csp, 0, usable_end - csp);
+            f->dirty_high = (lispobj *)csp;
+        } else if (csp < dirty_high) {
+            memset(csp, 0, dirty_high - csp);
+            f->dirty_high = (lispobj *)csp;
+        }
+    }
+}
+
+void sb_fiber_lisp_stack_resume(struct sb_fiber_ctx *f, struct thread *th)
+{
+    th->control_stack_start   = f->control_stack_base;
+    th->control_stack_end     = f->control_stack_end;
+    th->control_stack_pointer = f->control_stack_pointer;
+    th->control_frame_pointer = f->control_frame_pointer;
+    th->state_word.control_stack_guard_page_protected = f->cs_guard_protected;
+}
+
+size_t sb_fiber_control_stack_size_bytes(const struct sb_fiber_ctx *f)
+{
+    if (!f->control_stack_base || !f->control_stack_end) return 0;
+    size_t total = (char *)f->control_stack_end - (char *)f->control_stack_base;
+    if (f->control_stack_alloc_size > 0) {
+        size_t guards = 3 * STACK_GUARD_SIZE;
+        return total > guards ? total - guards : 0;
+    }
+    return total;
+}
+
+size_t sb_fiber_control_stack_used_bytes(const struct sb_fiber_ctx *f)
+{
+    if (f->control_stack_pointer && f->control_stack_base)
+        return (char *)f->control_stack_pointer - (char *)f->control_stack_base;
+    return 0;
+}

--- a/src/runtime/arm64-fiber.h
+++ b/src/runtime/arm64-fiber.h
@@ -1,0 +1,28 @@
+#ifndef SBCL_FIBER_ARM64_H
+#define SBCL_FIBER_ARM64_H
+
+struct sb_fiber_regs {
+    void   *sp;     /* 0x00 */
+    void   *fp;     /* 0x08 x29 */
+    void   *lr;     /* 0x10 x30 */
+    void   *x19;    /* 0x18 */
+    void   *x20;    /* 0x20 */
+    void   *x21;    /* 0x28 */
+    void   *x22;    /* 0x30 */
+    void   *x23;    /* 0x38 */
+    void   *x24;    /* 0x40 */
+    void   *x25;    /* 0x48 */
+    void   *x26;    /* 0x50 */
+    void   *x27;    /* 0x58 */
+    void   *x28;    /* 0x60 */
+    double  d8;     /* 0x68 */
+    double  d9;     /* 0x70 */
+    double  d10;    /* 0x78 */
+    double  d11;    /* 0x80 */
+    double  d12;    /* 0x88 */
+    double  d13;    /* 0x90 */
+    double  d14;    /* 0x98 */
+    double  d15;    /* 0xa0 */
+};
+
+#endif

--- a/src/runtime/fiber.c
+++ b/src/runtime/fiber.c
@@ -1,0 +1,462 @@
+#include "fiber.h"
+#include "os.h"
+#include "globals.h"
+#include "thread.h"
+#include "validate.h"
+#include "interr.h"
+#include "interrupt.h"
+#include "align.h"
+#include "genesis/symbol.h"
+#include "genesis/static-symbols.h"
+#include "lispobj.h"
+#include <sys/mman.h>
+#include <string.h>
+#include <assert.h>
+#include <stdint.h>
+
+#ifndef MAP_STACK
+#define MAP_STACK 0
+#endif
+
+extern void gc_preserve_fiber_word(lispobj word);
+extern void gc_scav_fiber_binding_stack(lispobj *base, lispobj *end);
+
+void gc_scan_fiber_stacks(struct thread *th)
+{
+    for (struct sb_fiber_ctx *f = thread_extra_data(th)->fiber_list;
+         f; f = f->next) {
+        if (f->state != FIBER_RUNNABLE && f->state != FIBER_NEW) continue;
+
+        lispobj *hi = (lispobj *)f->stack_end;
+#ifdef LISP_FEATURE_X86_64
+        /* Main fiber: stack_end==NULL but Lisp frames live on the
+         * thread's C stack captured at make-main-fiber time. */
+        if (!hi) hi = f->control_stack_end;
+#endif
+        if (hi)
+            for (lispobj *p = (lispobj *)sb_fiber_sp(f); p < hi; p++)
+                gc_preserve_fiber_word(*p);
+
+        lispobj regs[16];
+        int n = sb_fiber_gc_regs(f, regs, 16);
+        for (int i = 0; i < n; i++)
+            gc_preserve_fiber_word(regs[i]);
+
+#ifdef LISP_FEATURE_ARM64
+        if (f->control_stack_base && f->control_stack_pointer
+            && f->control_stack_pointer > f->control_stack_base)
+            for (lispobj *p = f->control_stack_base;
+                 p < f->control_stack_pointer; p++)
+                gc_preserve_fiber_word(*p);
+#endif
+    }
+}
+
+void gc_scav_fiber_binding_stacks(struct thread *th)
+{
+    for (struct sb_fiber_ctx *f = thread_extra_data(th)->fiber_list;
+         f; f = f->next) {
+        if ((f->state == FIBER_RUNNABLE || f->state == FIBER_NEW)
+            && f->binding_stack_base)
+            gc_scav_fiber_binding_stack(f->binding_stack_base,
+                                        f->binding_stack_pointer);
+    }
+}
+
+static void fiber_free(struct sb_fiber_ctx *f)
+{
+    if (f->stack_base && f->stack_base != MAP_FAILED)
+        munmap(f->stack_base, f->stack_alloc_size);
+    if (f->binding_stack_base)
+        munmap(f->binding_stack_base, f->binding_stack_alloc_size);
+    sb_fiber_lisp_stack_free(f);
+    free(f);
+}
+
+void sb_fiber_release_registered(struct thread *th)
+{
+    struct extra_thread_data *ed = thread_extra_data(th);
+    struct sb_fiber_ctx *f = ed->fiber_list;
+    ed->fiber_list = NULL;
+    while (f) {
+        struct sb_fiber_ctx *next = f->next;
+        f->owner = NULL;
+        f->next = NULL;
+        fiber_free(f);
+        f = next;
+    }
+}
+
+struct sb_fiber_ctx *sb_fiber_create(size_t stack_size,
+                                 size_t binding_stack_size)
+{
+    size_t ps = os_reported_page_size;
+    struct sb_fiber_ctx *f = calloc(1, sizeof(struct sb_fiber_ctx));
+    if (!f) return NULL;
+
+    size_t guard = STACK_GUARD_SIZE;
+    stack_size = ALIGN_UP(stack_size ? stack_size : 65536, ps);
+    f->stack_alloc_size = 3*guard + stack_size;
+    f->stack_base = mmap(NULL, f->stack_alloc_size,
+                         PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS | MAP_STACK,
+                         -1, 0);
+    if (f->stack_base == MAP_FAILED) { free(f); return NULL; }
+
+    mprotect(f->stack_base,                    guard, PROT_NONE);
+    mprotect((char *)f->stack_base + guard,    guard, PROT_NONE);
+    f->stack_start = (char *)f->stack_base + 3*guard;
+    f->stack_end   = (char *)f->stack_base + f->stack_alloc_size;
+    f->cs_guard_protected = 1;
+
+    binding_stack_size = ALIGN_UP(
+        binding_stack_size ? binding_stack_size : 8192, ps);
+    f->binding_stack_alloc_size = binding_stack_size + 3 * ps;
+    f->binding_stack_base = mmap(NULL, f->binding_stack_alloc_size,
+                                 PROT_READ | PROT_WRITE,
+                                 MAP_PRIVATE | MAP_ANONYMOUS,
+                                 -1, 0);
+    if (f->binding_stack_base == MAP_FAILED) {
+        munmap(f->stack_base, f->stack_alloc_size);
+        free(f);
+        return NULL;
+    }
+    mprotect((char *)f->binding_stack_base + binding_stack_size + ps,
+             2 * ps, PROT_NONE);
+    f->binding_stack_end = (lispobj *)((char *)f->binding_stack_base
+                                       + binding_stack_size);
+    f->binding_stack_pointer = f->binding_stack_base;
+    f->binding_stack_start_for_thread = f->binding_stack_base;
+    f->bs_guard_protected = 1;
+
+    if (sb_fiber_lisp_stack_alloc(f, stack_size) != 0) {
+        munmap(f->stack_base, f->stack_alloc_size);
+        munmap(f->binding_stack_base, f->binding_stack_alloc_size);
+        free(f);
+        return NULL;
+    }
+    return f;
+}
+
+/* main fiber wraps the thread's own stack. */
+struct sb_fiber_ctx *sb_fiber_create_main(struct thread *th)
+{
+    struct sb_fiber_ctx *f = calloc(1, sizeof(struct sb_fiber_ctx));
+    if (!f) return NULL;
+    f->state = FIBER_RUNNING;
+    f->binding_stack_pointer          = get_binding_stack_pointer(th);
+    f->binding_stack_start_for_thread = th->binding_stack_start;
+    f->current_catch_block            = th->current_catch_block;
+    f->current_unwind_protect_block   = th->current_unwind_protect_block;
+    f->cs_guard_protected = th->state_word.control_stack_guard_page_protected;
+    sb_fiber_lisp_stack_capture_main(f, th);
+    return f;
+}
+
+void sb_fiber_release(struct sb_fiber_ctx *f)
+{
+    if (!f) return;
+    if (f->owner) sb_fiber_unregister(f->owner, f);
+    fiber_free(f);
+}
+
+void sb_fiber_register(struct thread *th, struct sb_fiber_ctx *fiber)
+{
+    assert(fiber->owner == NULL);
+    fiber->owner = th;
+    fiber->next = thread_extra_data(th)->fiber_list;
+    __atomic_store_n(&thread_extra_data(th)->fiber_list,
+                     fiber, __ATOMIC_RELEASE);
+}
+
+void sb_fiber_unregister(struct thread *th, struct sb_fiber_ctx *fiber)
+{
+    struct sb_fiber_ctx **pp = &thread_extra_data(th)->fiber_list;
+    while (*pp) {
+        if (*pp == fiber) {
+            *pp = fiber->next;
+            fiber->next = NULL;
+            fiber->owner = NULL;
+            return;
+        }
+        pp = &(*pp)->next;
+    }
+}
+
+static int fiber_list_remove(struct thread *src, struct sb_fiber_ctx *fiber)
+{
+    struct extra_thread_data *ed = thread_extra_data(src);
+    for (;;) {
+        struct sb_fiber_ctx **pp = &ed->fiber_list;
+        struct sb_fiber_ctx *cur =
+            __atomic_load_n(&ed->fiber_list, __ATOMIC_ACQUIRE);
+        while (cur && cur != fiber) {
+            pp  = &cur->next;
+            cur = cur->next;
+        }
+        if (!cur) return -1;           /* fiber not on this list */
+        struct sb_fiber_ctx *next = cur->next;
+        if (pp == &ed->fiber_list) {
+            struct sb_fiber_ctx *expected = fiber;
+            if (__atomic_compare_exchange_n(&ed->fiber_list, &expected,
+                                            next, 0,
+                                            __ATOMIC_ACQ_REL,
+                                            __ATOMIC_ACQUIRE))
+                return 0;
+            continue;                   /* head changed; restart walk */
+        }
+        *pp = next;
+        return 0;
+    }
+}
+
+static void fiber_list_insert(struct thread *dest, struct sb_fiber_ctx *fiber)
+{
+    struct extra_thread_data *ed = thread_extra_data(dest);
+    struct sb_fiber_ctx *head;
+    do {
+        head = __atomic_load_n(&ed->fiber_list, __ATOMIC_ACQUIRE);
+        fiber->next = head;
+    } while (!__atomic_compare_exchange_n(&ed->fiber_list, &head, fiber, 0,
+                                          __ATOMIC_ACQ_REL,
+                                          __ATOMIC_ACQUIRE));
+}
+
+static inline void sb_fiber_enter_pa(struct thread *th);
+
+int sb_fiber_migrate(struct sb_fiber_ctx *fiber, struct thread *dest)
+{
+    if (fiber->state != FIBER_RUNNABLE) return -1;
+    struct thread *src = fiber->owner;
+    if (!src) return -2;
+    if (src == dest) return 0;
+
+    struct thread *self = get_sb_vm_thread();
+    sb_fiber_enter_pa(self);
+    int rc = fiber_list_remove(src, fiber);
+    if (rc == 0) {
+        fiber->owner = dest;
+        sb_fiber_rebind_thread(fiber, dest);
+        fiber_list_insert(dest, fiber);
+    }
+    sb_fiber_exit_pa(self);
+    return rc;
+}
+
+static inline void swap_bindings_forward (struct thread *th,
+                                          lispobj *base, lispobj *limit);
+static inline void swap_bindings_backward(struct thread *th,
+                                          lispobj *base, lispobj *limit);
+
+void sb_fiber_lower_bs_guard(struct sb_fiber_ctx *f)
+{
+    size_t ps = os_reported_page_size;
+    char *base = (char *)f->binding_stack_base;
+    size_t usable = f->binding_stack_alloc_size - 3 * ps;
+    mprotect(base + usable + ps, ps, PROT_READ | PROT_WRITE);
+    mprotect(base + usable,      ps, PROT_NONE);
+    f->bs_guard_protected = 0;
+}
+
+void sb_fiber_reset_bs_guard(struct sb_fiber_ctx *f)
+{
+    size_t ps = os_reported_page_size;
+    char *base = (char *)f->binding_stack_base;
+    size_t usable = f->binding_stack_alloc_size - 3 * ps;
+    mprotect(base + usable + ps, ps, PROT_NONE);
+    mprotect(base + usable,      ps, PROT_READ | PROT_WRITE);
+    f->bs_guard_protected = 1;
+}
+
+static int sb_fiber_classify_bs_fault(struct thread *th, void *addr,
+                                      struct sb_fiber_ctx **out_fiber)
+{
+    size_t ps = os_reported_page_size;
+    char *a = (char *)addr;
+    for (struct sb_fiber_ctx *f = thread_extra_data(th)->fiber_list;
+         f; f = f->next) {
+        if (!f->binding_stack_base) continue;
+        char *base = (char *)f->binding_stack_base;
+        size_t usable = f->binding_stack_alloc_size - 3 * ps;
+        char *r = base + usable, *s = r + ps, *h = s + ps;
+        if (a >= h && a < h + ps) { if (out_fiber) *out_fiber = f; return 1; }
+        if (a >= s && a < s + ps) { if (out_fiber) *out_fiber = f; return 2; }
+        if (a >= r && a < r + ps) { if (out_fiber) *out_fiber = f; return 3; }
+    }
+    return 0;
+}
+
+int sb_fiber_handle_bs_fault(void *context_, void *addr, struct thread *th)
+{
+    os_context_t *context = (os_context_t *)context_;
+    struct sb_fiber_ctx *f = NULL;
+    int kind = sb_fiber_classify_bs_fault(th, addr, &f);
+    if (kind == 1) {                    /* HARD guard hit */
+        fake_foreign_function_call(context);
+        lose("Fiber binding stack exhausted, fault: %p, PC: %p",
+             addr, (void*)os_context_pc(context));
+    } else if (kind == 2) {             /* SOFT guard hit */
+        sb_fiber_lower_bs_guard(f);
+        if (lose_on_corruption_p) {
+            fake_foreign_function_call(context);
+            lose("Fiber binding stack exhausted (lose-on-corruption)");
+        }
+        unblock_signals_in_context_and_maybe_warn(context);
+        arrange_return_to_lisp_function
+            (context, StaticSymbolFunction(BINDING_STACK_EXHAUSTED_ERROR));
+        return 1;
+    } else if (kind == 3) {             /* RETURN guard -- re-arm */
+        sb_fiber_reset_bs_guard(f);
+        return 1;
+    }
+    return 0;
+}
+
+typedef void (*fiber_swap_regs_fn)(void *save, void *restore);
+
+/* A fiber can migrate to a different OS thread inside entry_fn.  The
+ * compiler may cache the TLS-slot address of `current_thread', making
+ * causing post-yield `get_sb_vm_thread()' to read the old thread's
+ * slot.  Hide the read behind a noinline to defeat the cache. */
+static __attribute__((noinline)) struct thread *fresh_sb_vm_thread(void)
+{
+    return get_sb_vm_thread();
+}
+
+void fiber_tramp_c(struct sb_fiber_ctx *self)
+{
+    struct thread *th = get_sb_vm_thread();
+#ifdef LISP_FEATURE_ARM64
+    th->control_stack_pointer = self->control_stack_pointer;
+    th->control_frame_pointer = self->control_frame_pointer;
+#endif
+    sb_fiber_exit_pa(th);
+    self->entry_fn(self->entry_arg);
+    self->state = FIBER_DEAD;
+
+    if (self->return_fiber) {
+        struct sb_fiber_ctx *ret = self->return_fiber;
+        struct thread *th = fresh_sb_vm_thread();
+        sb_fiber_switch_prep(self, ret);
+        th->current_catch_block          = ret->current_catch_block;
+        th->current_unwind_protect_block = ret->current_unwind_protect_block;
+        set_binding_stack_pointer(th, ret->binding_stack_pointer);
+        th->binding_stack_start          = ret->binding_stack_start_for_thread;
+        ret->state = FIBER_RUNNING;
+        ((fiber_swap_regs_fn)SYMBOL(FIBER_SWAP_REGS)->value)
+            (&self->regs, &ret->regs);
+    }
+    lose("fiber_tramp_c reached past auto-return");
+}
+
+/* --- Binding-stack swap --- */
+
+#ifdef LISP_FEATURE_TLS_LOAD_INDIRECT
+extern lispobj *tlsindex_to_symbol_map;
+extern int tls_map_starting_offset;
+#  ifndef NO_TLS_VALUE_MARKER
+#    define NO_TLS_VALUE_MARKER (~(uword_t)0)
+#  endif
+#endif
+
+static inline void exchange_binding_with_tls(struct thread *th, struct binding *b)
+{
+    if (b->symbol && b->symbol != UNBOUND_MARKER_WIDETAG) {
+#ifdef LISP_FEATURE_SB_THREAD
+        lispobj *tls_slot = (lispobj *)(b->symbol + (char *)th);
+#else
+        lispobj *tls_slot = &SYMBOL(b->symbol)->value;
+#endif
+        lispobj tmp = *tls_slot;
+        *tls_slot = b->value;
+        b->value = tmp;
+
+#ifdef LISP_FEATURE_TLS_LOAD_INDIRECT
+        /* Maintain the indirect cell for symbols at or above the
+         * map-starting offset (others are :always-thread-local; see
+         * README.md "Binding-stack swap"). */
+        if (b->symbol >= (lispobj)tls_map_starting_offset) {
+            lispobj *indirect_cell =
+                (lispobj *)((char *)th + b->symbol - N_WORD_BYTES);
+            if (*tls_slot == (lispobj)NO_TLS_VALUE_MARKER) {
+                lispobj symbol =
+                    tlsindex_to_symbol_map[b->symbol >> (1 + WORD_SHIFT)];
+                *indirect_cell =
+                    (symbol == (lispobj)NO_TLS_VALUE_MARKER)
+                    ? (lispobj)((char *)th + b->symbol - 1)
+                    : symbol;
+            } else {
+                *indirect_cell = (lispobj)((char *)th + b->symbol - 1);
+            }
+        }
+#endif
+    }
+}
+
+/* Swap-in: oldest -> newest. */
+static inline void swap_bindings_forward(struct thread *th,
+                                         lispobj *base, lispobj *limit)
+{
+    for (struct binding *b = (struct binding *)base,
+           *end = (struct binding *)limit;
+         b < end; b++)
+        exchange_binding_with_tls(th, b);
+}
+
+/* Swap-out: newest -> oldest. */
+static inline void swap_bindings_backward(struct thread *th,
+                                          lispobj *base, lispobj *limit)
+{
+    struct binding *start = (struct binding *)base;
+    struct binding *b     = (struct binding *)limit;
+    while (b > start) { b--; exchange_binding_with_tls(th, b); }
+}
+
+__attribute__((noinline))
+void sb_fiber_switch_prep(struct sb_fiber_ctx *from, struct sb_fiber_ctx *to)
+{
+    struct thread *th = get_sb_vm_thread();
+    sb_fiber_enter_pa(th);
+
+    from->binding_stack_pointer = get_binding_stack_pointer(th);
+
+    sb_fiber_lisp_stack_suspend(from, th);
+    sb_fiber_lisp_stack_resume(to, th);
+
+    if (from->binding_stack_base)
+        swap_bindings_backward(th, from->binding_stack_base,
+                               from->binding_stack_pointer);
+    if (to->binding_stack_base)
+        swap_bindings_forward(th, to->binding_stack_base,
+                              to->binding_stack_pointer);
+}
+
+static inline void sb_fiber_enter_pa(struct thread *th)
+{
+#if defined LISP_FEATURE_ARM64
+    ((volatile uint32_t *)&th->pseudo_atomic_bits)[0] = flag_PseudoAtomic;
+#else
+    th->pseudo_atomic_bits = (uword_t)th;
+#endif
+}
+
+void sb_fiber_exit_pa(struct thread *th)
+{
+#if defined LISP_FEATURE_ARM64
+    volatile uint32_t *halves = (volatile uint32_t *)&th->pseudo_atomic_bits;
+    halves[0] = 0;
+    if (halves[1]) {
+        halves[1] = 0;
+        asm volatile("brk %0" : : "i"(trap_PendingInterrupt));
+    }
+#else
+    uword_t pa = __sync_xor_and_fetch(&th->pseudo_atomic_bits, (uword_t)th);
+    if (pa) {
+#if defined LISP_FEATURE_UD2_BREAKPOINTS
+        asm volatile("ud2\n\t.byte %c0" : : "i"(trap_PendingInterrupt));
+#else
+        asm volatile("ud2");
+#endif
+    }
+#endif
+}

--- a/src/runtime/fiber.h
+++ b/src/runtime/fiber.h
@@ -1,0 +1,124 @@
+#ifndef SBCL_FIBER_H
+#define SBCL_FIBER_H
+
+#include "lispobj.h"
+
+#ifdef LISP_FEATURE_SB_FIBER
+
+#include "genesis/thread.h"
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(LISP_FEATURE_X86_64)
+#  include "x86-64-fiber.h"
+#elif defined(LISP_FEATURE_ARM64)
+#  include "arm64-fiber.h"
+#else
+#  error "fiber support not implemented on this architecture"
+#endif
+
+/* Mirrored by the fiber-state constants on the Lisp side. */
+enum fiber_state {
+    FIBER_NEW      = 0,
+    FIBER_RUNNABLE = 1,
+    FIBER_RUNNING  = 2,
+    FIBER_DEAD     = 3
+};
+
+#define FIBER_DEFAULT_STACK_SIZE         65536
+#define FIBER_DEFAULT_BINDING_STACK_SIZE 8192
+
+struct sb_fiber_ctx {
+    struct sb_fiber_regs regs;
+    enum fiber_state     state;
+
+    /* Control stack */
+    void    *stack_base;
+    void    *stack_start;
+    void    *stack_end;
+    size_t   stack_alloc_size;
+
+    /* Binding stack */
+    lispobj *binding_stack_base;
+    lispobj *binding_stack_end;
+    lispobj *binding_stack_pointer;
+    size_t   binding_stack_alloc_size;
+    /* What to install into thread->binding_stack_start while we run. */
+    lispobj *binding_stack_start_for_thread;
+    /* Per-fiber Lisp-stack bounds installed in thread->control_stack_* */
+    lispobj *control_stack_base;
+    lispobj *control_stack_end;
+#ifdef LISP_FEATURE_ARM64
+    lispobj *control_stack_pointer;
+    lispobj *control_frame_pointer;
+    size_t   control_stack_alloc_size;
+    lispobj *dirty_high;
+#endif
+
+    /* Saved thread-struct fields. */
+    lispobj  current_catch_block;
+    lispobj  current_unwind_protect_block;
+
+    struct sb_fiber_ctx *next;
+    struct thread       *owner;
+
+    void (*entry_fn)(void *arg);
+    void  *entry_arg;
+
+    struct sb_fiber_ctx *return_fiber;  /* auto-return target */
+
+    unsigned char cs_guard_protected;
+    unsigned char bs_guard_protected;
+};
+
+/* Lifecycle */
+struct sb_fiber_ctx *sb_fiber_create(size_t stack_size, size_t binding_stack_size);
+struct sb_fiber_ctx *sb_fiber_create_main(struct thread *th);
+void                 sb_fiber_release(struct sb_fiber_ctx *fiber);
+
+/* GC registration */
+void sb_fiber_register  (struct thread *th, struct sb_fiber_ctx *fiber);
+void sb_fiber_unregister(struct thread *th, struct sb_fiber_ctx *fiber);
+
+/* Cross-thread migration */
+int  sb_fiber_migrate(struct sb_fiber_ctx *fiber, struct thread *dest);
+
+/* Thread-exit cleanup.  Called from free_thread_struct. */
+void sb_fiber_release_registered(struct thread *th);
+
+/* Binding-stack guard manipulation. */
+void sb_fiber_lower_bs_guard(struct sb_fiber_ctx *f);
+void sb_fiber_reset_bs_guard(struct sb_fiber_ctx *f);
+
+/* Handle a SIGSEGV / SIGBUS address that may have landed on a
+ * fiber's binding-stack guard. */
+int sb_fiber_handle_bs_fault(void *context, void *addr, struct thread *th);
+
+void sb_fiber_switch_prep(struct sb_fiber_ctx *from, struct sb_fiber_ctx *to);
+void sb_fiber_exit_pa    (struct thread *th);
+
+/* Arch-specific helpers */
+void  sb_fiber_prepare(struct sb_fiber_ctx *f, void (*fn)(void *), void *arg);
+void *sb_fiber_sp (const struct sb_fiber_ctx *f);
+void  sb_fiber_rebind_thread(struct sb_fiber_ctx *f, struct thread *new_owner);
+/* Write the fiber's callee-saved GC-relevant register words into OUT
+ * (up to MAX). Return the count actually written. */
+int   sb_fiber_gc_regs(const struct sb_fiber_ctx *f, lispobj *out, int max);
+
+/* GC-side entry points (shared body in fiber.c).  Each GC TU provides
+ * gc_preserve_fiber_word and gc_scav_fiber_binding_stack as leaf
+ * functions; the shared scanners call them by name. */
+void gc_scan_fiber_stacks         (struct thread *th);
+void gc_scav_fiber_binding_stacks (struct thread *th);
+
+/* Per-fiber Lisp control stack hooks */
+int  sb_fiber_lisp_stack_alloc       (struct sb_fiber_ctx *f, size_t size);
+void sb_fiber_lisp_stack_free        (struct sb_fiber_ctx *f);
+void sb_fiber_lisp_stack_capture_main(struct sb_fiber_ctx *f, struct thread *th);
+void sb_fiber_lisp_stack_suspend     (struct sb_fiber_ctx *f, struct thread *th);
+void sb_fiber_lisp_stack_resume      (struct sb_fiber_ctx *f, struct thread *th);
+
+void fiber_tramp_c(struct sb_fiber_ctx *self);
+
+#endif /* LISP_FEATURE_SB_FIBER */
+#endif /* SBCL_FIBER_H */

--- a/src/runtime/gencgc.c
+++ b/src/runtime/gencgc.c
@@ -51,6 +51,7 @@
 #include "genesis/brothertree.h"
 #include "genesis/split-ordered-list.h"
 #include "var-io.h"
+#include "fiber.h"
 
 /* forward declarations */
 extern FILE *gc_activitylog();
@@ -1451,14 +1452,17 @@ static lispobj conservative_root_p(lispobj addr, page_index_t addr_page_index)
         && plausible_tag_p(addr)) return AMBIGUOUS_POINTER;
     return 0;
 }
-#elif defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC
+#elif defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC \
+   || (defined LISP_FEATURE_ARM64 && defined LISP_FEATURE_SB_FIBER)
 /* Consider interior pointers to code as roots.
  * But most other pointers are *unambiguous* conservative roots.
  * This is not "less conservative" per se, than the non-precise code,
  * because it's actually up to the user of this predicate to decide whehther
  * the control stack as a whole is scanned for objects to pin.
  * The so-called "precise" code should generally NOT scan the stack,
- * and not call this on stack words.
+ * and not call this on stack words.  ARM64 uses this only for fiber
+ * stack scanning, where the C control stack of suspended fibers has
+ * no precise root information.
  * Anyway, this code isn't as performance-critical as the x86 variant,
  * so it's not worth trying to optimize out the search for the object */
 static lispobj conservative_root_p(lispobj addr, page_index_t addr_page_index)
@@ -2007,7 +2011,8 @@ static void impart_mark_stickiness(lispobj word)
 }
 #endif
 
-#if !GENCGC_IS_PRECISE || defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC
+#if !GENCGC_IS_PRECISE || defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC \
+    || (defined LISP_FEATURE_ARM64 && defined LISP_FEATURE_SB_FIBER)
 /* Take a possible pointer to a Lisp object and mark its page in the
  * page_table so that it will not be relocated during a GC.
  *
@@ -2063,7 +2068,9 @@ static void NO_SANITIZE_MEMORY preserve_pointer(os_context_register_t word, void
     lispobj* found = search_dynamic_space((void*)word);
     if (found) gc_mark_obj(compute_lispobj(found));
 }
+#endif
 
+#if !GENCGC_IS_PRECISE || defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC
 static void sticky_preserve_pointer(os_context_register_t register_word, void* arg)
 {
     // registers can be wider than words. This could accept uword_t as the arg type
@@ -3145,6 +3152,21 @@ static void pin_call_chain_and_boxed_registers(struct thread* th) {
 }
 #endif
 
+#ifdef LISP_FEATURE_SB_FIBER
+/* Leaf hooks supplied to the shared scanners in fiber.c. */
+void gc_preserve_fiber_word(lispobj word)
+{
+    /* Skip words below the null-trap region (small fixnums, scalars). */
+    if (word >= BACKEND_PAGE_BYTES)
+        preserve_pointer(word, 0);
+}
+
+void gc_scav_fiber_binding_stack(lispobj *base, lispobj *end)
+{
+    scav_binding_stack(base, end, compacting_p() ? 0 : gc_mark_obj);
+}
+#endif /* LISP_FEATURE_SB_FIBER */
+
 #if !GENCGC_IS_PRECISE
 extern void visit_context_registers(void (*proc)(os_context_register_t, void*),
                                     os_context_t *context, void*);
@@ -3428,6 +3450,9 @@ garbage_collect_generation(generation_index_t generation, int raise,
 #elif defined reg_LINK_RETURN
             pin_call_chain_and_boxed_registers(th);
 #endif
+#ifdef LISP_FEATURE_SB_FIBER
+            gc_scan_fiber_stacks(th);
+#endif
         }
     }
 
@@ -3524,6 +3549,9 @@ garbage_collect_generation(generation_index_t generation, int raise,
             scav_binding_stack((lispobj*)th->binding_stack_start,
                                (lispobj*)get_binding_stack_pointer(th),
                                compacting_p() ? 0 : gc_mark_obj);
+#ifdef LISP_FEATURE_SB_FIBER
+            gc_scav_fiber_binding_stacks(th);
+#endif
             /* do the tls as well */
             lispobj* from = &th->lisp_thread;
             lispobj* to = (lispobj*)(SymbolValue(FREE_TLS_INDEX,0) + (char*)th);

--- a/src/runtime/gencgc.c
+++ b/src/runtime/gencgc.c
@@ -51,6 +51,7 @@
 #include "genesis/brothertree.h"
 #include "genesis/split-ordered-list.h"
 #include "var-io.h"
+#include "fiber.h"
 
 /* forward declarations */
 extern FILE *gc_activitylog();
@@ -1451,14 +1452,17 @@ static lispobj conservative_root_p(lispobj addr, page_index_t addr_page_index)
         && plausible_tag_p(addr)) return AMBIGUOUS_POINTER;
     return 0;
 }
-#elif defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC
+#elif defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC \
+   || (defined LISP_FEATURE_ARM64 && defined LISP_FEATURE_SB_FIBER)
 /* Consider interior pointers to code as roots.
  * But most other pointers are *unambiguous* conservative roots.
  * This is not "less conservative" per se, than the non-precise code,
  * because it's actually up to the user of this predicate to decide whehther
  * the control stack as a whole is scanned for objects to pin.
  * The so-called "precise" code should generally NOT scan the stack,
- * and not call this on stack words.
+ * and not call this on stack words.  ARM64 uses this only for fiber
+ * stack scanning, where the C control stack of suspended fibers has
+ * no precise root information.
  * Anyway, this code isn't as performance-critical as the x86 variant,
  * so it's not worth trying to optimize out the search for the object */
 static lispobj conservative_root_p(lispobj addr, page_index_t addr_page_index)
@@ -2007,7 +2011,8 @@ static void impart_mark_stickiness(lispobj word)
 }
 #endif
 
-#if !GENCGC_IS_PRECISE || defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC
+#if !GENCGC_IS_PRECISE || defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC \
+    || (defined LISP_FEATURE_ARM64 && defined LISP_FEATURE_SB_FIBER)
 /* Take a possible pointer to a Lisp object and mark its page in the
  * page_table so that it will not be relocated during a GC.
  *
@@ -2063,7 +2068,9 @@ static void NO_SANITIZE_MEMORY preserve_pointer(os_context_register_t word, void
     lispobj* found = search_dynamic_space((void*)word);
     if (found) gc_mark_obj(compute_lispobj(found));
 }
+#endif
 
+#if !GENCGC_IS_PRECISE || defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC
 static void sticky_preserve_pointer(os_context_register_t register_word, void* arg)
 {
     // registers can be wider than words. This could accept uword_t as the arg type
@@ -3145,6 +3152,21 @@ static void pin_call_chain_and_boxed_registers(struct thread* th) {
 }
 #endif
 
+#ifdef LISP_FEATURE_SB_FIBER
+/* Leaf hooks supplied to the shared scanners in fiber.c. */
+void gc_preserve_fiber_word(lispobj word)
+{
+    /* Skip words below the null-trap region (small fixnums, scalars). */
+    if (word >= BACKEND_PAGE_BYTES)
+        preserve_pointer(word, 0);
+}
+
+void gc_scav_fiber_binding_stack(lispobj *base, lispobj *end)
+{
+    scav_binding_stack(base, end, compacting_p() ? 0 : gc_mark_obj);
+}
+#endif /* LISP_FEATURE_SB_FIBER */
+
 #if !GENCGC_IS_PRECISE
 extern void visit_context_registers(void (*proc)(os_context_register_t, void*),
                                     os_context_t *context, void*);
@@ -3430,6 +3452,9 @@ garbage_collect_generation(generation_index_t generation, int raise,
 #elif defined reg_LINK_RETURN
             pin_call_chain_and_boxed_registers(th);
 #endif
+#ifdef LISP_FEATURE_SB_FIBER
+            gc_scan_fiber_stacks(th);
+#endif
         }
     }
 
@@ -3526,6 +3551,9 @@ garbage_collect_generation(generation_index_t generation, int raise,
             scav_binding_stack((lispobj*)th->binding_stack_start,
                                (lispobj*)get_binding_stack_pointer(th),
                                compacting_p() ? 0 : gc_mark_obj);
+#ifdef LISP_FEATURE_SB_FIBER
+            gc_scav_fiber_binding_stacks(th);
+#endif
             /* do the tls as well */
             lispobj* from = &th->lisp_thread;
             lispobj* to = (lispobj*)(SymbolValue(FREE_TLS_INDEX,0) + (char*)th);

--- a/src/runtime/interrupt.c
+++ b/src/runtime/interrupt.c
@@ -42,6 +42,8 @@
 
 #include "genesis/sbcl.h"
 
+#include "fiber.h"
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1719,7 +1721,10 @@ bool handle_guard_page_triggered(os_context_t *context,os_vm_address_t addr)
             (context, StaticSymbolFunction(UNDEFINED_ALIEN_VARIABLE_ERROR));
         return 1;
     }
-    else return 0;
+#ifdef LISP_FEATURE_SB_FIBER
+    if (sb_fiber_handle_bs_fault(context, addr, th)) return 1;
+#endif
+    return 0;
 }
 
 #ifndef LISP_FEATURE_WIN32

--- a/src/runtime/interrupt.h
+++ b/src/runtime/interrupt.h
@@ -39,6 +39,7 @@ extern void block_deferrable_signals(sigset_t *old);
 extern void block_blockable_signals(sigset_t *old);
 
 extern void unblock_deferrable_signals(sigset_t *where);
+extern void unblock_signals_in_context_and_maybe_warn(os_context_t *context);
 extern void unblock_gc_stop_signal(void);
 
 extern void maybe_save_gc_mask_and_block_deferrables(os_context_t *context);

--- a/src/runtime/pmrgc.c
+++ b/src/runtime/pmrgc.c
@@ -27,6 +27,7 @@
 #include "genesis/gc-tables.h"
 #include "genesis/split-ordered-list.h"
 #include "thread.h"
+#include "fiber.h"
 #include "sys_mmap.inc"
 
 /* forward declarations */
@@ -421,7 +422,8 @@ static void impart_mark_stickiness(lispobj word)
     }
 }
 
-#if !GENCGC_IS_PRECISE || defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC
+#if !GENCGC_IS_PRECISE || defined LISP_FEATURE_MIPS || defined LISP_FEATURE_PPC64 || defined LISP_FEATURE_PPC \
+    || (defined LISP_FEATURE_ARM64 && defined LISP_FEATURE_SB_FIBER)
 static void preserve_pointer(os_context_register_t object,
                              __attribute__((unused)) void* arg) {
     /* The mark-region GC never filters based on type tags,
@@ -616,6 +618,19 @@ static void pin_call_chain_and_boxed_registers(struct thread* th) {
     }
 }
 #endif
+
+#ifdef LISP_FEATURE_SB_FIBER
+void gc_preserve_fiber_word(lispobj word)
+{
+    /* mr_preserve_object self-filters; no pre-cull needed. */
+    preserve_pointer(word, 0);
+}
+
+void gc_scav_fiber_binding_stack(lispobj *base, lispobj *end)
+{
+    scav_binding_stack(base, end, mr_preserve_object);
+}
+#endif /* LISP_FEATURE_SB_FIBER */
 
 #if !GENCGC_IS_PRECISE
 extern void visit_context_registers(void (*proc)(os_context_register_t, void*),
@@ -883,6 +898,9 @@ garbage_collect_generation(generation_index_t generation, int raise,
 #elif defined reg_LINK_RETURN
             pin_call_chain_and_boxed_registers(th);
 #endif
+#ifdef LISP_FEATURE_SB_FIBER
+            gc_scan_fiber_stacks(th);
+#endif
         }
     }
 
@@ -978,6 +996,9 @@ garbage_collect_generation(generation_index_t generation, int raise,
             scav_binding_stack((lispobj*)th->binding_stack_start,
                                (lispobj*)get_binding_stack_pointer(th),
                                mr_preserve_object);
+#ifdef LISP_FEATURE_SB_FIBER
+            gc_scav_fiber_binding_stacks(th);
+#endif
             /* do the tls as well */
             lispobj* from = &th->lisp_thread;
             lispobj* to = (lispobj*)(SymbolValue(FREE_TLS_INDEX,0) + (char*)th);

--- a/src/runtime/thread.h
+++ b/src/runtime/thread.h
@@ -33,6 +33,10 @@ void* os_get_csp(struct thread* th);
 void assert_on_stack(struct thread *th, void *esp);
 #endif /* defined(LISP_FEATURE_SB_SAFEPOINT) */
 
+#ifdef LISP_FEATURE_SB_FIBER
+struct sb_fiber_ctx;
+#endif
+
 /* The thread struct is generated from lisp during genesis and it
  * needs to know the sizes of all its members, but some types may have
  * arbitrary lengths, thus the pointers are stored instead. This
@@ -91,6 +95,9 @@ struct extra_thread_data
     os_context_register_t carried_base_pointer;
     HANDLE synchronous_io_handle_and_flag;
     void* waiting_on_address; // used only if #+sb-futex
+#endif
+#ifdef LISP_FEATURE_SB_FIBER
+    struct sb_fiber_ctx *fiber_list; // head of registered fiber list
 #endif
     int arena_count; // number of structures in arena_saveareas
     arena_state* arena_savearea;

--- a/src/runtime/x86-64-fiber.c
+++ b/src/runtime/x86-64-fiber.c
@@ -1,0 +1,109 @@
+#include "fiber.h"
+#include "genesis/symbol.h"
+#include "genesis/static-symbols.h"
+#include <stdint.h>
+
+void sb_fiber_prepare(struct sb_fiber_ctx *f,
+                      void (*fn)(void *), void *arg)
+{
+    f->entry_fn = fn;
+    f->entry_arg = arg;
+
+    void **sp = (void **)f->stack_end;
+    sp = (void **)((uintptr_t)sp & ~0xFULL);      /* 16-byte align */
+    *(--sp) = (void *)0;
+    *(--sp) = (void *)SYMBOL(FIBER_TRAMP)->value; /* RET target */
+
+    f->regs.rsp = sp;
+    f->regs.rbp = 0;
+    f->regs.rbx = 0;
+    f->regs.r12 = (void *)f;
+    f->regs.r13 = 0;
+    f->regs.r14 = 0;
+    f->regs.r15 = 0;
+
+    uint32_t mxcsr;
+    __asm__ volatile ("stmxcsr %0" : "=m"(mxcsr));
+    f->regs.mxcsr = mxcsr;
+    f->regs.pad_  = 0;
+}
+
+void *sb_fiber_sp(const struct sb_fiber_ctx *f)
+{
+    return f->regs.rsp;
+}
+
+int sb_fiber_gc_regs(const struct sb_fiber_ctx *f, lispobj *out, int max)
+{
+    static const int n = 6;
+    if (max < n) return 0;
+    int i = 0;
+    out[i++] = (lispobj)f->regs.rbx;
+    out[i++] = (lispobj)f->regs.rbp;
+    out[i++] = (lispobj)f->regs.r12;
+    out[i++] = (lispobj)f->regs.r13;
+    out[i++] = (lispobj)f->regs.r14;
+    out[i++] = (lispobj)f->regs.r15;
+    return i;
+}
+
+void sb_fiber_rebind_thread(struct sb_fiber_ctx *f, struct thread *new_owner)
+{
+    f->regs.r13 = (void *)new_owner;
+}
+
+/* Lisp-stack hooks: alias control_stack_* to the fiber's native C
+   stack range. */
+
+int sb_fiber_lisp_stack_alloc(struct sb_fiber_ctx *f, size_t size)
+{
+    (void)size;
+    f->control_stack_base = (lispobj *)f->stack_base;
+    f->control_stack_end  = (lispobj *)f->stack_end;
+    return 0;
+}
+
+void sb_fiber_lisp_stack_free(struct sb_fiber_ctx *f)
+{
+    f->control_stack_base = NULL;
+    f->control_stack_end  = NULL;
+}
+
+void sb_fiber_lisp_stack_capture_main(struct sb_fiber_ctx *f, struct thread *th)
+{
+    f->control_stack_base = th->control_stack_start;
+    f->control_stack_end  = th->control_stack_end;
+    f->cs_guard_protected =
+        th->state_word.control_stack_guard_page_protected;
+}
+
+void sb_fiber_lisp_stack_suspend(struct sb_fiber_ctx *f, struct thread *th)
+{
+    f->control_stack_base = th->control_stack_start;
+    f->control_stack_end  = th->control_stack_end;
+    f->cs_guard_protected = th->state_word.control_stack_guard_page_protected;
+}
+
+void sb_fiber_lisp_stack_resume(struct sb_fiber_ctx *f, struct thread *th)
+{
+    th->control_stack_start = f->control_stack_base;
+    th->control_stack_end   = f->control_stack_end;
+    th->state_word.control_stack_guard_page_protected = f->cs_guard_protected;
+}
+
+size_t sb_fiber_control_stack_size_bytes(const struct sb_fiber_ctx *f)
+{
+    if (f->stack_start && f->stack_end)
+        return (char *)f->stack_end - (char *)f->stack_start;
+    if (f->control_stack_base && f->control_stack_end)
+        return (char *)f->control_stack_end - (char *)f->control_stack_base;
+    return 0;
+}
+
+size_t sb_fiber_control_stack_used_bytes(const struct sb_fiber_ctx *f)
+{
+    void *sp = f->regs.rsp;
+    if (sp && f->stack_end && (char *)sp < (char *)f->stack_end)
+        return (char *)f->stack_end - (char *)sp;
+    return 0;
+}

--- a/src/runtime/x86-64-fiber.h
+++ b/src/runtime/x86-64-fiber.h
@@ -1,0 +1,23 @@
+#ifndef SBCL_FIBER_X86_64_H
+#define SBCL_FIBER_X86_64_H
+
+#include <stdint.h>
+
+/* Callee-saved register set: RBX, RBP, R12-R15, MXCSR. RSP is first
+ * because the fallback switcher fiber-swap-regs is reached via CALL,
+ * so the callee's return PC sits at [RSP] when the save happens. The
+ * %swap-regs VOP pushes RESUME before saving so the same shape works.
+ */
+struct sb_fiber_regs {
+    void    *rsp;     /* 0x00 */
+    void    *rbx;     /* 0x08 */
+    void    *rbp;     /* 0x10 */
+    void    *r12;     /* 0x18 */
+    void    *r13;     /* 0x20 */
+    void    *r14;     /* 0x28 */
+    void    *r15;     /* 0x30 */
+    uint32_t mxcsr;   /* 0x38 */
+    uint32_t pad_;    /* 0x3C */
+};
+
+#endif /* SBCL_FIBER_X86_64_H */

--- a/tests/fiber.impure.lisp
+++ b/tests/fiber.impure.lisp
@@ -1,0 +1,625 @@
+;;;; Stress and regression tests for sb-fiber.
+
+;;;; This software is part of the SBCL system. See the README file for
+;;;; more information.
+
+(unless (and (member :sb-thread *features*)
+             (member :sb-fiber *features*)
+             (or (member :x86-64 *features*)
+                 (member :arm64 *features*))
+             (not (member :win32 *features*)))
+  (invoke-restart 'run-tests::skip-file))
+
+(require :sb-fiber)
+(use-package :sb-fiber)
+
+(defmacro with-main-fiber ((main) &body body)
+  `(let ((,main (make-main-fiber)))
+     (unwind-protect (progn ,@body)
+       (release-fiber ,main))))
+
+(defmacro with-main+child ((main child entry-fn &rest make-args) &body body)
+  `(with-main-fiber (,main)
+     (with-fiber (,child ,entry-fn ,@make-args) ,@body)))
+
+;;; --- GC integration ---------------------------------------------------
+
+(with-test (:name (:fiber :gc-with-suspended-fibers))
+  (with-main-fiber (main)
+    (let* ((n 50)
+           (fibers (make-array n))
+           (ok (make-array n :initial-element nil)))
+      (dotimes (i n)
+        (let ((idx i))
+          (setf (aref fibers i)
+                (make-fiber
+                 (lambda ()
+                   (let ((data (list (make-array 5 :initial-element idx)
+                                     (cons idx (* idx idx))
+                                     (format nil "fiber-~D" idx))))
+                     (switch-fiber (aref fibers idx) main)
+                     (setf (aref ok idx)
+                           (and (= (aref (first data) 0) idx)
+                                (= (car (second data)) idx)
+                                (string= (third data)
+                                         (format nil "fiber-~D" idx))))
+                     (switch-fiber (aref fibers idx) main)))))))
+      (dotimes (i n) (switch-fiber main (aref fibers i)))
+      (dotimes (_ 3) (sb-ext:gc :full t))
+      (dotimes (i n) (switch-fiber main (aref fibers i)))
+      (dotimes (i n) (assert (aref ok i) () "fiber ~D corrupted" i))
+      (dotimes (i n) (release-fiber (aref fibers i))))))
+
+(with-test (:name (:fiber :gc-during-repeated-switches))
+  (let ((count 0))
+    (with-main+child (main child
+                           (lambda ()
+                             (loop (incf count) (make-array 1000)
+                                   (yield-fiber))))
+      (dotimes (i 200)
+        (switch-fiber main child)
+        (when (zerop (mod i 20)) (sb-ext:gc :full t)))
+      (assert (= count 200)))))
+
+(with-test (:name (:fiber :gc-during-mass-creation))
+  (with-fiber-thread ()
+    (let (fibers)
+      (dotimes (i 500)
+        (push (make-fiber (lambda ())) fibers)
+        (when (zerop (mod i 50)) (sb-ext:gc :full t)))
+      (mapc #'release-fiber fibers))))
+
+(with-test (:name (:fiber :trampoline-vs-gc-stop))
+  (let ((done (sb-thread:make-semaphore))
+        (stop-gc nil))
+    (let ((gc-thread
+            (sb-thread:make-thread
+             (lambda ()
+               (loop until stop-gc do (sb-ext:gc) (sleep 0.0001)))
+             :name "trampoline-vs-gc-stop pumper")))
+      (sb-thread:make-thread
+       (lambda ()
+         (with-fiber-thread ()
+           (dotimes (i 500)
+             (let ((f (make-fiber (lambda () i))))
+               (resume-fiber f))))
+         (sb-thread:signal-semaphore done))
+       :name "trampoline-vs-gc-stop worker")
+      (sb-thread:wait-on-semaphore done)
+      (setf stop-gc t)
+      (sb-thread:join-thread gc-thread))))
+
+(defvar *bs-stress-var* :default)
+
+(with-test (:name (:fiber :binding-stack-stress))
+  (with-main-fiber (main)
+    (let* ((n 20)
+           (fibers (make-array n))
+           (results (make-array n :initial-element nil)))
+      (dotimes (i n)
+        (let ((idx i))
+          (setf (aref fibers i)
+                (make-fiber
+                 (lambda ()
+                   (let ((*bs-stress-var* idx))
+                     (dotimes (_ 10)
+                       (switch-fiber (aref fibers idx) main)
+                       (unless (= *bs-stress-var* idx)
+                         (setf (aref results idx) :failed)
+                         (return)))
+                     (setf (aref results idx) :ok))
+                   (switch-fiber (aref fibers idx) main))))))
+      (dotimes (_ 10)
+        (dotimes (i n) (switch-fiber main (aref fibers i)))
+        (assert (eq *bs-stress-var* :default)))
+      (dotimes (i n) (switch-fiber main (aref fibers i)))
+      (dotimes (i n) (assert (eq :ok (aref results i))))
+      (dotimes (i n) (release-fiber (aref fibers i))))))
+
+(with-test (:name (:fiber :handler-clusters-across-switch))
+  (let ((sem (sb-thread:make-semaphore))
+        (inner-caught nil)
+        (outer-caught nil))
+    (sb-thread:make-thread
+     (lambda ()
+       (let* ((mf (make-main-fiber))
+              (f nil))
+         (setf f (make-fiber
+                  (lambda ()
+                    (handler-case
+                        (handler-case
+                            (progn (switch-fiber f mf) (error "boom"))
+                          (error (e) (setf inner-caught (princ-to-string e))))
+                      (error (e) (setf outer-caught (princ-to-string e)))))))
+         (switch-fiber mf f)
+         (switch-fiber mf f)
+         (release-fiber f)
+         (release-fiber mf))
+       (sb-thread:signal-semaphore sem)))
+    (assert (sb-thread:wait-on-semaphore sem :timeout 5))
+    (assert (equal "boom" inner-caught))
+    (assert (null outer-caught))))
+
+(with-test (:name (:fiber :handler :escape))
+  (let (caught)
+    (with-main+child (mf f (lambda () (error "error")))
+      (handler-case (switch-fiber mf f)
+        (error (e) (setf caught (princ-to-string e)))))
+    (assert (equal caught "error"))))
+
+(with-test (:name (:fiber :handler :nested))
+  (dotimes (i 1000)
+    (let (caught)
+      (with-main+child (mf f
+                           (lambda ()
+                             (handler-case
+                                 (handler-case
+                                     (progn (yield-fiber) (error "iter ~A" i))
+                                   (error (e) (setf caught (princ-to-string e))))
+                               (error () nil))))
+        (switch-fiber mf f)
+        (switch-fiber mf f)
+        (assert (search (format nil "iter ~A" i) (or caught "")))))))
+
+(with-test (:name (:fiber :multi-thread-independent-fibers))
+  (let ((results (make-array 4 :initial-element nil))
+        (lock (sb-thread:make-mutex)))
+    (let ((threads
+            (loop for ti below 4 collect
+                  (let ((idx ti))
+                    (sb-thread:make-thread
+                     (lambda ()
+                       (with-fiber-thread ()
+                         (let* ((count 0)
+                                (child (make-fiber
+                                        (lambda ()
+                                          (dotimes (_ 1000)
+                                            (incf count) (yield-fiber))))))
+                           (dotimes (_ 1000)
+                             (switch-fiber *current-fiber* child))
+                           (release-fiber child)
+                           (sb-thread:with-mutex (lock)
+                             (setf (aref results idx) count))))))))))
+      (mapc #'sb-thread:join-thread threads))
+    (dotimes (i 4) (assert (= 1000 (aref results i))))))
+
+(with-test (:name (:fiber :current-fiber-is-per-thread))
+  (let* ((n-threads 4)
+         (start (sb-thread:make-semaphore))
+         (results (make-array n-threads :initial-element nil)))
+    (let ((threads
+            (loop for i below n-threads collect
+                  (let ((idx i))
+                    (sb-thread:make-thread
+                     (lambda ()
+                       (with-fiber-thread ()
+                         (let ((c (make-fiber
+                                   (lambda () (loop (yield-fiber))))))
+                           (sb-thread:wait-on-semaphore start)
+                           (handler-case
+                               (progn (dotimes (_ 5000)
+                                        (switch-fiber *current-fiber* c))
+                                      (setf (aref results idx) :ok))
+                             (error (e) (setf (aref results idx) e)))
+                           (release-fiber c)))))))))
+      (sleep 0.05)
+      (dotimes (_ n-threads) (sb-thread:signal-semaphore start))
+      (mapc #'sb-thread:join-thread threads))
+    (loop for r across results
+          do (assert (eq r :ok) () "thread errored: ~S" r))))
+
+(sb-alien:define-alien-variable ("lose_on_corruption_p" %lose-on-corruption-p)
+    sb-alien:int)
+
+(defmacro without-lose-on-corruption (&body body)
+  (let ((saved (gensym)))
+    `(let ((,saved %lose-on-corruption-p))
+       (unwind-protect (progn (setf %lose-on-corruption-p 0) ,@body)
+         (setf %lose-on-corruption-p ,saved)))))
+
+(with-test (:name (:fiber :stack-overflow-recovers))
+  (let (caught)
+    (with-main+child (main child
+                           (lambda ()
+                             (declare (optimize (speed 0) (safety 3) (debug 3)))
+                             (handler-case
+                                 (labels ((blow (n) (1+ (blow (1+ n)))))
+                                   (blow 0))
+                               (storage-condition () (setf caught t)))
+                             (yield-fiber))
+                           :stack-size 65536)
+      (without-lose-on-corruption (switch-fiber main child)))
+    (assert caught)))
+
+(defvar *bs-a*) (defvar *bs-b*) (defvar *bs-c*) (defvar *bs-d*)
+
+(with-test (:name (:fiber :binding-stack-overflow-recovers))
+  (let (caught)
+    (with-main+child (main child
+                           (lambda ()
+                             (declare (optimize (speed 0) (safety 3) (debug 3)))
+                             (labels ((recur (d)
+                                        (declare (type fixnum d))
+                                        (progv '(*bs-a* *bs-b* *bs-c* *bs-d*)
+                                            '(0 0 0 0)
+                                          (recur (1+ d)))))
+                               (handler-case (recur 0)
+                                 (storage-condition () (setf caught t))))))
+      (without-lose-on-corruption (switch-fiber main child)))
+    (assert caught)))
+
+(with-test (:name (:fiber :fanout-scaling) :slow t :skipped-on (not :slow))
+  (dolist (n '(10 100 1000 10000))
+    (with-main-fiber (main)
+      (let* ((fibers (make-array n))
+             (total  0))
+        (dotimes (i n)
+          (setf (aref fibers i)
+                (make-fiber (lambda ()
+                              (loop (incf total) (yield-fiber))))))
+        (let* ((rounds (max 1 (floor 100000 n)))
+               (start  (get-internal-real-time)))
+          (dotimes (_ rounds)
+            (dotimes (i n) (switch-fiber main (aref fibers i))))
+          (let* ((elapsed (/ (- (get-internal-real-time) start)
+                             internal-time-units-per-second))
+                 (rate    (if (> elapsed 0) (/ (* rounds n) elapsed) 0)))
+            (format t "~&;   ~6D fibers x ~D rounds: ~,2F switches/sec~%"
+                    n rounds rate)))
+        (assert (> total 0))
+        (dotimes (i n) (release-fiber (aref fibers i)))))))
+
+(with-test (:name (:fiber :fanout-gc-under-load) :slow t :skipped-on (not :slow))
+  (dolist (n '(100 1000 5000))
+    (with-main-fiber (main)
+      (let* ((fibers (make-array n))
+             (ok     (make-array n :initial-element nil)))
+        (dotimes (i n)
+          (let ((idx i))
+            (setf (aref fibers i)
+                  (make-fiber
+                   (lambda ()
+                     (let ((data (list (cons idx idx)
+                                       (make-array 3 :initial-element idx))))
+                       (yield-fiber)
+                       (setf (aref ok idx)
+                             (and (= idx (car (first data)))
+                                  (= idx (aref (second data) 0))))
+                       (yield-fiber)))))))
+        (dotimes (i n) (switch-fiber main (aref fibers i)))
+        (sb-ext:gc :full t)
+        (dotimes (i n) (switch-fiber main (aref fibers i)))
+        (assert (= n (count t ok)) () "GC corruption at n=~D" n)
+        (dotimes (i n) (release-fiber (aref fibers i)))))))
+
+(defun %caller-frame-driver ()
+  (with-main+child (main child (lambda () (loop (yield-fiber))))
+    (dotimes (_ 1000000) (switch-fiber main child))
+    ;; Force an INVOKE-WITH-SAVED-FP wrap after the loop.
+    (let ((x (get-internal-real-time))) (declare (ignore x)))))
+
+(with-test (:name (:fiber :caller-frame-live-across-1m-switches)
+            :slow t :skipped-on (not :slow))
+  (let ((witness (list :fiber :liveness-probe)))
+    (%caller-frame-driver)
+    (assert (consp witness))
+    (assert (eq (first witness) :fiber))
+    (assert (eq (second witness) :liveness-probe))))
+
+(with-test (:name (:fiber :gc-under-create-destroy-churn))
+  (with-fiber-thread ()
+    (dotimes (i 200)
+      (release-fiber (make-fiber (lambda () (make-array 10))))
+      (when (zerop (mod i 25)) (sb-ext:gc :full t)))))
+
+(with-test (:name (:fiber :switch-cycle-survives-gc-churn) :slow t :skipped-on (not :slow))
+  (with-main-fiber (main)
+    (let ((hits 0))
+      (dotimes (i 5000)
+        (let ((expected i))
+          (with-fiber (child (lambda ()
+                               (incf hits)
+                               (assert (= expected i))
+                               (yield-fiber)))
+            (switch-fiber main child)))
+        (when (zerop (mod i 250)) (sb-ext:gc :full t)))
+      (assert (= hits 5000)))))
+
+(with-test (:name (:fiber :cross-thread-destroy))
+  (let* ((created nil)
+         (creator-done (sb-thread:make-semaphore))
+         (destroyer-ok (sb-thread:make-semaphore))
+         (t1 (sb-thread:make-thread
+              (lambda ()
+                (let ((mf (make-main-fiber)))
+                  (setf created (make-fiber (lambda ())))
+                  (sb-thread:signal-semaphore creator-done)
+                  (sb-thread:wait-on-semaphore destroyer-ok :timeout 5)
+                  (release-fiber mf))))))
+    (sb-thread:wait-on-semaphore creator-done :timeout 5)
+    (release-fiber created)
+    (sb-thread:signal-semaphore destroyer-ok)
+    (sb-thread:join-thread t1)))
+
+(with-test (:name (:fiber :signal-safe-under-timer-gc))
+  (let ((fired 0))
+    (with-main+child (main child (lambda () (loop (yield-fiber))))
+      (let ((timer (sb-ext:make-timer
+                    (lambda ()
+                      (incf fired)
+                      (when (zerop (mod fired 50)) (sb-ext:gc)))
+                    :thread sb-thread:*current-thread*)))
+        (sb-ext:schedule-timer timer 0.0005 :repeat-interval 0.0005)
+        (unwind-protect
+             (dotimes (_ 200000) (switch-fiber main child))
+          (sb-ext:unschedule-timer timer))))
+    (assert (>= fired 1))))
+
+#+sb-thread
+(with-test (:name (:fiber :register-prepare-gc-race))
+  (let ((stop nil))
+    (let ((gc-th (sb-thread:make-thread
+                  (lambda () (loop until stop do (sb-ext:gc) (sleep 0.0005)))))
+          (drivers
+            (loop for d below 4 collect
+                  (sb-thread:make-thread
+                   (lambda ()
+                     (make-main-fiber)
+                     (dotimes (_ 50)
+                       (let ((fs (loop repeat 16
+                                       collect (make-fiber (lambda ())))))
+                         (mapc #'release-fiber fs))))))))
+      (mapc #'sb-thread:join-thread drivers)
+      (setf stop t)
+      (sb-thread:join-thread gc-th))))
+
+(with-test (:name (:fiber :thread-exit-releases-orphaned-fibers))
+  (dotimes (_ 50)
+    (sb-thread:join-thread
+     (sb-thread:make-thread
+      (lambda ()
+        (make-main-fiber)
+        (dotimes (_ 200)
+          (make-fiber (lambda () (loop (yield-fiber)))))))))
+  (sb-ext:gc :full t))
+
+(with-test (:name (:fiber :deep-stack-under-gc))
+  (let* ((depth 200)
+         (built nil))
+    (with-main+child (main child
+                           (lambda ()
+                             (labels ((rec (n acc)
+                                        (declare (type fixnum n))
+                                        (if (zerop n)
+                                            (progn (yield-fiber) acc)
+                                            (rec (1- n) (cons n acc)))))
+                               (setf built (rec depth nil)))))
+      (switch-fiber main child)         ; child reaches depth, yields
+      (sb-ext:gc :full t)
+      (sb-ext:gc :full t)
+      (switch-fiber main child))        ; resume, unwind, fiber dies
+    (assert (= (length built) depth))
+    (assert (= (reduce #'+ built) (/ (* depth (1+ depth)) 2)))))
+
+(with-test (:name (:fiber :scrub-shrunk-path :no-witness-corruption)
+            :slow t :skipped-on (not :slow))
+  (let* ((iterations 200)
+         (recurse-depth 150)
+         (witness (loop repeat 64 collect (cons :alive nil))))
+    (with-main+child (main child
+                           (lambda ()
+                             (labels ((rec (n acc)
+                                        (declare (type fixnum n))
+                                        (if (zerop n)
+                                            acc
+                                            (rec (1- n) (cons n acc)))))
+                               (loop
+                                 (rec recurse-depth nil) ; grows ~150 frames + conses
+                                 (yield-fiber)))))
+      (dotimes (_ iterations)
+        (switch-fiber main child)
+        (sb-ext:gc :full t)
+        (assert (every (lambda (c) (eq (car c) :alive)) witness)
+                ()
+                "witness corruption -- conservative scanner pinned garbage")))))
+
+(with-test (:name (:fiber :interrupt-fiber :nested-handler-case))
+  (let (inner-caught outer-caught)
+    (with-main+child (main child
+                           (lambda ()
+                             (handler-case
+                                 (handler-case (yield-fiber)
+                                   (simple-error (e) (setf inner-caught e)))
+                               (error (e) (setf outer-caught e)))))
+      (switch-fiber main child)         ; run to yield
+      (interrupt-fiber child (make-condition 'simple-error
+                                             :format-control "interrupted"))
+      (switch-fiber main child))        ; resume; interrupt fires inside child
+    (assert inner-caught   () "inner handler-case did not catch")
+    (assert (null outer-caught) () "outer handler-case fired (should not)")
+    (assert (search "interrupted" (princ-to-string inner-caught)))))
+
+(with-test (:name (:fiber :interrupt-fiber :handler-transforms-condition))
+  (let (received)
+    (with-main+child (main child
+                           (lambda ()
+                             (handler-case (yield-fiber)
+                               (simple-error () (error "transformed")))))
+      (switch-fiber main child)
+      (interrupt-fiber child (make-condition 'simple-error
+                                             :format-control "original"))
+      (handler-case (switch-fiber main child)
+        (simple-error (e) (setf received (princ-to-string e)))))
+    (assert (search "transformed" received) ()
+            "expected 'transformed', got ~S" received)))
+
+(with-test (:name (:fiber :join-fiber :condition-escape))
+  (with-main+child (main child (lambda () (error "escapes-via-join")))
+    (handler-case (join-fiber child)
+      (simple-error (e)
+        (assert (search "escapes-via-join" (princ-to-string e)))))))
+
+;;; --- Partial-failure cleanup --------------------------------------------
+;;;
+;;; If a step after the C-level fiber allocation signals, the raw SAP must
+;;; be released rather than leaked.  We force the failure by shadowing
+;;; %FIBER-REGISTER and instrument %FIBER-RELEASE to count cleanup calls.
+
+(defmacro with-injected-register-failure ((release-count-var) &body body)
+  (let ((orig-r (gensym)) (orig-rel (gensym)))
+    `(let* ((,release-count-var 0)
+            (,orig-r   (fdefinition 'sb-fiber::%fiber-register))
+            (,orig-rel (fdefinition 'sb-fiber::%fiber-release)))
+       (unwind-protect
+            (progn
+              (setf (fdefinition 'sb-fiber::%fiber-register)
+                    (lambda (th sap)
+                      (declare (ignore th sap))
+                      (error "injected register failure")))
+              (setf (fdefinition 'sb-fiber::%fiber-release)
+                    (lambda (sap)
+                      (incf ,release-count-var)
+                      (funcall ,orig-rel sap)))
+              ,@body)
+         (setf (fdefinition 'sb-fiber::%fiber-register) ,orig-r)
+         (setf (fdefinition 'sb-fiber::%fiber-release)  ,orig-rel)))))
+
+(with-test (:name (:fiber :make-fiber :partial-failure-releases-sap))
+  (with-main-fiber (main)
+    (assert (eq main *current-fiber*))
+    (let (got-error)
+      (with-injected-register-failure (releases)
+        (handler-case (make-fiber (lambda ()))
+          (simple-error () (setf got-error t)))
+        (assert got-error)
+        (assert (= 1 releases) ()
+                "expected one %fiber-release call, got ~D" releases))
+      ;; State remains usable: a subsequent make-fiber works fine.
+      (let ((f (make-fiber (lambda ()))))
+        (assert (fiber-alive-p f))
+        (release-fiber f)))))
+
+(with-test (:name (:fiber :make-main-fiber :partial-failure-releases-sap))
+  (assert (null *current-fiber*))
+  (let ((got-error nil))
+    (with-injected-register-failure (releases)
+      (handler-case (make-main-fiber)
+        (simple-error () (setf got-error t)))
+      (assert got-error)
+      (assert (= 1 releases) ()
+              "expected one %fiber-release call, got ~D" releases))
+    ;; A failed make-main-fiber must not publish the partial wrapper.
+    (assert (null *current-fiber*))
+    ;; Recovery: a subsequent make-main-fiber works.
+    (let ((m (make-main-fiber)))
+      (assert (fiber-alive-p m))
+      (release-fiber m))))
+
+;;; --- Cross-thread migration ---
+
+(with-test (:name (:fiber :migrate :metadata-only)
+            :skipped-on (not :sb-thread))
+  (let* ((fiber-cell (list nil))
+         (a-installed (sb-thread:make-semaphore :name "metaonly-installed"))
+         (a-released  (sb-thread:make-semaphore :name "metaonly-released"))
+         (b-go        (sb-thread:make-semaphore :name "metaonly-b-go")))
+    (let* ((a-thread
+             (sb-thread:make-thread
+              (lambda ()
+                (with-main-fiber (a-main)
+                  (let ((child (make-fiber (lambda () (yield-fiber) :done))))
+                    (resume-fiber child)
+                    (setf (car fiber-cell) child)
+                    (sb-thread:signal-semaphore a-installed)
+                    (sb-thread:wait-on-semaphore a-released))))
+              :name "fiber-migrate-meta-src"))
+           (b-thread
+             (sb-thread:make-thread
+              (lambda ()
+                (sb-thread:wait-on-semaphore b-go)
+                ;; Migrated child sits in B's fiber list.  B releases
+                ;; it without ever switching into it.  The wrapper's
+                ;; FIBER-THREAD must be B by this point, and
+                ;; RELEASE-FIBER must succeed without signalling.
+                (release-fiber (car fiber-cell)))
+              :name "fiber-migrate-meta-dest")))
+      (sb-thread:wait-on-semaphore a-installed)
+      (let ((child (car fiber-cell)))
+        (assert child)
+        (assert (eq (sb-fiber::fiber-thread child) a-thread)
+                nil "before migrate, fiber's thread slot should be A")
+        (assert (eq child (fiber-migrate child b-thread)))
+        (assert (eq (sb-fiber::fiber-thread child) b-thread)
+                nil "after migrate, fiber's thread slot should be B"))
+      (sb-thread:signal-semaphore b-go)
+      (sb-thread:join-thread b-thread)
+      (sb-thread:signal-semaphore a-released)
+      (sb-thread:join-thread a-thread))))
+
+(with-test (:name (:fiber :migrate :runnable-runs-on-dest)
+            :skipped-on (not :sb-thread))
+  (let* ((fiber-cell (list nil))
+         (a-installed (sb-thread:make-semaphore :name "a-installed"))
+         (a-released  (sb-thread:make-semaphore :name "a-released"))
+         (migrate-done (sb-thread:make-semaphore :name "migrate-done"))
+         (b-result    (list nil))
+         (observed-thread (list nil)))
+    (let* ((a-thread
+             (sb-thread:make-thread
+              (lambda ()
+                (with-main-fiber (a-main)
+                  (let ((child (make-fiber
+                                (lambda ()
+                                  (yield-fiber)
+                                  (setf (car observed-thread)
+                                        sb-thread:*current-thread*)
+                                  :body-done))))
+                    (resume-fiber child)
+                    (setf (car fiber-cell) child)
+                    (sb-thread:signal-semaphore a-installed)
+                    (sb-thread:wait-on-semaphore a-released))))
+              :name "fiber-migrate-src")))
+      (sb-thread:wait-on-semaphore a-installed)
+      (let ((child (car fiber-cell)))
+        (assert child)
+        (let ((b-thread
+                (sb-thread:make-thread
+                 (lambda ()
+                   (sb-thread:wait-on-semaphore migrate-done)
+                   (with-main-fiber (b-main)
+                     (setf (car b-result) (join-fiber child))))
+                 :name "fiber-migrate-dest")))
+          (fiber-migrate child b-thread)
+          (assert (eq (sb-fiber::fiber-thread child) b-thread)
+                  nil
+                  "after migrate, fiber THREAD slot should be B; got ~A"
+                  (sb-fiber::fiber-thread child))
+          (sb-thread:signal-semaphore migrate-done)
+          (sb-thread:join-thread b-thread)
+          (assert (eq (car observed-thread) b-thread)
+                  nil
+                  "fiber body ran on ~A; expected B = ~A"
+                  (car observed-thread) b-thread)
+          (assert (eq (car b-result) :body-done)
+                  nil
+                  "join-fiber returned ~A; expected :body-done"
+                  (car b-result))))
+      (sb-thread:signal-semaphore a-released)
+      (sb-thread:join-thread a-thread))))
+
+(with-test (:name (:fiber :migrate :rejects-released)
+            :skipped-on (not :sb-thread))
+  (let* ((other (sb-thread:make-thread
+                 (lambda () (sb-thread:thread-yield) :ok)
+                 :name "migrate-validate-dest"))
+         (released-fiber nil))
+    (with-main-fiber (main)
+      (let ((f (make-fiber (lambda () :immediately-done))))
+        (join-fiber f)
+        (release-fiber f)
+        (setf released-fiber f)))
+    (handler-case
+        (progn (fiber-migrate released-fiber other)
+               (error "expected DEAD-FIBER-ERROR; none signaled"))
+      (dead-fiber-error () :ok))
+    (sb-thread:join-thread other)))

--- a/tests/fiber.impure.lisp
+++ b/tests/fiber.impure.lisp
@@ -176,7 +176,7 @@
                                           (dotimes (_ 1000)
                                             (incf count) (yield-fiber))))))
                            (dotimes (_ 1000)
-                             (switch-fiber *current-fiber* child))
+                             (switch-fiber (current-fiber) child))
                            (release-fiber child)
                            (sb-thread:with-mutex (lock)
                              (setf (aref results idx) count))))))))))
@@ -198,7 +198,7 @@
                            (sb-thread:wait-on-semaphore start)
                            (handler-case
                                (progn (dotimes (_ 5000)
-                                        (switch-fiber *current-fiber* c))
+                                        (switch-fiber (current-fiber) c))
                                       (setf (aref results idx) :ok))
                              (error (e) (setf (aref results idx) e)))
                            (release-fiber c)))))))))
@@ -486,7 +486,7 @@
 
 (with-test (:name (:fiber :make-fiber :partial-failure-releases-sap))
   (with-main-fiber (main)
-    (assert (eq main *current-fiber*))
+    (assert (eq main (current-fiber)))
     (let (got-error)
       (with-injected-register-failure (releases)
         (handler-case (make-fiber (lambda ()))
@@ -500,7 +500,7 @@
         (release-fiber f)))))
 
 (with-test (:name (:fiber :make-main-fiber :partial-failure-releases-sap))
-  (assert (null *current-fiber*))
+  (assert (null (current-fiber)))
   (let ((got-error nil))
     (with-injected-register-failure (releases)
       (handler-case (make-main-fiber)
@@ -509,7 +509,7 @@
       (assert (= 1 releases) ()
               "expected one %fiber-release call, got ~D" releases))
     ;; A failed make-main-fiber must not publish the partial wrapper.
-    (assert (null *current-fiber*))
+    (assert (null (current-fiber)))
     ;; Recovery: a subsequent make-main-fiber works.
     (let ((m (make-main-fiber)))
       (assert (fiber-alive-p m))
@@ -623,3 +623,84 @@
                (error "expected DEAD-FIBER-ERROR; none signaled"))
       (dead-fiber-error () :ok))
     (sb-thread:join-thread other)))
+
+;;; --- Current-fiber storage ---
+
+(with-test (:name (:fiber :current-fiber :not-visible-across-threads))
+  (let ((promoted (sb-thread:make-semaphore))
+        (release (sb-thread:make-semaphore))
+        (a-main nil)
+        (b-result nil))
+    (let ((a (sb-thread:make-thread
+              (lambda ()
+                (setf a-main (make-main-fiber :name "thread-A-main"))
+                (sb-thread:signal-semaphore promoted)
+                (sb-thread:wait-on-semaphore release))
+              :name "thread-A")))
+      (sb-thread:wait-on-semaphore promoted)
+      ;; Neither this thread nor a fresh one sees A's main fiber.
+      (assert (not (eq a-main (current-fiber))))
+      (sb-thread:join-thread
+       (sb-thread:make-thread
+        (lambda ()
+          (assert (null (current-fiber)))
+          (with-fiber-thread ()
+            (assert (not (eq a-main (current-fiber))))
+            (let ((f (make-fiber (lambda () 42))))
+              (setf b-result (resume-fiber f)))))
+        :name "thread-B"))
+      (sb-thread:signal-semaphore release)
+      (sb-thread:join-thread a))
+    (assert (eql 42 b-result))))
+
+;;; RELEASE-FIBER on one thread must not clear another thread's current
+;;; fiber, even when that thread is mid-fiber.
+(with-test (:name (:fiber :current-fiber :release-does-not-cross-threads))
+  (let ((ready (sb-thread:make-semaphore))
+        (go (sb-thread:make-semaphore))
+        (result nil))
+    (let ((worker (sb-thread:make-thread
+                   (lambda ()
+                     (with-fiber-thread ()
+                       (let ((f (make-fiber
+                                 (lambda ()
+                                   (sb-thread:signal-semaphore ready)
+                                   (sb-thread:wait-on-semaphore go)
+                                   (yield-fiber :yielded)
+                                   :finished))))
+                         (resume-fiber f)
+                         (setf result (resume-fiber f)))))
+                   :name "worker")))
+      (sb-thread:wait-on-semaphore ready)
+      ;; Promote and release a main fiber here while the worker's fiber
+      ;; is suspended inside its entry function.
+      (release-fiber (make-main-fiber))
+      (assert (null (current-fiber)))
+      (sb-thread:signal-semaphore go)
+      (sb-thread:join-thread worker))
+    (assert (eq :finished result))))
+
+;;; A dynamic binding is not involved anywhere: a nested
+;;; WITH-FIBER-THREAD inside a worker fiber (a no-op) followed by
+;;; resuming a brand-new fiber used to crash, because the binding it
+;;; pushed onto the worker's binding stack was swapped against TLS
+;;; after the switch had stored the new fiber.
+(with-test (:name (:fiber :current-fiber :nested-with-fiber-thread-in-worker))
+  (with-fiber-thread ()
+    (let* ((seen-in-n nil)
+           (n (make-fiber (lambda ()
+                            (setf seen-in-n (current-fiber))
+                            :n-done)
+                          :name "N"))
+           (w nil))
+      (setf w (make-fiber (lambda ()
+                            (with-fiber-thread ()
+                              (assert (eq w (current-fiber)))
+                              (let ((r (resume-fiber n)))
+                                (assert (eq w (current-fiber)))
+                                r)))
+                          :name "W"))
+      (assert (eq :n-done (resume-fiber w)))
+      (assert (eq n seen-in-n))
+      (release-fiber n)
+      (release-fiber w))))

--- a/tests/fiber.pure.lisp
+++ b/tests/fiber.pure.lisp
@@ -1,0 +1,457 @@
+;;;; Tests for sb-fiber, one per public entry point and error case.
+;;;; Stress and regression coverage lives in fiber.impure.lisp.
+
+;;;; This software is part of the SBCL system. See the README file for
+;;;; more information.
+
+(unless (and (member :sb-thread *features*)
+             (member :sb-fiber *features*)
+             (or (member :x86-64 *features*)
+                 (member :arm64 *features*))
+             (not (member :win32 *features*)))
+  (invoke-restart 'run-tests::skip-file))
+
+(require :sb-fiber)
+(use-package :sb-fiber)
+
+(defmacro with-main-fiber ((main) &body body)
+  `(let ((,main (make-main-fiber)))
+     (unwind-protect (progn ,@body)
+       (release-fiber ,main))))
+
+(defmacro with-main+child ((main child entry-fn &rest make-args) &body body)
+  `(with-main-fiber (,main)
+     (with-fiber (,child ,entry-fn ,@make-args) ,@body)))
+
+;;; --- Lifecycle ---
+
+(with-test (:name (:fiber :make-and-destroy))
+  (with-fiber-thread ()
+    (let ((f (make-fiber (lambda ()))))
+      (assert (fiber-alive-p f))
+      (assert (eq (fiber-state f) :new))
+      (release-fiber f)
+      (assert (not (fiber-alive-p f)))
+      ;; Double destroy is a no-op.
+      (release-fiber f))))
+
+(with-test (:name (:fiber :make-fiber :custom-sizes))
+  (with-fiber-thread ()
+    (let ((f (make-fiber (lambda ()) :stack-size 131072 :binding-stack-size 16384)))
+      (assert (fiber-alive-p f))
+      (release-fiber f))))
+
+(with-test (:name (:fiber :make-fiber :requires-main-fiber))
+  (let ((sb-fiber::*current-fiber* nil))
+    (assert-error (make-fiber (lambda ())))))
+
+(with-test (:name (:fiber :with-fiber-cleans-up))
+  (with-fiber-thread ()
+    (let (captured)
+      (with-fiber (f (lambda ()) :stack-size 65536)
+        (setf captured f)
+        (assert (fiber-alive-p f)))
+      (assert (not (fiber-alive-p captured))))))
+
+(with-test (:name (:fiber :with-fiber-thread :creates-and-releases))
+  (let ((sb-fiber::*current-fiber* nil))
+    (with-fiber-thread ()
+      (assert (typep *current-fiber* 'fiber))
+      (assert (fiber-alive-p *current-fiber*)))
+    (assert (null *current-fiber*))))
+
+(with-test (:name (:fiber :with-fiber-thread :nested-is-noop))
+  ;; If *CURRENT-FIBER* is already bound, the inner WITH-FIBER-THREAD
+  ;; must not create or release anything.
+  (with-main-fiber (outer)
+    (with-fiber-thread ()
+      (assert (eq outer *current-fiber*)))
+    (assert (eq outer *current-fiber*))
+    (assert (fiber-alive-p outer))))
+
+(with-test (:name (:fiber :make-main-fiber))
+  (with-main-fiber (main)
+    (assert (fiber-alive-p main))
+    (assert (eq main *current-fiber*))))
+
+(with-test (:name (:fiber :fiber-thread))
+  (with-main+child (main f (lambda ()))
+    (assert (eq sb-thread:*current-thread* (fiber-thread main)))
+    (assert (eq sb-thread:*current-thread* (fiber-thread f))))
+  ;; Foreign fiber carries its creating thread.
+  (let* ((other (sb-thread:make-thread
+                 (lambda ()
+                   (make-main-fiber)
+                   (make-fiber (lambda ())))
+                 :name "fiber-thread-test"))
+         (foreign (sb-thread:join-thread other)))
+    (assert (eq other (fiber-thread foreign)))
+    (release-fiber foreign)
+    (assert (null (fiber-thread foreign)))))
+
+(with-test (:name (:fiber :name :is-accessible-and-printed))
+  (with-fiber-thread ()
+    (with-fiber (f (lambda ()) :name "worker")
+      (assert (equal "worker" (fiber-name f)))
+      (assert (search "worker" (princ-to-string f))
+              ()
+              "expected PRINT-OBJECT to mention the name, got ~S"
+              (princ-to-string f)))
+    (with-fiber (f (lambda ()))
+      (assert (null (fiber-name f))))))
+
+(with-test (:name (:fiber :join-fiber))
+  ;; join-fiber drives FIBER to completion, propagates entry-fn return
+  ;; values (including zero), and leaves the fiber DEAD.
+  (with-main+child (main child (lambda () (yield-fiber :step) :done))
+    (assert (eq :done (join-fiber child)))
+    (assert (eq (fiber-state child) :dead)))
+  (with-main+child (main child (lambda ()
+                                 (yield-fiber :step)
+                                 (values :a 1 #\x)))
+    (multiple-value-bind (k n c) (join-fiber child)
+      (assert (eq :a k))
+      (assert (eql 1 n))
+      (assert (eql #\x c))))
+  (with-main+child (main child (lambda () (yield-fiber :step) (values)))
+    (assert (equal '() (multiple-value-list (join-fiber child))))))
+
+(with-test (:name (:fiber :yield-fiber :zero-values))
+  (with-main+child (main child (lambda () (yield-fiber)))
+    (assert (equal '() (multiple-value-list (switch-fiber main child))))))
+
+;;; --- Interrupt / condition staging ---
+
+(with-test (:name (:fiber :interrupt-fiber :new-never-runs))
+  (let (ran)
+    (with-main+child (main f (lambda () (setf ran t) :unreached))
+      (interrupt-fiber f (make-condition 'simple-error
+                                         :format-control "cancelled"))
+      (handler-case (switch-fiber main f)
+        (simple-error (e)
+          (assert (search "cancelled" (princ-to-string e)))))
+      (assert (null ran)))))
+
+(with-test (:name (:fiber :interrupt-fiber :runnable-fires-in-context))
+  (let (caught)
+    (with-main+child (main f (lambda ()
+                               (handler-case (yield-fiber)
+                                 (simple-error (e) (setf caught (princ-to-string e))))
+                               :done))
+      (switch-fiber main f)             ; run to the yield
+      (interrupt-fiber f (make-condition 'simple-error
+                                         :format-control "ouch"))
+      (assert (eq :done (join-fiber f)))
+      (assert (string= caught "ouch")))))
+
+(with-test (:name (:fiber :fiber-condition))
+  (with-fiber-thread ()
+    (with-fiber (f (lambda ()))
+      (assert (null (fiber-condition f)))
+      (let ((c (make-condition 'simple-error :format-control "x")))
+        (interrupt-fiber f c)
+        (assert (eq c (fiber-condition f)))))))
+
+(with-test (:name (:fiber :interrupt-fiber :stays-staged-across-yield))
+  ;; A condition staged via INTERRUPT-FIBER must fire only when the
+  ;; target actually resumes -- not when the target yields back to
+  ;; its resumer.  Regression: the interrupt and escape channels are
+  ;; separate; only an entry-function escape propagates to the
+  ;; resumer.
+  (let ((c (make-condition 'simple-error :format-control "staged"))
+        caught-in-child)
+    (with-main+child (main child
+                           (lambda ()
+                             (interrupt-fiber *current-fiber* c)
+                             (handler-case (yield-fiber)
+                               (simple-error (e) (setf caught-in-child e)))
+                             :done))
+      (handler-case (switch-fiber main child)
+        (simple-error (e)
+          (error "condition leaked to resumer: ~S" e)))
+      (assert (eq c (fiber-condition child)) ()
+              "condition no longer staged on child after yield")
+      (assert (eq :done (join-fiber child)))
+      (assert (eq c caught-in-child) ()
+              "child did not see staged condition on resume"))))
+
+(with-test (:name (:fiber :interrupt-fiber :dead-errors))
+  (with-fiber-thread ()
+    (let ((f (make-fiber (lambda ()))))
+      (release-fiber f)
+      (assert-error
+       (interrupt-fiber f (make-condition 'simple-error
+                                          :format-control "x"))
+       dead-fiber-error))))
+
+;;; --- Control transfer ---
+
+(with-test (:name (:fiber :switch-fiber :basic))
+  (let (log)
+    (with-main+child (main child
+                           (lambda ()
+                             (push :child log)
+                             (switch-fiber *current-fiber*
+                                           (fiber-return-fiber *current-fiber*))
+                             (push :child-again log)))
+      (push :main log)
+      (switch-fiber main child)
+      (push :main-again log)
+      (switch-fiber main child)
+      (assert (equal (nreverse log) '(:main :child :main-again :child-again))))))
+
+(with-test (:name (:fiber :switch-fiber :value-in))
+  ;; SWITCH-FIBER delivers VALUE to the resumed fiber as the return
+  ;; value of its own (preceding) YIELD-FIBER / SWITCH-FIBER call.
+  (let (received)
+    (with-main+child (main child
+                           (lambda () (setf received (yield-fiber))))
+      (switch-fiber main child)           ; first entry, no value
+      (switch-fiber main child :hello)    ; resumed: yield returns :hello
+      (assert (eq received :hello)))))
+
+(with-test (:name (:fiber :yield-fiber :value-out))
+  ;; YIELD-FIBER's argument becomes SWITCH-FIBER's return value in
+  ;; the resumer.
+  (with-main+child (main child (lambda () (yield-fiber :from-child)))
+    (assert (eq :from-child (switch-fiber main child)))))
+
+(with-test (:name (:fiber :switch-fiber :entry-fn-return-propagates))
+  ;; When a fiber's entry function returns normally, its value is
+  ;; delivered to the resumer on auto-return.
+  (with-main+child (main child (lambda () :done))
+    (assert (eq :done (switch-fiber main child)))
+    (assert (eq (fiber-state child) :dead))
+    (assert (not (fiber-alive-p child)))))
+
+(with-test (:name (:fiber :yield-fiber :no-return-fiber-errors))
+  (with-main-fiber (main)
+    (assert (eq main *current-fiber*))
+    (assert-error (yield-fiber))))
+
+(with-test (:name (:fiber :resume-fiber :basic))
+  ;; RESUME-FIBER is (SWITCH-FIBER *CURRENT-FIBER* TO . VALUES); test
+  ;; both directions of the value channel including multiple values.
+  (with-main+child (main child
+                         (lambda ()
+                           (let ((v (multiple-value-list (yield-fiber :a 1 #\x))))
+                             (list :got v))))
+    (multiple-value-bind (k n c) (resume-fiber child)
+      (assert (eq :a k))
+      (assert (eql 1 n))
+      (assert (eql #\x c)))
+    (assert (equal '(:got (99)) (resume-fiber child 99)))))
+
+(with-test (:name (:fiber :resume-fiber :no-current-fiber-errors))
+  (with-main+child (main f (lambda ()))
+    (assert (eq main *current-fiber*))
+    (let ((sb-fiber::*current-fiber* nil))
+      (assert-error (resume-fiber f) no-current-fiber-error))))
+
+(with-test (:name (:fiber :yield-preserves-resumer-return-fiber))
+  (with-main-fiber (main)
+    (let* ((g2 (make-fiber (lambda () (yield-fiber 42))))
+           (g1 (make-fiber
+                (lambda ()
+                  (let ((v (resume-fiber g2)))
+                    (yield-fiber v))))))
+      (assert (eql 42 (resume-fiber g1)))
+      (release-fiber g1)
+      (release-fiber g2))))
+
+(with-test (:name (:fiber :stack-usage-accessors))
+  (let* ((stack-size 131072)
+         (bs-size    16384))
+    (with-main-fiber (main)
+      (let ((f (make-fiber (lambda ()
+                             (progv '(*print-base*) '(16) (yield-fiber)))
+                           :stack-size stack-size
+                           :binding-stack-size bs-size)))
+        (assert (= stack-size (fiber-control-stack-size f)))
+        (assert (= bs-size    (fiber-binding-stack-size f)))
+        (assert (zerop (fiber-binding-stack-usage f)))
+        (switch-fiber main f)             ; run to the yield
+        (assert (= stack-size (fiber-control-stack-size f)))
+        (assert (plusp (fiber-control-stack-usage f)))
+        (assert (plusp (fiber-binding-stack-usage f))
+                ()
+                "expected PROGV to grow the binding stack; got ~D"
+                (fiber-binding-stack-usage f))
+        (release-fiber f)
+        (assert (zerop (fiber-control-stack-size f)))
+        (assert (zerop (fiber-control-stack-usage f)))
+        (assert (zerop (fiber-binding-stack-size f)))
+        (assert (zerop (fiber-binding-stack-usage f))))
+      ;; Main fiber: binding-stack-size = 0 (not owned); other three
+      ;; should be queryable without error.
+      (assert (zerop (fiber-binding-stack-size main)))
+      (fiber-control-stack-size main)
+      (fiber-control-stack-usage main)
+      (fiber-binding-stack-usage main))))
+
+;;; --- Switch validation ---
+
+(with-test (:name (:fiber :switch-fiber :destroyed-errors))
+  (with-main-fiber (main)
+    (let ((child (make-fiber (lambda ()))))
+      (release-fiber child)
+      (assert-error (switch-fiber main child) dead-fiber-error))))
+
+(with-test (:name (:fiber :switch-fiber :wrong-thread-errors))
+  (with-main-fiber (main)
+    (let* ((other (sb-thread:make-thread
+                   (lambda ()
+                     (make-main-fiber)
+                     (make-fiber (lambda ())))))
+           (foreign (sb-thread:join-thread other)))
+      (assert-error (switch-fiber main foreign) fiber-thread-mismatch-error)
+      (release-fiber foreign))))
+
+;;; --- Dynamic environment isolation across switches ---
+
+(defvar *fiber-test-var* :main-value)
+
+(with-test (:name (:fiber :special-variable-isolation))
+  (with-main-fiber (main)
+    (let* ((seen nil)
+           (child nil))
+      (setf child (make-fiber
+                   (lambda ()
+                     (setf seen *fiber-test-var*)
+                     (switch-fiber child main))))
+      (let ((*fiber-test-var* :rebound))
+        (switch-fiber main child)
+        (assert (eq *fiber-test-var* :rebound)))
+      (assert (eq seen :rebound))
+      (release-fiber child))))
+
+(with-test (:name (:fiber :handler-case-across-switch))
+  (with-main-fiber (main)
+    (let* ((child nil)
+           (caught nil))
+      (setf child (make-fiber
+                   (lambda ()
+                     (handler-case
+                         (progn (switch-fiber child main)
+                                (error "test error"))
+                       (error (c) (setf caught (princ-to-string c))))
+                     (switch-fiber child main))))
+      (switch-fiber main child)
+      (switch-fiber main child)
+      (assert (string= caught "test error"))
+      (release-fiber child))))
+
+(with-test (:name (:fiber :unwind-protect-across-switch))
+  (with-main-fiber (main)
+    (let* ((child nil)
+           (cleanup-ran nil))
+      (setf child (make-fiber
+                   (lambda ()
+                     (unwind-protect (switch-fiber child main)
+                       (setf cleanup-ran t))
+                     (switch-fiber child main))))
+      (switch-fiber main child)
+      (switch-fiber main child)
+      (assert cleanup-ran)
+      (release-fiber child))))
+
+(with-test (:name (:fiber :throw-cannot-escape-fiber))
+  ;; THROW out of a fiber to a CATCH on the caller's stack is
+  ;; intercepted (control-error) -- it would otherwise unwind to a
+  ;; frame on a different stack.  Distinguish "outer caught" vs
+  ;; "fell through" via the entry-fn's terminal sentinel value.
+  (let (child-caught)
+    (with-main+child (main child
+                           (lambda ()
+                             (handler-case (throw 'outer :outer-fired)
+                               (control-error () (setf child-caught t)))
+                             :fell-through))
+      (let ((result (catch 'outer (switch-fiber main child))))
+        (assert child-caught () "child did not catch CONTROL-ERROR")
+        (assert (eq result :fell-through) ()
+                "throw escaped to outer catch (got ~S)" result)))))
+
+;;; --- Pinning ---
+
+(with-test (:name (:fiber :with-fiber-pinned :predicate))
+  (with-main-fiber (main)
+    (assert (not (fiber-pinned-p main)))
+    (with-fiber-pinned ()
+      (assert (fiber-pinned-p main))
+      (with-fiber-pinned ()
+        (assert (= 2 (fiber-pin-count main))))
+      (assert (fiber-pinned-p main)))
+    (assert (not (fiber-pinned-p main)))))
+
+(with-test (:name (:fiber :with-fiber-pinned :no-current-fiber-errors))
+  (let ((sb-fiber::*current-fiber* nil))
+    (assert-error (with-fiber-pinned () :unreachable) no-current-fiber-error)))
+
+(with-test (:name (:fiber :with-fiber-pinned :switch-from-pinned-errors))
+  (with-main+child (main child (lambda ()))
+    (with-fiber-pinned ()
+      (assert-error (switch-fiber main child) pinned-fiber-error))))
+
+;;; --- Conditions ---------------------------------------------------------
+
+(with-test (:name (:fiber :conditions :base-catches-subclasses))
+  ;; A scheduler can HANDLER-CASE on FIBER-ERROR to catch all sb-fiber
+  ;; precondition failures uniformly.
+  (with-main-fiber (main)
+    (let ((dead (make-fiber (lambda ()))))
+      (release-fiber dead)
+      (let ((caught
+              (handler-case (switch-fiber main dead)
+                (fiber-error (c) c))))
+        (assert (typep caught 'dead-fiber-error))
+        (assert (eq dead (fiber-error-fiber caught)))))))
+
+(with-test (:name (:fiber :conditions :state-error-slots))
+  ;; FIBER-STATE-ERROR exposes the actual and expected states.
+  (with-main+child (main child (lambda ()))
+    (switch-fiber main child)           ; runs to completion, now :dead
+    (handler-case (switch-fiber main child)
+      (fiber-state-error (c)
+        (assert (eq child (fiber-error-fiber c)))
+        (assert (eq :dead (fiber-state-error-state c)))
+        (assert (equal '(:runnable :new) (fiber-state-error-expected c)))))))
+
+(with-test (:name (:fiber :conditions :pinned-error-depth))
+  (with-main+child (main child (lambda ()))
+    (with-fiber-pinned ()
+      (with-fiber-pinned ()
+        (handler-case (switch-fiber main child)
+          (pinned-fiber-error (c)
+            (assert (eq main (fiber-error-fiber c)))
+            (assert (= 2 (pinned-fiber-error-depth c)))))))))
+
+(with-test (:name (:fiber :conditions :no-current-fiber))
+  (let ((sb-fiber::*current-fiber* nil))
+    (let ((c (handler-case (make-fiber (lambda ()))
+               (fiber-error (e) e))))          ; caught via the base class
+      (assert (typep c 'no-current-fiber-error))
+      (assert (eq 'make-fiber (no-current-fiber-error-operation c)))
+      (assert (null (fiber-error-fiber c))))
+    (let ((c (handler-case (yield-fiber)
+               (no-current-fiber-error (e) e))))
+      (assert (eq 'yield-fiber (no-current-fiber-error-operation c))))))
+
+(with-test (:name (:fiber :conditions :thread-mismatch-role))
+  (with-main-fiber (main)
+    (let* ((other (sb-thread:make-thread
+                   (lambda ()
+                     (make-main-fiber)
+                     (make-fiber (lambda ())))))
+           (foreign (sb-thread:join-thread other)))
+      (handler-case (switch-fiber main foreign)
+        (fiber-thread-mismatch-error (c)
+          (assert (eq foreign (fiber-error-fiber c)))
+          (assert (eq :to (fiber-thread-mismatch-error-role c)))))
+      (release-fiber foreign))))
+
+(with-test (:name (:fiber :with-fiber-pinned :released-on-non-local-exit))
+  (with-main-fiber (main)
+    (block nil
+      (with-fiber-pinned ()
+        (return)))
+    (assert (not (fiber-pinned-p main)))))

--- a/tests/fiber.pure.lisp
+++ b/tests/fiber.pure.lisp
@@ -23,6 +23,14 @@
   `(with-main-fiber (,main)
      (with-fiber (,child ,entry-fn ,@make-args) ,@body)))
 
+;;; Simulates a thread with no main fiber
+(defmacro without-current-fiber (&body body)
+  (let ((saved (gensym "SAVED")))
+    `(let ((,saved (current-fiber)))
+       (setf (sb-fiber::%current-fiber) nil)
+       (unwind-protect (progn ,@body)
+         (setf (sb-fiber::%current-fiber) ,saved)))))
+
 ;;; --- Lifecycle ---
 
 (with-test (:name (:fiber :make-and-destroy))
@@ -42,7 +50,7 @@
       (release-fiber f))))
 
 (with-test (:name (:fiber :make-fiber :requires-main-fiber))
-  (let ((sb-fiber::*current-fiber* nil))
+  (without-current-fiber
     (assert-error (make-fiber (lambda ())))))
 
 (with-test (:name (:fiber :with-fiber-cleans-up))
@@ -54,25 +62,25 @@
       (assert (not (fiber-alive-p captured))))))
 
 (with-test (:name (:fiber :with-fiber-thread :creates-and-releases))
-  (let ((sb-fiber::*current-fiber* nil))
+  (without-current-fiber
     (with-fiber-thread ()
-      (assert (typep *current-fiber* 'fiber))
-      (assert (fiber-alive-p *current-fiber*)))
-    (assert (null *current-fiber*))))
+      (assert (typep (current-fiber) 'fiber))
+      (assert (fiber-alive-p (current-fiber))))
+    (assert (null (current-fiber)))))
 
 (with-test (:name (:fiber :with-fiber-thread :nested-is-noop))
-  ;; If *CURRENT-FIBER* is already bound, the inner WITH-FIBER-THREAD
-  ;; must not create or release anything.
+  ;; If the thread already has a current fiber, the inner
+  ;; WITH-FIBER-THREAD must not create or release anything.
   (with-main-fiber (outer)
     (with-fiber-thread ()
-      (assert (eq outer *current-fiber*)))
-    (assert (eq outer *current-fiber*))
+      (assert (eq outer (current-fiber))))
+    (assert (eq outer (current-fiber)))
     (assert (fiber-alive-p outer))))
 
 (with-test (:name (:fiber :make-main-fiber))
   (with-main-fiber (main)
     (assert (fiber-alive-p main))
-    (assert (eq main *current-fiber*))))
+    (assert (eq main (current-fiber)))))
 
 (with-test (:name (:fiber :fiber-thread))
   (with-main+child (main f (lambda ()))
@@ -162,7 +170,7 @@
         caught-in-child)
     (with-main+child (main child
                            (lambda ()
-                             (interrupt-fiber *current-fiber* c)
+                             (interrupt-fiber (current-fiber) c)
                              (handler-case (yield-fiber)
                                (simple-error (e) (setf caught-in-child e)))
                              :done))
@@ -191,8 +199,8 @@
     (with-main+child (main child
                            (lambda ()
                              (push :child log)
-                             (switch-fiber *current-fiber*
-                                           (fiber-return-fiber *current-fiber*))
+                             (switch-fiber (current-fiber)
+                                           (fiber-return-fiber (current-fiber)))
                              (push :child-again log)))
       (push :main log)
       (switch-fiber main child)
@@ -226,7 +234,7 @@
 
 (with-test (:name (:fiber :yield-fiber :no-return-fiber-errors))
   (with-main-fiber (main)
-    (assert (eq main *current-fiber*))
+    (assert (eq main (current-fiber)))
     (assert-error (yield-fiber))))
 
 (with-test (:name (:fiber :resume-fiber :basic))
@@ -244,8 +252,8 @@
 
 (with-test (:name (:fiber :resume-fiber :no-current-fiber-errors))
   (with-main+child (main f (lambda ()))
-    (assert (eq main *current-fiber*))
-    (let ((sb-fiber::*current-fiber* nil))
+    (assert (eq main (current-fiber)))
+    (without-current-fiber
       (assert-error (resume-fiber f) no-current-fiber-error))))
 
 (with-test (:name (:fiber :yield-preserves-resumer-return-fiber))
@@ -384,7 +392,7 @@
     (assert (not (fiber-pinned-p main)))))
 
 (with-test (:name (:fiber :with-fiber-pinned :no-current-fiber-errors))
-  (let ((sb-fiber::*current-fiber* nil))
+  (without-current-fiber
     (assert-error (with-fiber-pinned () :unreachable) no-current-fiber-error)))
 
 (with-test (:name (:fiber :with-fiber-pinned :switch-from-pinned-errors))
@@ -426,7 +434,7 @@
             (assert (= 2 (pinned-fiber-error-depth c)))))))))
 
 (with-test (:name (:fiber :conditions :no-current-fiber))
-  (let ((sb-fiber::*current-fiber* nil))
+  (without-current-fiber
     (let ((c (handler-case (make-fiber (lambda ()))
                (fiber-error (e) e))))          ; caught via the base class
       (assert (typep c 'no-current-fiber-error))

--- a/tests/input-manifest.lisp-expr
+++ b/tests/input-manifest.lisp-expr
@@ -46,6 +46,8 @@
  ("elfcore.test.sh" "src/runtime/shrinkwrap-sbcl")
  ("exit-hang.impure.lisp" "tests/fcb-threads.so")
  ("fcb-threads.impure.lisp" "tests/fcb-threads.so")
+ ("fiber.pure.lisp" "contrib/sb-fiber.fasl")
+ ("fiber.impure.lisp" "contrib/sb-fiber.fasl")
  ("fifo-slow.impure.lisp" "contrib/sb-posix.fasl")
  ("filecompile.impure.lisp"
   "tests/data/wonky1.lisp"


### PR DESCRIPTION
Runtime support and a contrib ('sb-fiber') that provide user-space coroutines with control and binding stacks, cooperatively scheduled, migratable between OS threads.

Gated on :sb-fiber (off by default) for x86-64 and arm64 POSIX builds. API documentation in contrib/sb-fiber/sb-fiber.texinfo.