### PR TITLE
SBCL_RUNNER hook for portable cross-compilation

### DIFF
--- a/contrib/make-contrib.lisp
+++ b/contrib/make-contrib.lisp
@@ -10,6 +10,16 @@
 
 (declaim (muffle-conditions (and compiler-note (not sb-c::unknown-typep-note))))
 
+;; See the comment in sb-grovel/def-to-lisp.lisp: under qemu-user the
+;; target lisp cannot execve the target groveler directly, so when
+;; SBCL_RUNNER is set the a.out runs through it.
+(defun split-runner (string)
+  (loop for start = 0 then (1+ end)
+        for end = (position #\Space string :start start)
+        unless (= start (or end (length string)))
+          collect (subseq string start end)
+        while end))
+
 (defun run-defs-to-lisp (inputs output)
   (flet ((invoke (string &rest args)
            #+android
@@ -39,10 +49,18 @@
       (let* ((c-compiler-output (merge-pathnames #+unix "a.out" #+win32 "a.exe" output))
              (result (invoke "RUN-C-COMPILER" c-file c-compiler-output)))
         (unless (= result 0) (error "C compilation failed"))
-        (let ((result
-               (process-exit-code
-                (run-program (namestring c-compiler-output) (list (namestring output))
-                             :search nil :input nil :output *trace-output*))))
+        (let* ((runner #+win32 nil
+                       #-win32 (split-runner
+                                (or (sb-ext:posix-getenv "SBCL_RUNNER") "")))
+               (result
+                (process-exit-code
+                 (run-program (or (first runner) (namestring c-compiler-output))
+                              (append (rest runner)
+                                      (when runner
+                                        (list (namestring c-compiler-output)))
+                                      (list (namestring output)))
+                              :search (if runner t nil)
+                              :input nil :output *trace-output*))))
           (unless (= result 0) (error "C execution failed")))))))
 
 (defparameter +genfile+ "generated-constants")

--- a/contrib/sb-grovel/def-to-lisp.lisp
+++ b/contrib/sb-grovel/def-to-lisp.lisp
@@ -303,12 +303,25 @@ int main(int argc, char *argv[]) {
       (let ((code (run-c-compiler tmp-c-source tmp-a-dot-out)))
         (unless (= code 0)
           (apply 'error 'c-compile-failed condition-arguments)))
-      (let ((code (sb-ext:process-exit-code
-                   (sb-ext:run-program (namestring tmp-a-dot-out)
-                                       (list (namestring tmp-constants))
-                                       :search nil
-                                       :input nil
-                                       :output *trace-output*))))
+      ;; The groveler is a target binary.  Under qemu-user emulation
+      ;; the lisp cannot execve it directly (guest-to-guest exec is
+      ;; not emulated without binfmt_misc), so when SBCL_RUNNER is
+      ;; set, run it through that emulator — the same convention the
+      ;; make-target-*.sh scripts use.  Not wanted on win32: there
+      ;; the target lisp runs target executables natively (both on
+      ;; Windows proper and under Wine).
+      (let* ((runner #+win32 nil
+                     #-win32 (split-cflags
+                              (or (sb-ext:posix-getenv "SBCL_RUNNER") "")))
+             (code (sb-ext:process-exit-code
+                    (sb-ext:run-program
+                     (or (first runner) (namestring tmp-a-dot-out))
+                     (append (rest runner)
+                             (when runner (list (namestring tmp-a-dot-out)))
+                             (list (namestring tmp-constants)))
+                     :search (if runner t nil)
+                     :input nil
+                     :output *trace-output*))))
         (unless (= code 0)
           (apply 'error 'a-dot-out-failed condition-arguments)))
     (multiple-value-bind (output warnings-p failure-p)

--- a/make-config.sh
+++ b/make-config.sh
@@ -295,6 +295,13 @@ echo "android=$android; export android" >> output/build-config
 
 # And now, sorting out the per-target dependencies...
 
+# The target OS is normally detected with `uname`.  Set SBCL_OS to
+# override the detection, for cross-OS builds whose target binaries
+# are run by an emulator on the build host (e.g. SBCL_OS=win32 with
+# SBCL_RUNNER set to a script that runs them with Wine).
+if [ -n "$SBCL_OS" ]; then
+    sbcl_os="$SBCL_OS"
+else
 case `uname` in
     Linux)
         sbcl_os="linux"
@@ -339,6 +346,7 @@ case `uname` in
         exit 1
         ;;
 esac
+fi
 
 link_or_copy() {
    if [ "$sbcl_os" = "win32" ] ; then

--- a/make-config.sh
+++ b/make-config.sh
@@ -292,6 +292,7 @@ if [ -n "$SBCL_TARGET_LOCATION" ]; then
     echo "SBCL_TARGET_LOCATION=\"$SBCL_TARGET_LOCATION\"; export SBCL_TARGET_LOCATION" >> output/build-config
 fi
 echo "android=$android; export android" >> output/build-config
+echo "SBCL_RUNNER=\"$SBCL_RUNNER\"; export SBCL_RUNNER" >> output/build-config
 
 # And now, sorting out the per-target dependencies...
 
@@ -751,7 +752,7 @@ case "$sbcl_arch" in
             SBCL_CONTRIB_BLOCKLIST="$SBCL_CONTRIB_BLOCKLIST sb-simd"
         fi
     else
-        if ! $GNUMAKE -C tools-for-build avx2 2> /dev/null || tools-for-build/avx2 ; then
+        if ! $GNUMAKE -C tools-for-build avx2 2> /dev/null || $SBCL_RUNNER tools-for-build/avx2 ; then
             SBCL_CONTRIB_BLOCKLIST="$SBCL_CONTRIB_BLOCKLIST sb-simd"
         fi
     fi
@@ -819,9 +820,9 @@ else
         android_run tools-for-build/determine-endianness >> $ltf
     else
         $GNUMAKE -C tools-for-build determine-endianness -I ../src/runtime
-        tools-for-build/determine-endianness >> $ltf
+        $SBCL_RUNNER tools-for-build/determine-endianness >> $ltf
     fi
-    export sbcl_os sbcl_arch android
+    export sbcl_os sbcl_arch android SBCL_RUNNER
     sh tools-for-build/grovel-features.sh >> $ltf
 fi
 

--- a/make-target-1.sh
+++ b/make-target-1.sh
@@ -49,7 +49,7 @@ then
     android_run tools-for-build/grovel-headers > output/stuff-groveled-from-headers.lisp
 else
     ( cd tools-for-build; $GNUMAKE -I../src/runtime grovel-headers )
-    tools-for-build/grovel-headers > output/stuff-groveled-from-headers.lisp
+    $SBCL_RUNNER tools-for-build/grovel-headers > output/stuff-groveled-from-headers.lisp
 fi
 touch -r tools-for-build/grovel-headers.c output/stuff-groveled-from-headers.lisp
 

--- a/make-target-2.sh
+++ b/make-target-2.sh
@@ -52,12 +52,12 @@ elif [ "x$1" != x ]; then
 fi
 if [ "$warm_compile" = yes ]; then
     echo //doing warm init - compilation phase
-    ./src/runtime/sbcl --core output/cold-sbcl.core \
+    $SBCL_RUNNER ./src/runtime/sbcl --core output/cold-sbcl.core \
      --lose-on-corruption $SBCL_MAKE_TARGET_2_OPTIONS --no-sysinit --no-userinit \
      --eval '(sb-fasl::!warm-load "src/cold/warm.lisp")' --quit
 fi
 echo //doing warm init - load and dump phase
-./src/runtime/sbcl --noinform --core output/cold-sbcl.core \
+$SBCL_RUNNER ./src/runtime/sbcl --noinform --core output/cold-sbcl.core \
                    --lose-on-corruption $SBCL_MAKE_TARGET_2_OPTIONS \
                    --no-sysinit --no-userinit --noprint <<EOF
 (progn ${devel})
@@ -73,7 +73,7 @@ echo //doing warm init - load and dump phase
  (sb-ext:save-lisp-and-die "output/sbcl.core"))
 EOF
 
-./src/runtime/sbcl --noinform --core output/sbcl.core \
+$SBCL_RUNNER ./src/runtime/sbcl --noinform --core output/sbcl.core \
                    --no-sysinit --no-userinit --noprint <<EOF
   (load "validate-float.lisp")
   (check-float-file "output/xfloat-math.lisp-expr")

--- a/make-target-contrib.sh
+++ b/make-target-contrib.sh
@@ -44,7 +44,7 @@ SBCL_TOP="../../"
 SBCL_HOME="$SBCL_TOP/obj/sbcl-home"
 export SBCL_HOME SBCL_TOP
 
-SBCL="$SBCL_TOP/src/runtime/sbcl --noinform --core $SBCL_TOP/output/sbcl.core \
+SBCL="$SBCL_RUNNER $SBCL_TOP/src/runtime/sbcl --noinform --core $SBCL_TOP/output/sbcl.core \
 --lose-on-corruption --disable-debugger --no-sysinit --no-userinit"
 export SBCL
 

--- a/make.sh
+++ b/make.sh
@@ -88,12 +88,12 @@ maybetime sh make-target-2.sh
 maybetime sh make-target-contrib.sh
 
 # Confirm that default evaluation strategy is :INTERPRET if sb-fasteval was built
-src/runtime/sbcl --core output/sbcl.core --lose-on-corruption --noinform \
+$SBCL_RUNNER src/runtime/sbcl --core output/sbcl.core --lose-on-corruption --noinform \
   --no-sysinit --no-userinit --disable-debugger \
   --eval '(when (find-package "SB-INTERPRETER") (assert (eq *evaluator-mode* :interpret)))' \
   --quit
 
-./src/runtime/sbcl --core output/sbcl.core \
+$SBCL_RUNNER ./src/runtime/sbcl --core output/sbcl.core \
  --lose-on-corruption --noinform $SBCL_MAKE_TARGET_2_OPTIONS --no-sysinit --no-userinit --eval '
     (progn
       #-sb-devel

--- a/run-sbcl.sh
+++ b/run-sbcl.sh
@@ -15,8 +15,20 @@ set -e
 
 this="$0"
 
+# On Windows, the runtime is sbcl.exe; on Unix, it's sbcl.  A tree
+# reused for different cross-build targets may carry both; prefer
+# the newer one.
+find_sbcl_runtime(){
+    SBCL_RUNTIME="$1"/src/runtime/sbcl
+    if [ -f "$SBCL_RUNTIME".exe ] && \
+       { [ ! -f "$SBCL_RUNTIME" ] || [ "$SBCL_RUNTIME".exe -nt "$SBCL_RUNTIME" ]; }; then
+        SBCL_RUNTIME="$SBCL_RUNTIME".exe
+    fi
+}
+
 build_directory_p(){
-    [ -x "$1"/src/runtime/sbcl -a -f "$1"/output/sbcl.core ];
+    find_sbcl_runtime "$1"
+    [ -x "$SBCL_RUNTIME" -a -f "$1"/output/sbcl.core ];
 }
 
 # OSX 10.8 readlink doesn't have -f
@@ -76,9 +88,9 @@ fi
 if build_directory_p "$BASE"; then
     export SBCL_HOME
     if [ "$CORE_DEFINED" = "no" ]; then
-	SBCL_HOME="$BASE"/obj/sbcl-home exec "$BASE"/src/runtime/sbcl --core "$CORE" "$@"
+	SBCL_HOME="$BASE"/obj/sbcl-home exec $SBCL_RUNNER "$SBCL_RUNTIME" --core "$CORE" "$@"
     else
-	SBCL_HOME="$BASE"/obj/sbcl-home exec "$BASE"/src/runtime/sbcl "$@"
+	SBCL_HOME="$BASE"/obj/sbcl-home exec $SBCL_RUNNER "$SBCL_RUNTIME" "$@"
     fi
 else
     echo "No built SBCL here ($BASE): run 'sh make.sh' first!"

--- a/tools-for-build/grovel-features.sh
+++ b/tools-for-build/grovel-features.sh
@@ -18,7 +18,7 @@ featurep() {
         $CC -I../src/runtime -ldl -o $bin $bin.c > /dev/null 2>&1
 	exit_code=`android_run_for_exit_code $bin`
     else
-        $GNUMAKE $bin -I ../src/runtime > /dev/null 2>&1 && echo "input" | ./$bin> /dev/null 2>&1
+        $GNUMAKE $bin -I ../src/runtime > /dev/null 2>&1 && echo "input" | $SBCL_RUNNER ./$bin > /dev/null 2>&1
 	exit_code="$?"
     fi
     if [ "$exit_code" -eq 104 ]


### PR DESCRIPTION
I have a long history of personal patches for SBCL to make it build for Windows under Linux+wine+(mingw for Linux). It's usually a bit complicated setup involving an extra directory in the Linux `PATH` with toolchain shims (cc & gcc starting ` x86_64-w64-mingw32-gcc`, etc) and an extra directory in the `WINEPATH` (allowing Windows executables to call out Linux tools). Beside that, I also had to patch the SBCL proper, to make it know that it has to run `.exe` files instead of files with no extensions, etc etc. `binfmt_misc` came in handy at that stage, allowing host binaries to run target binaries as if nothing unusual happens.

Recently I switched to a solution based on a more systematic approach, which I present here. `SBCL_RUNNER` environment variable is patched into any point where the host system calls target binaries (~12 points in regular building machinery + 2 grovellers). This patchset represents everything I need *from the SBCL side*, while [another repository](https://github.com/akovalenko/wrun) is an example of how `SBCL_RUNNER` can be actually used. So instead of patching for `.exe` suffix support, the environment provides *a tool that is able to run target binaries*, having `.exe`-resolution as its natural part. We also stop needing `binfmt_misc` at all, allowing builds to run in unprivileged containers without any problems.

To prove to myself the usefulness of `SBCL_RUNNER`, I did several builds with the goal of getting the target binaries from the bundled `make.sh` without further patching sbcl itself:
* Wine+CrossMingw build, as initially intended, including within a container, with `binfmt_misc` disabled
* Qemu-User aarch64 build (every thing belonging to "host" runs natively on x86, with qemu-user used exclusively for "target" invocations)
* An android/NDK aarch64 build without sbcl built-in `:android` machinery, not needing any device connection during the build, just qemu-user again
* Another variant of android build, where `SBCL_RUNNER` is rsync+ssh-hopping to my phone and back, gaining me 4x build speedup compared to qemu on my laptop

Some of these things needed nasty workarounds, but none required further patching of the build system or SBCL itself. `SBCL_RUNNER` abstraction holds water, and I hope it will be accepted into SBCL, simplifying custom cross-platform building significantly. 