### PR TITLE
In SB-ASSEM:INST, pass mnemonic through string before format

### DIFF
--- a/src/compiler/assem.lisp
+++ b/src/compiler/assem.lisp
@@ -1607,7 +1607,7 @@
            ;; By using an unusual convention of a symbol with #\: in its name,
            ;; FIND-SYMBOL reliably tests whether a macro is defined without further
            ;; using FBOUNDP or MACRO-FUNCTION.
-           (let ((macro (find-symbol (format nil "M:~A" mnemonic)
+           (let ((macro (find-symbol (format nil "M:~A" (string mnemonic))
                                      *backend-instruction-set-package*)))
              (when macro
                (return-from inst `(,macro ,@args))))


### PR DESCRIPTION
This finds the appropriate instructions even if `*print-case*` is something other than `:upcase`. 

Another option could be to use `symbol-name`.

This fixes https://github.com/sharplispers/ironclad/issues/82. 

`ironclad/src/opt/sbcl/x86-oid-vm.lisp` defines VOPs that rely on instructions like `pslld-imm`. However, while `(find-symbol "M:PSLLD-IMM" *backend-instruction-set-package*)` finds the symbol for the instruction, `(find-symbol "M:pslld-imm" *backend-instruction-set-package*)` does not. The latter case arises when `(define-vop (chacha-core-fast) ...)` is compiled with `:downcase`.

While ironclad itself could drop these instructions and use the instructions in newer SBCL, or conditionalize on SBCL, I think the problem with the `sb-assem:inst` being dependent on `*print-case*` is a more general problem.
