### PR TITLE
bug fix stmt-prev pointer linking in insert-stmt

### DIFF
--- a/src/compiler/assem.lisp
+++ b/src/compiler/assem.lisp
@@ -366,7 +366,7 @@
           (stmt-prev stmt) predecessor
           (stmt-next stmt) successor)
     (when successor
-      (stmt-prev successor) stmt))
+      (setf (stmt-prev successor) stmt)))
   stmt)
 
 (defun delete-stmt (stmt)

--- a/tests/assembler.pure.lisp
+++ b/tests/assembler.pure.lisp
@@ -622,3 +622,16 @@
     (try `(vminmaxph ,ymm31 ,ymm16 ,ymm17 0))
     (try `(vaddps ,xmm31 ,xmm16 ,xmm17))
     (try `(vminmaxss ,xmm31 ,xmm16 ,xmm17 0))))
+
+(test-util:with-test (:name :insert-stmt-linking)
+  (let ((s1 (sb-assem::make-stmt nil nil nil 'op1 nil))
+        (s2 (sb-assem::make-stmt nil nil nil 'op2 nil))
+        (s-mid (sb-assem::make-stmt nil nil nil 'op-mid nil)))
+    (setf (sb-assem::stmt-next s1) s2
+          (sb-assem::stmt-prev s2) s1)
+    (sb-assem::insert-stmt s-mid s1)
+    (assert (eq (sb-assem::stmt-next s1) s-mid))
+    (assert (eq (sb-assem::stmt-next s-mid) s2))
+    (assert (eq (sb-assem::stmt-prev s-mid) s1))
+    (assert (eq (sb-assem::stmt-prev s2) s-mid))))
+


### PR DESCRIPTION
When inserting a statement between an existing predecessor and successor, (stmt-prev successor) was evaluated without setf, leaving the successor's backward link pointing to predecessor instead of the newly inserted statement.

Add a regression test in assembler.pure.lisp.