### PR TITLE
sb-gmp: hand a non-rational base back to the original INTEXP

### DIFF
--- a/contrib/sb-gmp/gmp.lisp
+++ b/contrib/sb-gmp/gmp.lisp
@@ -963,6 +963,9 @@ pre-allocated bignum. The allocated bignum-length must be (1+ COUNT)."
     ((or (and (integerp base)
               (< (abs power) 1000)
               (< (blength base) 4))
+         ;; EXPT dispatches to INTEXP for a (COMPLEX RATIONAL) base as well,
+         ;; and MPZ-POW below only takes an integer.
+         (not (rationalp base))
          (member base '(0 1 -1))
          *gmp-disabled*)
      (orig-intexp base power))

--- a/contrib/sb-gmp/tests.lisp
+++ b/contrib/sb-gmp/tests.lisp
@@ -207,6 +207,14 @@
     (sb-gmp::gmp-intexp 113/355 -1)
   355/113)
 
+;; EXPT dispatches to INTEXP for a (COMPLEX RATIONAL) base as well.
+(deftest intexp-complex-rational
+    (list (sb-gmp::gmp-intexp #c(1/5 1) 1)
+          (sb-gmp::gmp-intexp #c(1/5 1) 2)
+          (sb-gmp::gmp-intexp #c(2 3) 5)
+          (sb-gmp::gmp-intexp #c(1/5 1) -1))
+  (#c(1/5 1) #c(-24/25 2/5) #c(122 -597) #c(5/26 -25/26)))
+
 (deftest remove-1
     (multiple-value-list (mpz-remove 28 2))
   (7 2))


### PR DESCRIPTION
`EXPT` dispatches to `INTEXP` for a `(COMPLEX RATIONAL)` base as well as for fixnums, bignums and ratios (`src/code/irrat.lisp`):

```lisp
(((foreach fixnum (or bignum ratio) (complex rational)) integer)
 (intexp base power))
```

`SB-GMP::GMP-INTEXP` handles integers, ratios and 0/±1, then sends everything else to `MPZ-POW`, which only takes an integer. Loading the contrib is enough to break it — `LOAD-GMP` calls `INSTALL-GMP-FUNS` itself at load time, and again from an init hook — so a working `EXPT` turns into a type error:

```lisp
* (require :sb-gmp)
* (sb-gmp::gmp-intexp #c(1/5 1) 2)
; Evaluation aborted on #<TYPE-ERROR expected-type: INTEGER datum: #C(1/5 1)>
```

Constant folding hides it from a toplevel `(expt #c(1/5 1) 2)`, so it only surfaces in compiled code with a computed base. That is how I ran into it: Maxima reaches it through `bernstein_poly(k, n, 1/5 + %i)`, and on any build linked against sb-gmp that fails one of Maxima's own regression tests (`rtest_bernstein`, problem 11). It reproduces on 5.49.0 and 5.50.0 alike.

The fix sends non-rational bases to `ORIG-INTEXP`, which handles them by repeated squaring; GMP keeps the integer and ratio paths it was installed for.

Verified on SBCL 2.6.8, x86-64, Fedora 44, by loading the patched `GMP-INTEXP` into a running image:

| call | stock | patched |
|---|---|---|
| `(gmp-intexp #c(1/5 1) 1)` | type error | `#C(1/5 1)` |
| `(gmp-intexp #c(1/5 1) 2)` | type error | `#C(-24/25 2/5)` |
| `(gmp-intexp #c(2 3) 5)` | type error | `#C(122 -597)` |
| `(gmp-intexp #c(1/5 1) -1)` | type error | `#C(5/26 -25/26)` |
| `(gmp-intexp 3 5000)`, `(gmp-intexp 2 4096)`, `(gmp-intexp 113/355 -1)` | ok | unchanged |

All values agree with a plain SBCL without sb-gmp loaded. The existing `intexp-1` and `intexp-2` tests still pass; `intexp-complex-rational` is added next to them and fails without the change.
