### PR TITLE
Don't emit overflow+ if result is a word

### DIFF
--- a/src/compiler/srctran.lisp
+++ b/src/compiler/srctran.lisp
@@ -4152,12 +4152,13 @@
                            (csubtypep result-type type)))
               (values cast-type result-type))))))))
 
-;;; (the fixnum (+ x fixnum)) can use inline arithmetic because X can only be a singed word.
+;;; (the fixnum (+ x fixnum)) can use inline arithmetic because X can only be a signed word.
 (when-vop-existsp (:translate overflow+)
   (macrolet ((def (name types word-var args vop)
                `(deftransform ,name ((x y) ,types
                                      * :node node :important nil)
-                  (when (csubtypep (lvar-type ,word-var) (specifier-type 'sb-vm:signed-word))
+                  (when (or (csubtypep (lvar-type ,word-var) (specifier-type 'word))
+                            (csubtypep (lvar-type ,word-var) (specifier-type 'sb-vm:signed-word)))
                     (give-up-ir1-transform))
                   (delay-ir1-transform node :ir1-phases)
                   (let ((cast (cast-or-check-bound-type node (specifier-type 'fixnum))))

--- a/tests/arith-2.pure.lisp
+++ b/tests/arith-2.pure.lisp
@@ -916,6 +916,33 @@
               (truncate a 2305843009213693949)))
     ((11094097273866491717) (values 4 1870725237011715921))))
 
+(with-test (:name :overflow+-word
+            :implemented-on (:vop-existsp sb-c::overflow+))
+  (checked-compile-and-assert
+   (:allow-notes nil :optimize :safe)
+   `(lambda (x y)
+      (declare (type (integer 0 ,(ash 1 (- sb-vm:n-word-bits 2))) x)
+               (type (integer 0 5) y))
+      (the fixnum (+ x x y)))
+   ((3 4) 10)
+   ((h 5) (condition 'type-error)))
+  (checked-compile-and-assert
+   (:allow-notes nil :optimize :safe)
+   `(lambda (x y)
+      (declare (type (integer 0 ,(ash 1 (- sb-vm:n-word-bits 2))) x)
+               (type (integer 0 5) y))
+      (the fixnum (- y (+ x x))))
+   ((1 5) 3)
+   ((h 0) (condition 'type-error)))
+  (checked-compile-and-assert
+   (:allow-notes nil :optimize :safe)
+   `(lambda (x y)
+      (declare (sb-vm:word x y))
+      (< (the sb-vm:word (+ x x)) y))
+   ((5 11) t)
+   ((5 10) nil)
+   (((ash 1 (1- sb-vm:n-word-bits)) 0) (condition 'type-error))))
+
 (with-test (:name :logxor-1-type)
   (assert-type
    (lambda (x)


### PR DESCRIPTION
Affects (the word (+ x y)) and intermediate result in (the fixnum (+ x y small-number))